### PR TITLE
Added ability to automatically save episode playback and resume it

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ sudo make
   ### resume watching anime
   ``ani-cli -H``
 
+  ### delete anime from history
+  ``ani-cli -D``
+
   ### set video quality
   ``ani-cli -q 360``
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This would open/download episodes 1 2 3 4 5 6
 * curl
 * sed
 * mpv
+* ffmpeg
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo make
   ### resume watching anime
   ``ani-cli -H``
 
-If you have the optional dependencies installed and you are using MPV, playback will resume from where you stopped in the episode. However if you do not have them installed or if you are not using MPV this option will just play the next episode.
+If you have the optional dependencies installed and if you are using MPV, playback will resume from where you stopped in the episode. However if you do not have them installed or if you are not using MPV this option will just play the next episode.
   ### delete anime from history
   ``ani-cli -D``
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ sudo make
   ### resume watching anime
   ``ani-cli -H``
 
+If you have the optional dependencies installed and you are using MPV, playback will resume from where you stopped in the episode. However if you do not have them installed or if you are not using MPV this option will just play the next episode.
   ### delete anime from history
   ``ani-cli -D``
 
@@ -59,6 +60,8 @@ This would open/download episodes 1 2 3 4 5 6
 * sed
 * mpv
 * ffmpeg
+
+### Optional Dependencies
 * socat
 * jq
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ This would open/download episodes 1 2 3 4 5 6
 * sed
 * mpv
 * ffmpeg
+* socat
+* jq
 
 ## Misc
 

--- a/ani-cli
+++ b/ani-cli
@@ -24,8 +24,9 @@ help_text () {
 	 -h	 show this help text
 	 -d	 download episode
 	 -H	 continue where you left off
-	 -D	 delete anime from history
+	 -D	 delete history
 	 -q	 set video quality (best/worst/360/480/720/..)
+	 --dub  play the dub version if present
 	EOF
 }
 
@@ -71,7 +72,8 @@ get_embedded_video_link() {
 	ep_no=$2
 
 	# credits to fork: https://github.com/Dink4n/ani-cli for the fix
-	curl -s "https://gogoanime.pe/$anime_id-episode-$ep_no" |
+	# dub prefix takes the value "-dub" when dub is needed else is empty
+	curl -s "https://gogoanime.pe/$anime_id${dub_prefix}-episode-$ep_no" |
 	sed -n -E '
 		/^[[:space:]]*<a href="#" rel="100"/{
 		s/.*data-video="([^"]*)".*/https:\1/p
@@ -278,7 +280,7 @@ dep_ch "$player_fn" "curl" "sed" "grep"
 is_download=0
 quality=best
 scrape=query
-while getopts 'hdHDq:' OPT; do
+while getopts 'hdHDq:-:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -297,6 +299,13 @@ while getopts 'hdHDq:' OPT; do
 			;;
 		q)
 			quality=$OPTARG
+			;;
+		-)
+			case $OPTARG in
+				dub)
+					dub_prefix="-dub"
+					;;
+			esac
 			;;
 	esac
 done

--- a/ani-cli
+++ b/ani-cli
@@ -129,7 +129,15 @@ get_links () {
 dep_ch () {
 	for dep; do
 		if ! command -v "$dep" >/dev/null ; then
-			die "Program \"$dep\" not found. Please install it."
+			die "Program \"$dep\" not found. Please install it.\n"
+		fi
+	done
+}
+
+optional_dep_ch () {
+	for optional_dep; do
+		if ! command -v "$optional_dep" >/dev/null ; then
+			printf "Optional program \"$optional_dep\" not found. It is recommended to install it.\n"
 		fi
 	done
 }
@@ -257,6 +265,7 @@ open_episode () {
 		if [ $player_fn == "mpv" ]; then
 			setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" "--input-ipc-server=/tmp/mpvsocket" "--start=+$episode_start_time" >/dev/null 2>&1
 		else
+			record_playback_history=false
 			setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" >/dev/null 2>&1
 		fi
 	else
@@ -280,10 +289,12 @@ open_episode () {
 # to clear the colors when exited using SIGINT
 trap "printf '$c_reset'" INT HUP
 
-dep_ch "$player_fn" "curl" "sed" "grep" "socat" "jq"
+dep_ch "$player_fn" "curl" "sed" "grep"
+optional_dep_ch "socat" "jq"
 
-#I don't really know where else to declare this variable, move it to somewhere better
+#I don't really know where else to declare these variable, move it to somewhere better
 ep_choice_start_time=0
+record_playback_history=true
 
 # option parsing
 is_download=0
@@ -381,7 +392,7 @@ while :; do
 	printf "${c_blue}Enter choice:${c_green} "
 
 	#Start a background process that checks for playback progress and writes it
-	if [ $player_fn == "mpv" ]; then
+	if [ $record_playback_history = true ]; then
 		while true
 		do
 			sleep 10s

--- a/ani-cli
+++ b/ani-cli
@@ -256,8 +256,8 @@ open_episode () {
 		# add 0 padding to the episode name
 		episode=$(printf "%03d" $episode)
 		{
-			curl -L -# -C - "$video_url" -G -e 'https://streamani.io/' \
-				-o "${anime_id}-${episode}.mp4" "$video_url" >/dev/null 2>&1 &&
+			ffmpeg -headers "Referer: $embedded_video_url" -i "$video_url" \
+				-c copy "${anime_id}-${episode}.mkv" >/dev/null 2>&1 &&
 				printf "${c_green}Downloaded episode: %s${c_reset}\n" "$episode" ||
 				printf "${c_red}Download failed episode: %s${c_reset}\n" "$episode"
 		}

--- a/ani-cli
+++ b/ani-cli
@@ -217,6 +217,7 @@ episode_selection () {
 open_episode () {
 	anime_id=$1
 	episode=$2
+	episode_start_time=$3
 
 	# Cool way of clearing screen
 	tput reset
@@ -252,7 +253,12 @@ open_episode () {
 			s/^${selection_id}\t[0-9]+/${selection_id}\t$((episode+1))/
 		" "$logfile" > "${logfile}.new" && mv "${logfile}.new" "$logfile"
 
-		setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" >/dev/null 2>&1
+		#In order for playback history to be recorded MPV needs to be used
+		if [ $player_fn == "mpv" ]; then
+			setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" "--input-ipc-server=/tmp/mpvsocket" "--start=+$episode_start_time" >/dev/null 2>&1
+		else
+			setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" >/dev/null 2>&1
+		fi
 	else
 		printf "Downloading episode $episode ...\n"
 		printf "%s\n" "$video_url"
@@ -274,7 +280,10 @@ open_episode () {
 # to clear the colors when exited using SIGINT
 trap "printf '$c_reset'" INT HUP
 
-dep_ch "$player_fn" "curl" "sed" "grep"
+dep_ch "$player_fn" "curl" "sed" "grep" "socat" "jq"
+
+#I don't really know where else to declare this variable, move it to somewhere better
+ep_choice_start_time=0
 
 # option parsing
 is_download=0
@@ -324,10 +333,13 @@ case $scrape in
 		episode_selection
 		;;
 	history)
-		search_results=$(sed -n -E 's/\t[0-9]*//p' "$logfile")
+		search_results=$(sed 's/\t[0-9]*//g' "$logfile")
 		[ -z "$search_results" ] && die "History is empty"
 		anime_selection "$search_results"
-		ep_choice_start=$(sed -n -E "s/${selection_id}\t//p" "$logfile")
+		#ep_choice_start=$(sed -n -E "s/${selection_id}\t//p" "$logfile")
+		episodeInfoArray=($(grep -i "$selection_id" "$logfile"))
+		ep_choice_start=${episodeInfoArray[1]}
+		ep_choice_start_time=${episodeInfoArray[2]}
 		;;
 esac
 
@@ -344,11 +356,12 @@ esac
 
 # add anime to history file
 grep -q -w "${selection_id}" "$logfile" ||
-	printf "%s\t%d\n" "$selection_id" $((episode+1)) >> "$logfile"
+	printf "%s\t%d\t%d\n" "$selection_id" $((episode+1)) "0" >> "$logfile"
 
 for ep in $episodes
 do
-	open_episode "$selection_id" "$ep"
+	open_episode "$selection_id" "$ep" "$ep_choice_start_time"
+	ep_choice_start_time=0
 done
 episode=${ep_choice_end:-$ep_choice_start}
 
@@ -366,6 +379,19 @@ while :; do
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_magenta%s$c_reset\n" "r" "replay current episode"
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_red%s$c_reset\n" "q" "exit"
 	printf "${c_blue}Enter choice:${c_green} "
+
+	#Start a background process that checks for playback progress and writes it
+	if [ $player_fn == "mpv" ]; then
+		while true
+		do
+			sleep 10s
+			POSITION=$(echo '{ "command": ["get_property_string", "time-pos"] }' | socat - /tmp/mpvsocket 2>/dev/null | jq .data | tr '"' ' ' | cut -d'.' -f 1)
+			if [ ${#POSITION} -lt 1 ]; then break; fi
+			historyFileLine=$(printf "%s\t%d\t%d\n" "$selection_id" "$episode" "$POSITION") 2>/dev/null
+			sed -i "/$selection_id/ c \\$historyFileLine" "$logfile"
+		done &
+	fi
+
 	read choice
 	printf "$c_reset"
 	case $choice in
@@ -387,6 +413,9 @@ while :; do
 			;;
 
 		q)
+			#first kill the background process checking for playback progress then break
+			jobtokill=$(jobs -l | grep "Running" | grep -o "[[:digit:]]\{3,10\}")
+			if [ ${#jobtokill} -gt 1 ]; then kill $jobtokill >/dev/null; fi
 			break;;
 
 		*)
@@ -394,5 +423,5 @@ while :; do
 			;;
 	esac
 
-	open_episode "$selection_id" "$episode"
+	open_episode "$selection_id" "$episode" "$0"
 done

--- a/ani-cli
+++ b/ani-cli
@@ -347,10 +347,10 @@ case $scrape in
 		search_results=$(sed 's/\t[0-9]*//g' "$logfile")
 		[ -z "$search_results" ] && die "History is empty"
 		anime_selection "$search_results"
-		#ep_choice_start=$(sed -n -E "s/${selection_id}\t//p" "$logfile")
 		episodeInfoArray=($(grep -i "$selection_id" "$logfile"))
 		ep_choice_start=${episodeInfoArray[1]}
 		ep_choice_start_time=${episodeInfoArray[2]}
+		if [ ${#ep_choice_start_time} -lt 1 ]; then ep_choice_start_time=0; fi #Redundancy for the old history file format
 		;;
 esac
 
@@ -367,7 +367,7 @@ esac
 
 # add anime to history file
 grep -q -w "${selection_id}" "$logfile" ||
-	printf "%s\t%d\t%d\n" "$selection_id" $((episode+1)) "0" >> "$logfile"
+	printf "%s\t%d\t%d\n" "$selection_id" $((episode+1)) 0 >> "$logfile"
 
 for ep in $episodes
 do
@@ -397,8 +397,15 @@ while :; do
 		do
 			sleep 10s
 			POSITION=$(echo '{ "command": ["get_property_string", "time-pos"] }' | socat - /tmp/mpvsocket 2>/dev/null | jq .data | tr '"' ' ' | cut -d'.' -f 1)
+			REMAINING=$(echo '{ "command": ["get_property_string", "time-remaining"] }' | socat - /tmp/mpvsocket 2>/dev/null | jq .data | tr '"' ' ' | cut -d'.' -f 1)
+			printf "$POSITION - $REMAINING\n"
 			if [ ${#POSITION} -lt 1 ]; then break; fi
-			historyFileLine=$(printf "%s\t%d\t%d\n" "$selection_id" "$episode" "$POSITION") 2>/dev/null
+			if [ $REMAINING -lt 15 ];
+				#If there are less than 15 sec left in episode switch location to start of next episode to prevent issues when resuming playback from -H
+				then historyFileLine=$(printf "%s\t%d\t%d\n" "$selection_id" "$((episode+1))" 0) 2>/dev/null
+				else historyFileLine=$(printf "%s\t%d\t%d\n" "$selection_id" "$episode" "$POSITION") 2>/dev/null
+			fi
+			
 			sed -i "/$selection_id/ c \\$historyFileLine" "$logfile"
 		done &
 	fi

--- a/ani-cli
+++ b/ani-cli
@@ -423,5 +423,5 @@ while :; do
 			;;
 	esac
 
-	open_episode "$selection_id" "$episode" "$0"
+	open_episode "$selection_id" "$episode" "0"
 done

--- a/ani-cli
+++ b/ani-cli
@@ -262,7 +262,7 @@ open_episode () {
 		" "$logfile" > "${logfile}.new" && mv "${logfile}.new" "$logfile"
 
 		#In order for playback history to be recorded MPV needs to be used
-		if [ $player_fn == "mpv" ]; then
+		if [ $player_fn = "mpv" ]; then
 			setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" "--input-ipc-server=/tmp/mpvsocket" "--start=+$episode_start_time" >/dev/null 2>&1
 		else
 			record_playback_history=false
@@ -347,9 +347,8 @@ case $scrape in
 		search_results=$(sed 's/\t[0-9]*//g' "$logfile")
 		[ -z "$search_results" ] && die "History is empty"
 		anime_selection "$search_results"
-		episodeInfoArray=($(grep -i "$selection_id" "$logfile"))
-		ep_choice_start=${episodeInfoArray[1]}
-		ep_choice_start_time=${episodeInfoArray[2]}
+		ep_choice_start=$(grep -i "$selection_id" "$logfile" | cut -d "	" -f 2)
+		ep_choice_start_time=$(grep -i "$selection_id" "$logfile" | cut -d "	" -f 3)
 		if [ ${#ep_choice_start_time} -lt 1 ]; then ep_choice_start_time=0; fi #Redundancy for the old history file format
 		;;
 esac
@@ -398,7 +397,6 @@ while :; do
 			sleep 10s
 			POSITION=$(echo '{ "command": ["get_property_string", "time-pos"] }' | socat - /tmp/mpvsocket 2>/dev/null | jq .data | tr '"' ' ' | cut -d'.' -f 1)
 			REMAINING=$(echo '{ "command": ["get_property_string", "time-remaining"] }' | socat - /tmp/mpvsocket 2>/dev/null | jq .data | tr '"' ' ' | cut -d'.' -f 1)
-			printf "$POSITION - $REMAINING\n"
 			if [ ${#POSITION} -lt 1 ]; then break; fi
 			if [ $REMAINING -lt 15 ];
 				#If there are less than 15 sec left in episode switch location to start of next episode to prevent issues when resuming playback from -H

--- a/ani-cli
+++ b/ani-cli
@@ -24,6 +24,7 @@ help_text () {
 	 -h	 show this help text
 	 -d	 download episode
 	 -H	 continue where you left off
+	 -D	 delete anime from history
 	 -q	 set video quality (best/worst/360/480/720/..)
 	EOF
 }
@@ -277,7 +278,7 @@ dep_ch "$player_fn" "curl" "sed" "grep"
 is_download=0
 quality=best
 scrape=query
-while getopts 'hdHq:' OPT; do
+while getopts 'hdHDq:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -288,6 +289,11 @@ while getopts 'hdHq:' OPT; do
 			;;
 		H)
 			scrape=history
+			;;
+
+		D)
+			: > "$logfile"
+			exit 0
 			;;
 		q)
 			quality=$OPTARG


### PR DESCRIPTION
NGL, I'm the type of person who has issues watching a full episode in one sitting. I usually pause or stop in the middle because I'm a zoomer (or millennial). This became such an issue for me that I stopped torrenting anime and switched to official streaming sites because they tracked playback progress. No more.

Now with the power of God(Lain) and Anime on my side I've added the ability for this program to remember your playback progress in the same file as your viewing history and to resume it with the '-H' option. This works by having MPV write to an IPC socket its playback progress while a background process checks playback progress every 10 seconds and writes it to the logfile. The point it stops recording your progress is either when you close the MPV player or the program itself. This solution is specific to MPV but in the future i might work on a VLC version of this.

The biggest issue with this method of playback recording is that it requires two dependencies to work, _socat_ and _jq_. Given that VLC and Windows support is something that is being worked towards, I have added flags to disable this feature to mitigate any potential issues. In short, **if MPV is not being used or if the optional dependencies are not installed, this program will work the same way it has in the past**. There is still a warning that is shown when the optional dependencies are not installed, but it does not terminate the program as it does with non-optional dependencies.

Also, I imagine that people have already been using this program for a while and may have built up their history and don't want it overwritten by a new format. As such I haven't fundamentally changed the format of the logfile that has been used (data separated by tabs) and this program can still read files with the old data format. **So your old anime viewing history will still be saved and won't be overwritten.** I have had to rewrite the way data from the logfile is read but this new method of using arrays could be useful for storing additional parameters unique to each episode/anime such as video quality or dub/sub.

Finally, once playback reaches the last 15 seconds of an episode the background process will switch over from writing the current playback location of the current episode to writing the starting location (0 seconds) of the next episode. I noticed that when I didn't have this set, using '-H' resulted in just the last 10 seconds of a show playing and MPV closing immediately which could be frustrating to some users. I am considering extending this time period from 15 seconds to a minute but for now I'll leave it here.

As always, sorry for my sloppy code!