### PR TITLE
replace ffmpeg with aria2c

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -356,10 +356,11 @@ open_episode () {
 		mkdir -p "$download_dir"
 		printf "Downloading episode $episode ...\n"
 		printf "%s\n" "$video_url"
+		printf "%s\n" "$play_link"
 		# add 0 padding to the episode name
 		episode=$(printf "%03d" $episode)
 		{
-			ffmpeg -i "$play_link" -c copy "$download_dir/${anime_id}-${episode}.mkv" >/dev/null 2>&1 &&
+			aria2c "$play_link" --dir=$download_dir -o "${anime_id}-${episode}.mkv" &&
 				printf "${c_green}Downloaded episode: %s${c_reset}\n" "$episode" ||
 				printf "${c_red}Download failed episode: %s , please retry or check your internet connection${c_reset}\n" "$episode"
 		}


### PR DESCRIPTION
replace ffmpeg with aria2c for downloading episodes for following reasons:-
1. resume downloading capabilities of aria2c..
2. parallel downloading (if server supports, not in our case right now) for faster downloading
3. can specify directories for downloading episodes.
4. can downloading in non-linux partitions (e.g. - ntfs, fat32,exfat etc).. by allocating space first...
5. can also download torrents... if in the future we add support for torrent anime websites (subplease.org)

And many more...[read here](https://aria2.github.io/manual/en/html/aria2c.html)