### PR TITLE
 gogoanime domain change on windows-vlc branch

### DIFF
--- a/ani-cli-win
+++ b/ani-cli-win
@@ -6,7 +6,7 @@ player_fn="vlc"
 
 prog="ani-cli"
 logfile="${XDG_CACHE_HOME:-$HOME/.cache}/ani-hsts"
-base_url="https://gogoanime.cm"
+base_url="https://ww1.gogoanime.cm"
 
 c_red="\033[1;31m"
 c_green="\033[1;32m"

--- a/ani-cli-win
+++ b/ani-cli-win
@@ -6,7 +6,7 @@ player_fn="vlc"
 
 prog="ani-cli"
 logfile="${XDG_CACHE_HOME:-$HOME/.cache}/ani-hsts"
-base_url="https://ww1.gogoanime.cm"
+base_url="https://www1.gogoanime.cm"
 
 c_red="\033[1;31m"
 c_green="\033[1;32m"


### PR DESCRIPTION
this PR updates ``base_url="https://gogoanime.cm"`` to ``base_url="https://ww1.gogoanime.cm"`` on the windows-vlc branch as it is using the old domain.