### PR TITLE
Reset shell color when exiting via keyboard interrupt

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -222,6 +222,8 @@ open_episode () {
 # Start Up #
 ############
 
+trap "echo -e '$c_reset'" INT HUP
+
 dep_ch "$player_fn" "curl" "sed" "grep"
 
 # option parsing


### PR DESCRIPTION
Previously, when you control c in the script, the shell will start to be displayed in green. This echos the reset color code when there is a keyboard interrupt.
