### PR TITLE
Makefile for Mac and Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,24 @@ PREFIX := /usr/local
 # Specify path of install directory
 # The install directory contains a .git file, which is used on startup to determine if an update is available
 CURRENT_DIR := $(shell pwd)
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+	SED_FLAGS := "-i ''"
+	LN_FLAGS := "-s"
+	LN_SRC := "$(CURRENT_DIR)/ani-cli"
+else ifeq ($(UNAME), Linux)
+	SED_FLAGS := "-i"
+	LN_FLAGS := "-sr"
+	LN_SRC := "ani-cli"
+endif
 
 all: install
 
 install: uninstall
-	@# # writes ORIGINAL_DIR variable to ani-cli file
-	sed -i '' '2s}.*}ORIGINAL_DIR="$(CURRENT_DIR)"}' ./ani-cli
+	@# writes ORIGINAL_DIR variable to ani-cli file
+	sed $(SED_FLAGS) '2s}.*}ORIGINAL_DIR="$(CURRENT_DIR)"}' ./ani-cli
 	@# symlinks ani-cli file to /usr/local/bin/ani-cli, which should be in path
-	ln -s $(CURRENT_DIR)/ani-cli $(DESTDIR)$(PREFIX)/bin/ani-cli
+	ln $(LN_FLAGS) $(LN_SRC) $(DESTDIR)$(PREFIX)/bin/ani-cli
 	@# marks ani-cli symlink executable
 	chmod 0755 $(DESTDIR)$(PREFIX)/bin/ani-cli
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CURRENT_DIR := $(shell pwd)
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 	SED_FLAGS := -i ''
-else ifeq ($(UNAME), Linux)
+else
 	SED_FLAGS := -i
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ PREFIX := /usr/local
 CURRENT_DIR := $(shell pwd)
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
-	SED_FLAGS := "-i ''"
-	LN_FLAGS := "-s"
-	LN_SRC := "$(CURRENT_DIR)/ani-cli"
+	SED_FLAGS := -i ''
+	LN_FLAGS := -s
+	LN_SRC := $(CURRENT_DIR)/ani-cli
 else ifeq ($(UNAME), Linux)
-	SED_FLAGS := "-i"
-	LN_FLAGS := "-sr"
-	LN_SRC := "ani-cli"
+	SED_FLAGS := -i
+	LN_FLAGS := -sr
+	LN_SRC := ani-cli
 endif
 
 all: install

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,8 @@ CURRENT_DIR := $(shell pwd)
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 	SED_FLAGS := -i ''
-	LN_FLAGS := -s
-	LN_SRC := $(CURRENT_DIR)/ani-cli
 else ifeq ($(UNAME), Linux)
 	SED_FLAGS := -i
-	LN_FLAGS := -sr
-	LN_SRC := ani-cli
 endif
 
 all: install
@@ -20,7 +16,7 @@ install: uninstall
 	@# writes ORIGINAL_DIR variable to ani-cli file
 	sed $(SED_FLAGS) '2s}.*}ORIGINAL_DIR="$(CURRENT_DIR)"}' ./ani-cli
 	@# symlinks ani-cli file to /usr/local/bin/ani-cli, which should be in path
-	ln $(LN_FLAGS) $(LN_SRC) $(DESTDIR)$(PREFIX)/bin/ani-cli
+	ln -s $(CURRENT_DIR)/ani-cli $(DESTDIR)$(PREFIX)/bin/ani-cli
 	@# marks ani-cli symlink executable
 	chmod 0755 $(DESTDIR)$(PREFIX)/bin/ani-cli
 

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ CURRENT_DIR := $(shell pwd)
 
 all: install
 
-install:
-	# writes ORIGINAL_DIR variable to ani-cli file
-	sed -i '2s}.*}ORIGINAL_DIR="$(CURRENT_DIR)"}' ./ani-cli
-  # symlinks ani-cli file to /usr/local/bin/ani-cli, which should be in path
-	ln -sr ani-cli $(DESTDIR)$(PREFIX)/bin/ani-cli
-  # marks ani-cli symlink executable
+install: uninstall
+	@# # writes ORIGINAL_DIR variable to ani-cli file
+	sed -i '' '2s}.*}ORIGINAL_DIR="$(CURRENT_DIR)"}' ./ani-cli
+	@# symlinks ani-cli file to /usr/local/bin/ani-cli, which should be in path
+	ln -s $(CURRENT_DIR)/ani-cli $(DESTDIR)$(PREFIX)/bin/ani-cli
+	@# marks ani-cli symlink executable
 	chmod 0755 $(DESTDIR)$(PREFIX)/bin/ani-cli
 
 uninstall:
-  # removes symlink in /usr/local/bin/ani-cli
+	@# removes symlink in /usr/local/bin/ani-cli
 	$(RM) $(DESTDIR)$(PREFIX)/bin/ani-cli
 
 .PHONY: all install uninstall


### PR DESCRIPTION
It seems to me that `sed` and `ln` have slight differences on Mac and Linux.
On Mac, `sed`'s `-i` flag requires an argument.
On Mac, `ln` does not have a `-r` flag.
Because of this, I used `uname` to check which operating system is running, and used different flags in the case of Mac vs Linux.

Additionally, I put `@` in front of the comments to make it so `make` does not print them.