### PR TITLE
Added the possibility to search for another anime in the main loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ani-cli
 
-> Script working again :), thanks to fork by
+> Script working again :), thanks to the fork by
 > [Dink4n](https://github.com/Dink4n/ani-cli) for the alternative approach to
 > by pass the captcha on [gogoanime](https://gogoanime.vc)
 
@@ -23,17 +23,17 @@ sudo make
 
 ## Usage
 
-  # watch anime
-  ani-cli <query>
+  ### watch anime
+  ``ani-cli <query>``
 
-  # download anime
-  ani-cli -d <query>
+  ### download anime
+  ``ani-cli -d <query>``
 
-  # resume watching anime
-  ani-cli -H
+  ### resume watching anime
+  ``ani-cli -H``
 
-  # set video quality
-  ani-cli -q 360
+  ### set video quality
+  ``ani-cli -q 360``
 
 By default `ani-cli` would try to get the best video quality available  
 You can give specific qualities like `360/480/720/..`
@@ -56,6 +56,6 @@ This would open/download episodes 1 2 3 4 5 6
 * sed
 * mpv
 
-### Misc
+## Misc
 
 - Windows instructions can be found in this branch https://github.com/pystardust/ani-cli/tree/windows-vlc

--- a/ani-cli
+++ b/ani-cli
@@ -371,11 +371,14 @@ while :; do
 			episode=$((episode))
 			;;
 		a)
-			get_search_query "$*"
+			get_search_query ""
 			search_results=$(search_anime "$query")
 			[ -z "$search_results" ] && die "No search results found"
 			anime_selection "$search_results"
-			episode_selection;;
+			episode_selection
+			grep -q -w "${selection_id}" "$logfile" ||
+				printf "%s\t%d\n" "$selection_id" $((episode+1)) >> "$logfile"
+			;;
 
 		q)
 			break;;

--- a/ani-cli
+++ b/ani-cli
@@ -356,19 +356,23 @@ while :; do
 	case $choice in
 		n)
 			episode=$((episode + 1))
+			open_episode "$selection_id" "$episode"
 			;;
 		p)
 			episode=$((episode - 1))
+			open_episode "$selection_id" "$episode"
 			;;
 
 		s)	printf "${c_blue}Choose episode $c_cyan[1-%d]$c_reset:$c_green " $last_ep_number
 			read episode
 			printf "$c_reset"
 			[ "$episode" -eq "$episode" ] 2>/dev/null || die "Invalid number entered"
+			open_episode "$selection_id" "$episode"
 			;;
 
 		r)
 			episode=$((episode))
+			open_episode "$selection_id" "$episode"
 			;;
 		a)
 			get_search_query ""
@@ -376,8 +380,24 @@ while :; do
 			[ -z "$search_results" ] && die "No search results found"
 			anime_selection "$search_results"
 			episode_selection
+			{ # checking input
+				[ "$ep_choice_start" -eq "$ep_choice_start" ] 2>/dev/null || die "Invalid number entered"
+				episodes=$ep_choice_start
+
+				if [ -n "$ep_choice_end" ]; then
+					[ "$ep_choice_end" -eq "$ep_choice_end" ] 2>/dev/null || die "Invalid number entered"
+					# create list of episodes to download/watch
+					episodes=$(seq $ep_choice_start $ep_choice_end)
+				fi
+			}
 			grep -q -w "${selection_id}" "$logfile" ||
 				printf "%s\t%d\n" "$selection_id" $((episode+1)) >> "$logfile"
+			for ep in $episodes
+			do
+				open_episode "$selection_id" "$ep"
+			done
+			episode=${ep_choice_end:-$ep_choice_start}
+
 			;;
 
 		q)
@@ -388,5 +408,5 @@ while :; do
 			;;
 	esac
 
-	open_episode "$selection_id" "$episode"
+
 done

--- a/ani-cli
+++ b/ani-cli
@@ -211,6 +211,29 @@ episode_selection () {
 	fi
 }
 
+check_input() {
+	[ "$ep_choice_start" -eq "$ep_choice_start" ] 2>/dev/null || die "Invalid number entered"
+	episodes=$ep_choice_start
+	if [ -n "$ep_choice_end" ]; then
+		[ "$ep_choice_end" -eq "$ep_choice_end" ] 2>/dev/null || die "Invalid number entered"
+		# create list of episodes to download/watch
+		episodes=$(seq $ep_choice_start $ep_choice_end)
+	fi
+}
+
+append_history () {
+	grep -q -w "${selection_id}" "$logfile" ||
+		printf "%s\t%d\n" "$selection_id" $((episode+1)) >> "$logfile"
+}
+
+open_selection() {
+	for ep in $episodes
+	do
+		open_episode "$selection_id" "$ep"
+	done
+	episode=${ep_choice_end:-$ep_choice_start}
+}
+
 open_episode () {
 	anime_id=$1
 	episode=$2
@@ -315,26 +338,9 @@ case $scrape in
 		;;
 esac
 
-{ # checking input
-	[ "$ep_choice_start" -eq "$ep_choice_start" ] 2>/dev/null || die "Invalid number entered"
-	episodes=$ep_choice_start
-
-	if [ -n "$ep_choice_end" ]; then
-		[ "$ep_choice_end" -eq "$ep_choice_end" ] 2>/dev/null || die "Invalid number entered"
-		# create list of episodes to download/watch
-		episodes=$(seq $ep_choice_start $ep_choice_end)
-	fi
-}
-
-# add anime to history file
-grep -q -w "${selection_id}" "$logfile" ||
-	printf "%s\t%d\n" "$selection_id" $((episode+1)) >> "$logfile"
-
-for ep in $episodes
-do
-	open_episode "$selection_id" "$ep"
-done
-episode=${ep_choice_end:-$ep_choice_start}
+check_input
+append_history
+open_selection
 
 while :; do
 	printf "\n${c_green}Currently playing %s episode ${c_cyan}%d/%d\n" "$selection_id" $episode $last_ep_number
@@ -380,24 +386,9 @@ while :; do
 			[ -z "$search_results" ] && die "No search results found"
 			anime_selection "$search_results"
 			episode_selection
-			{ # checking input
-				[ "$ep_choice_start" -eq "$ep_choice_start" ] 2>/dev/null || die "Invalid number entered"
-				episodes=$ep_choice_start
-
-				if [ -n "$ep_choice_end" ]; then
-					[ "$ep_choice_end" -eq "$ep_choice_end" ] 2>/dev/null || die "Invalid number entered"
-					# create list of episodes to download/watch
-					episodes=$(seq $ep_choice_start $ep_choice_end)
-				fi
-			}
-			grep -q -w "${selection_id}" "$logfile" ||
-				printf "%s\t%d\n" "$selection_id" $((episode+1)) >> "$logfile"
-			for ep in $episodes
-			do
-				open_episode "$selection_id" "$ep"
-			done
-			episode=${ep_choice_end:-$ep_choice_start}
-
+			check_input
+			append_history
+			open_selection
 			;;
 
 		q)

--- a/ani-cli
+++ b/ani-cli
@@ -361,26 +361,20 @@ while :; do
 	printf "$c_reset"
 	case $choice in
 		n)
-			episode=$((episode + 1))
-			open_episode "$selection_id" "$episode"
-			;;
+			episode=$((episode + 1));;
 		p)
-			episode=$((episode - 1))
-			open_episode "$selection_id" "$episode"
-			;;
+			episode=$((episode - 1));;
 
 		s)	printf "${c_blue}Choose episode $c_cyan[1-%d]$c_reset:$c_green " $last_ep_number
 			read episode
 			printf "$c_reset"
 			[ "$episode" -eq "$episode" ] 2>/dev/null || die "Invalid number entered"
-			open_episode "$selection_id" "$episode"
 			;;
 
 		r)
-			episode=$((episode))
-			open_episode "$selection_id" "$episode"
-			;;
+			episode=$((episode));;
 		a)
+			tput reset
 			get_search_query ""
 			search_results=$(search_anime "$query")
 			[ -z "$search_results" ] && die "No search results found"
@@ -389,6 +383,7 @@ while :; do
 			check_input
 			append_history
 			open_selection
+			continue
 			;;
 
 		q)
@@ -398,6 +393,6 @@ while :; do
 			die "invalid choice"
 			;;
 	esac
-
+	open_episode "$selection_id" "$episode"
 
 done

--- a/ani-cli
+++ b/ani-cli
@@ -348,6 +348,7 @@ while :; do
 		printf "$c_blue[${c_cyan}%s$c_blue] $c_yellow%s$c_reset\n" "s" "select episode"
 	fi
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_magenta%s$c_reset\n" "r" "replay current episode"
+	printf "$c_blue[${c_cyan}%s$c_blue] $c_cyan%s$c_reset\n" "a" "search for another anime"
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_red%s$c_reset\n" "q" "exit"
 	printf "${c_blue}Enter choice:${c_green} "
 	read choice
@@ -369,6 +370,12 @@ while :; do
 		r)
 			episode=$((episode))
 			;;
+		a)
+			get_search_query "$*"
+			search_results=$(search_anime "$query")
+			[ -z "$search_results" ] && die "No search results found"
+			anime_selection "$search_results"
+			episode_selection;;
 
 		q)
 			break;;

--- a/ani-cli
+++ b/ani-cli
@@ -377,9 +377,11 @@ while :; do
 	printf "$c_reset"
 	case $choice in
 		n)
-			episode=$((episode + 1));;
+			episode=$((episode + 1))
+			;;
 		p)
-			episode=$((episode - 1));;
+			episode=$((episode - 1))
+			;;
 
 		s)	printf "${c_blue}Choose episode $c_cyan[1-%d]$c_reset:$c_green " $last_ep_number
 			read episode
@@ -388,7 +390,8 @@ while :; do
 			;;
 
 		r)
-			episode=$((episode));;
+			episode=$((episode))
+			;;
 		a)
 			tput reset
 			get_search_query ""
@@ -409,6 +412,6 @@ while :; do
 			die "invalid choice"
 			;;
 	esac
-	open_episode "$selection_id" "$episode"
 
+	open_episode "$selection_id" "$episode"
 done


### PR DESCRIPTION
I had this annoyance with your script that I need to relaunch it if I wish to watch another series.
To solve this I created a new option to the main loop: entering "a" will now bring up the search anime again. (I used cyan, because I don't know the reason for the original colour choices. Change it if you feel like so.)
![image](https://user-images.githubusercontent.com/66648475/139277222-e064c239-6a61-4c96-a007-fbe76d36bfcb.png)
I copied the code that runs on startup (query mode) since I don't understand the script that well. There might be better ways to do it, but this appears to work just fine.
It would make sense to make a function for those four lines, but I couldn't come up with an intuitive enough name for them. It shouldn't take more than a minute though.
I have tested my modifications myself, but I think an independent test would be appropriate to ensure I didn't break the script.