### PR TITLE
Replace curl with aria2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
 grep
 curl
 sed
-ffmpeg
+aria2
 git
 ```
 

--- a/ani-cli
+++ b/ani-cli
@@ -353,7 +353,7 @@ open_episode () {
 		# add 0 padding to the episode name
 		episode=$(printf "%03d" $episode)
 		{
-			curl -L -# -e "$dpage_link" -C - "$video_url" -o "${anime_id}-${episode}.mp4" &&
+			aria2c -x 16 -s 16 --referer "$dpage_link" "$video_url" --dir=$download_dir -o "${anime_id}-${episode}.mp4" --download-result=hide &&
 				printf "${c_green}Downloaded episode: %s${c_reset}\n" "$episode" ||
 				printf "${c_red}Download failed episode: %s , please retry or check your internet connection${c_reset}\n" "$episode"
 		}
@@ -428,6 +428,12 @@ dep_ch "curl" "sed" "grep" "git"
 # check for optional dependencies
 if [ $is_download -eq 0 ]; then
 	dep_ch "$player_fn"
+else
+    if ! command -v aria2c > /dev/null ; then
+	echo "command aria2c not found. Please install it"
+	echo "To install aria2c, Type <your_package_manager> aria2"
+	exit 1
+    fi
 fi
 
 check_for_update


### PR DESCRIPTION
As we know that, gogoanime enabled referer link for downloading... we now get reduced speed.. like 400-600 KBps... Now we can use parallel downloading of aria2... to get above 1-2 MBps speed..
@Dink4n @ura43 you can try it with or without aria2.. by checking any episode..

note:- some download links ends at "==" or "=" .. they are little slower than the links ending at "alphabet" or "numeric"... In my testing...