### PR TITLE
Fix color formatting on some status messages

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -254,18 +254,18 @@ open_episode () {
 
 			"mpv")
 				if echo "$status_code" | grep -vE "^2.*"; then
-					echo "${c_red}\nCannot reach servers!"
+					printf "${c_red}\nCannot reach servers!"
 				else
 					setsid -f $player_fn get_video_quality "$play_link" > /dev/null 2>&1
-					echo "${c_green}\nVideo playing"
+					printf "${c_green}\nVideo playing"
 				fi;;
 			"vlc")
 				
 				if echo "$status_code" | grep -vE "^2.*"; then	
-					echo "${c_red}\nCannot reach servers!"
+					printf "${c_red}\nCannot reach servers!"
 				else
 					setsid -f $player_fn get_video_quality "$play_link" > /dev/null 2>&1
-					echo "${c_green}\nVideo playing"
+					printf "${c_green}\nVideo playing"
 				fi;;
 		esac
 	else


### PR DESCRIPTION
This could be done by either adding the `-e` flag to echo or using `printf`, but I decided to go with the latter, since its used predominantly throughout the rest of the script.
Previously e.g. [line 260](https://github.com/pystardust/ani-cli/pull/239/files#diff-194f14a8c6649316c12fa9d712dd46d7f2424da13786e02de699144517efc3a6L260) would result in the output `\033[1;32m\nVideo played` instead of green formatting for the text.