### PR TITLE
Added option to select episode with next and previous episode.

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -289,6 +289,7 @@ while :; do
 	printf "\n${c_green}Currently playing %s episode ${c_cyan}%d/%d\n" "$selection_id" $episode $last_ep_number
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_yellow%s$c_reset\n" "n" "next episode"
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_magenta%s$c_reset\n" "p" "previous episode"
+	printf "$c_blue[${c_cyan}%s$c_blue] $c_yellow%s$c_reset\n" "s" "select episode"
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_red%s$c_reset\n" "q" "exit"
 	printf "${c_blue}Enter choice:${c_green} "
 	read choice
@@ -300,8 +301,15 @@ while :; do
 		p)
 			episode=$((episode - 1))
 			;;
-		q)
+
+		s)	printf "${c_blue}Choose episode $c_cyan[1-%d]$c_reset:$c_green " $last_ep_number
+			read episode
+			printf "$c_reset"
+			;;
+
+		q) 
 			break;;
+
 		*)
 			die "invalid choice"
 			;;


### PR DESCRIPTION
Instead of getting 3 options, next episode, previous episode and exit, we now get a fourth option to select any episode. It really bugged me that we can only go to next or previous episode so I added this feature.
```
[n] next episode
[p] previous episode
[s] select episode
[q] exit
Enter choice: s
Choose episode [1-11]: 4
Getting data for episode 4
```