### PR TITLE
[hardcoded] Trying to added --wid=WINDOWID

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -277,7 +277,7 @@ open_episode () {
 			s/^${selection_id}\t[0-9]+/${selection_id}\t$((episode+1))/
 		" "$logfile" > "${logfile}.new" && mv "${logfile}.new" "$logfile"
 
-		setsid -f $player_fn --http-header-fields="Referer: $embedded_video_url" "$video_url" >/dev/null 2>&1
+		setsid -f $player_fn --wid=$WINDOWID --http-header-fields="Referer: $embedded_video_url" "$video_url" >/dev/null 2>&1
 	else
 		printf "Downloading episode $episode ...\n"
 		printf "%s\n" "$video_url"


### PR DESCRIPTION
Hello and thanks for this beatuful cli program!

I don't know much about shell scripting, and I just hardcoded here (I know it'll conflict if someone choice different video player, and hard to change)

So, if you don't mind, would you be able to add some variables like`player_params` at the top of the file, and we would just add  `player_params=--wid=$WINDOWID` to this variable if we need.

We would just leave it empty by default for non-mpv users.
