### PR TITLE
fix: interrupt signal didn't quit

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -384,7 +384,7 @@ open_episode () {
 ############
 
 # to clear the colors when exited using SIGINT
-trap "printf '$c_reset'" INT HUP
+trap "printf '$c_reset'; exit 1" INT HUP
 
 # option parsing
 is_download=0


### PR DESCRIPTION
Interrupting (ctrl+c) during a prompt did not quit immediately, but caused error messages due to invalid input.
Especially when interrupting the `get_search_query`, a invalid search request was sent to the website.