### PR TITLE
Error handling for: `[ytdl_hook] ERROR: Unsupported URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,21 @@
-# Use ani-cli for Android devices (through Termux)
+## **OLD SCRIPT NOT WORKING**: https://gogoanime.vc, has added a captcha to block bots
+
+## work in progress, scraping 9anim.vip
+
+# ani-cli
 
 A cli to browse and watch anime.
 
-This tool scrapes the site 9anim.vip
+This tool scrapes the site [gogoanime](https://gogoanime.vc).
 
-## Setup
-
-### Downloading necessary apps
-
-* Download Termux from [F-Droid](https://f-droid.org/en/packages/com.termux/).
-
-* Download mpv-android from [Play Store](https://play.google.com/store/apps/details?id=is.xyz.mpv) or [F-Droid](https://f-droid.org/packages/is.xyz.mpv). (VLC is also an option, however, it does not work well. Video stops working after few seconds).
-
-### Setup in termux
-
-* Open Termux and run this command to install git and curl:
-```
-pkg install git curl  
-```
-
-
-* Run this command to install youtube-dl on Termux:
-```
-termux-setup-storage ; curl -s -L https://raw.githubusercontent.com/shukryshuk/androidydl/master/youtubedl.sh | bash
-```
-`termux-setup-storage` asks for storage permissions so that Termux can access the shared storage in your device. 
-
-
-* Use the `git clone` command to clone this repository on your device
-```
-git clone https://github.com/nasseef20/ani-cli.git
-```
 
 ## Usage
 
-Run this command on Termux everytime you want to use it:
-
-```
-cd ani-cli
-./ani-cli <Enter search query. Use quotation marks if its more than a word>
-```
-
-
+	# watch anime
+	ani-cli <query>
 
 ## Dependencies
 
 * curl
+* mpv
 * youtube-dl
-(The 'mpv' package is not needed for this)
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
-## **OLD SCRIPT NOT WORKING**: https://gogoanime.vc, has added a captcha to block bots
-
-## work in progress, scraping 9anim.vip
-
-# ani-cli
+# Use ani-cli for Android devices (through Termux)
 
 A cli to browse and watch anime.
 
-This tool scrapes the site [gogoanime](https://gogoanime.vc).
+This tool scrapes the site 9anim.vip
 
+## Setup
+
+### Downloading necessary apps
+
+* Download Termux from [F-Droid](https://f-droid.org/en/packages/com.termux/).
+
+* Download mpv-android from [Play Store](https://play.google.com/store/apps/details?id=is.xyz.mpv) or [F-Droid](https://f-droid.org/packages/is.xyz.mpv). (VLC is also an option, however, it does not work well. Video stops working after few seconds).
+
+### Setup in termux
+
+* Open Termux and run:
+```
+pkg install git curl mpv 
+```
+
+* Run this command to install youtube-dl on Termux:
+```
+termux-setup-storage ; curl -s -L https://raw.githubusercontent.com/shukryshuk/androidydl/master/youtubedl.sh | bash
+```
+`termux-setup-storage` asks for storage permissions so that Termux can access the shared storage in your device. 
+
+* Use the `git clone` command to clone this repository on your device
+```
+git clone https://github.com/nasseef20/ani-cli.git
+```
 
 ## Usage
 
-	# watch anime
-	ani-cli <query>
+```
+cd ani-cli
+./ani-cli <Enter search query. Use quotation marks if its more than a word>
+```
+
+
 
 ## Dependencies
 
 * curl
 * mpv
 * youtube-dl
+
+
+

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This tool scrapes the site 9anim.vip
 
 ### Setup in termux
 
-* Open Termux and run this command to install git, curl, and mpv:
+* Open Termux and run this command to install git and curl:
 ```
-pkg install git curl mpv 
+pkg install git curl  
 ```
 
 
@@ -46,8 +46,8 @@ cd ani-cli
 ## Dependencies
 
 * curl
-* mpv
 * youtube-dl
+(The 'mpv' package is not needed for this)
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ This tool scrapes the site 9anim.vip
 pkg install git curl mpv 
 ```
 
+
 * Run this command to install youtube-dl on Termux:
 ```
 termux-setup-storage ; curl -s -L https://raw.githubusercontent.com/shukryshuk/androidydl/master/youtubedl.sh | bash
 ```
 `termux-setup-storage` asks for storage permissions so that Termux can access the shared storage in your device. 
+
 
 * Use the `git clone` command to clone this repository on your device
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This tool scrapes the site 9anim.vip
 
 ### Setup in termux
 
-* Open Termux and run:
+* Open Termux and run this command to install git, curl, and mpv:
 ```
 pkg install git curl mpv 
 ```
@@ -31,6 +31,8 @@ git clone https://github.com/nasseef20/ani-cli-android.git
 ```
 
 ## Usage
+
+Run this command on Termux everytime you want to use it:
 
 ```
 cd ani-cli

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ termux-setup-storage ; curl -s -L https://raw.githubusercontent.com/shukryshuk/a
 
 * Use the `git clone` command to clone this repository on your device
 ```
-git clone https://github.com/nasseef20/ani-cli.git
+git clone https://github.com/nasseef20/ani-cli-android.git
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ termux-setup-storage ; curl -s -L https://raw.githubusercontent.com/shukryshuk/a
 
 * Use the `git clone` command to clone this repository on your device
 ```
-git clone https://github.com/nasseef20/ani-cli-android.git
+git clone https://github.com/nasseef20/ani-cli.git
 ```
 
 ## Usage

--- a/ani-cli
+++ b/ani-cli
@@ -117,7 +117,7 @@ play_ep () {
 	done<<-!
 	$html
 	!
-	mpv "$url"
+	xdg-open "$url"
 }
 
 case $selected_anime_url in

--- a/ani-cli
+++ b/ani-cli
@@ -117,7 +117,7 @@ play_ep () {
 	done<<-!
 	$html
 	!
-	xdg-open "$url"
+	mpv "$url" || xdg-open "$url"
 }
 
 case $selected_anime_url in


### PR DESCRIPTION
For some animes, such as Attack on Titan season 3, or Tokyo Revengers, playing the url through `mpv` throws a `[ytdl_hook] ERROR: Unsupported URL: https://yare3.yare.wtf/vidstreaming/animefrenzy/.....` error, as described in  [Issue #22 of master branch](https://github.com/pystardust/ani-cli/issues/22#issue-937292919).
If that happens, then playing the url through `xdg-open` results in the video directly being opened from a browser. Then the anime is watchable again. 
However, `xdg-open` will always open the url through the browser, so it cannot replace `mpv.`
Which is why it is kept as an option if `mpv` fails. 
