### PR TITLE
Fixed update instructions

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -155,7 +155,7 @@ check_for_update () {
 		REMOTE=$(git -C "$ORIGINAL_DIR" rev-parse "$UPSTREAM")
 
 		if [ $LOCAL != $REMOTE ]; then
-			printf "UPDATE AVAILABLE\nPlease run the following commands in your ani-cli directory to update\n----------\ngit pull\nsudo make\n----------\n"
+			printf "UPDATE AVAILABLE\nPlease run the following commands in your ani-cli directory to update\n----------\ngit pull\nsudo rm -rf /usr/local/bin/ani-cli\nsudo make\n----------\n"
 		fi
 	fi
 }


### PR DESCRIPTION
The update instructions didn't tell you to remove `/usr/local/bin/ani-cli` before running make which caused errors.
Also not sure why I added the `-rf` flag when its a binary so you can remove that from the commit.