### PR TITLE
Auto-resolve $base_url

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -41,6 +41,10 @@ err () {
 	printf "$c_red%s$c_reset\n" "$*" >&2
 }
 
+resolve_baseurl () {
+	curl --silent --location --head --output /dev/null --write-out '%{url_effective}' -- $base_url
+}
+
 search_anime () {
 	# get anime name along with its id
 	search=$(printf '%s' "$1" | tr ' ' '-' )
@@ -339,6 +343,8 @@ shift $((OPTIND - 1))
 ########
 # main #
 ########
+
+base_url=$(resolve_baseurl $base_url)
 
 case $scrape in
 	query)


### PR DESCRIPTION
This way we can avoid having to hardcode a new base_url every time the domain moves, since they keep the old domains as redirects.

Invokes `curl` once, but may take a bit longer to resolve since it's, well, _resolving_. I used long options here for clarity, but the short ones appear to work as well.