### PR TITLE
Stop current episode from continuously playing when switching between episodes.

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -338,7 +338,7 @@ open_episode () {
 					rm "${logfile}.new"
 				else
                                         if ps "$PID" &> /dev/null; then
-						kill "$PID"
+					        kill "$PID"
 					fi
 					nohup $player_fn "$play_link" > /dev/null 2>&1 &
 					PID="$!"
@@ -352,7 +352,7 @@ open_episode () {
 					rm "${logfile}.new"
 				else
                                         if ps "$PID" &> /dev/null; then
-                                            pkill "$PID"
+                                                kill "$PID"
                                         fi
 					nohup $player_fn "$play_link" > /dev/null 2>&1 &
 					PID="$!"

--- a/ani-cli
+++ b/ani-cli
@@ -337,6 +337,9 @@ open_episode () {
 					printf "${c_red}\nCannot reach servers!"
 					rm "${logfile}.new"
 				else
+                                        if pgrep mpv; then
+                                            pkill mpv
+                                        fi
 					nohup $player_fn "$play_link" > /dev/null 2>&1 &
 					printf "${c_green}\nVideo playing"
 					mv "${logfile}.new" "$logfile"
@@ -347,6 +350,9 @@ open_episode () {
 					printf "${c_red}\nCannot reach servers!"
 					rm "${logfile}.new"
 				else
+                                        if pgrep vlc; then
+                                            pkill vlc
+                                        fi
 					nohup $player_fn "$play_link" > /dev/null 2>&1 &
 					printf "${c_green}\nVideo playing"
 					mv "${logfile}.new" "$logfile"

--- a/ani-cli
+++ b/ani-cli
@@ -337,10 +337,11 @@ open_episode () {
 					printf "${c_red}\nCannot reach servers!"
 					rm "${logfile}.new"
 				else
-                                        if pgrep mpv; then
-                                            pkill mpv
-                                        fi
+                                        if ps "$PID" &> /dev/null; then
+						kill "$PID"
+					fi
 					nohup $player_fn "$play_link" > /dev/null 2>&1 &
+					PID="$!"
 					printf "${c_green}\nVideo playing"
 					mv "${logfile}.new" "$logfile"
 				fi;;
@@ -350,10 +351,11 @@ open_episode () {
 					printf "${c_red}\nCannot reach servers!"
 					rm "${logfile}.new"
 				else
-                                        if pgrep vlc; then
-                                            pkill vlc
+                                        if ps "$PID" &> /dev/null; then
+                                            pkill "$PID"
                                         fi
 					nohup $player_fn "$play_link" > /dev/null 2>&1 &
+					PID="$!"
 					printf "${c_green}\nVideo playing"
 					mv "${logfile}.new" "$logfile"
 				fi;;


### PR DESCRIPTION
This short statement is pretty convenient in my opinion when trying to switch between episodes. I used `pgrep` to check if the process of `mpv` or `vlc` is still running.