### PR TITLE
Fix: subbed version not opening for some animes, going for the dub instead

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -98,6 +98,9 @@ play_ep () {
 	)
 	flag=0
 	while read line; do
+		if [[ $line == *"yare"* ]]; then
+                	line=$(sed '/yare/d' <<< $line)
+        	fi
 		case $line in
 			'<td>'*)
 				if [ $flag -eq 0 ]; then


### PR DESCRIPTION
The previous pull request did fix [the error](https://github.com/pystardust/ani-cli/issues/22). **However,** the dubbed version of the episode opened, instead of the subbed version that one would normally expect (as nowhere in the name there is any mention of this being the dub).

After investigating the `curl` output in the `play_ep` function, and also visiting 9anim.vip myself, I realised that there were two links being given with the same "Download" button, one with the subbed episode and the other one being the dubbed. The script cannot distinguish between the two, and as a result *always* ends up picking the dubbed version (updating the `url` variable with the dubbed link) and never the subbed one, as the script goes through the curl output line by line.

The dubbed link is always a `yare3.yare.wtf` link, so I used `sed` to remove this link from the `line` variable. This way, the subbed version will open up directly in the mpv player. There is no need for `xdg-open` either, although I kept it anyway just in case.

However, instead of getting rid of the dubbed link in this way, I wanted to provide it as an option instead, like a prompt in the terminal asking whether to play the subbed or dubbed version after entering the episode number. However, I cannot come up with where to put this and exactly how to do implement the `read` function here, however, I did come up with the basic function. If anyone can implement this and commit, thanks a lot in advance. I included the basic `sub_or_dub` function in a .txt file
[sub_or_dub.txt](https://github.com/pystardust/ani-cli/files/6797396/sub_or_dub.txt)


