### PR TITLE
Change copy to symlink in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PREFIX := /usr/local
 all: install
 
 install:
-	cp ani-cli $(DESTDIR)$(PREFIX)/bin/ani-cli
+	ln -sr ani-cli $(DESTDIR)$(PREFIX)/bin/ani-cli
 	chmod 0755 $(DESTDIR)$(PREFIX)/bin/ani-cli
 
 uninstall:


### PR DESCRIPTION
I changed `cp` for `ln -sr`, which creates a relative symbolic link instead of a copy. 

With `cp` it's necessary to run `make install` after pulling and it's possible to have different versions of the script in the repo folder and `usr/local/bin/`.

The symbolic links only needs to be done once and it will make unnecessary to execute `make install` after every update, since any changes to the repo file will affect the one in `usr/local/bin` as well.