### PR TITLE
fix: change to the new Referer header link

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -206,7 +206,7 @@ open_episode () {
 			s/^${selection_id}\t[0-9]+/${selection_id}\t$((episode+1))/
 		" "$logfile" > "${logfile}.new" && mv "${logfile}.new" "$logfile"
 
-		setsid -f $player_fn --http-header-fields='Referer: https://streamani.io/' "$video_url" >/dev/null 2>&1
+		setsid -f $player_fn --http-header-fields='Referer: https://goload.one/' "$video_url" >/dev/null 2>&1
 	else
 		printf "Downloading episode $episode ...\n"
 		printf "%s\n" "$video_url"


### PR DESCRIPTION
Fix #32 

gogoanime.vc changed the link of the Referer header to https://goload.one/, I think they will keep changing it everytime we fix, I guess we scrape it from somewhere and append, since it's a custom header so we can easily get it