### PR TITLE
Feature add: update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
   ```
     ani-cli [-kv] [--dub] [-q <quality>] [-d | -p <download_dir>] [<query>]
     ani-cli [-kv] [--dub] [-q <quality>] -u | -n | -H
-    ani-cli -h | -D
+    ani-cli -h | -D | -U
   Options:
     -u shows anime from history with unwatched episodes
     -n show recent anime
@@ -47,16 +47,15 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
 grep
 curl
 sed
-aria2
-git
 ```
 
 ### Optional
 ```
 mpv - The default video player (recommended)
+aria2 - For downloading (recommended)
 vlc - An alternative video player
-diff
-patch
+diff - Update checking
+patch - Update checking
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
     -k on keypress navigation (previous/next/replay/quit episode)
     --dub play the dub version if present
     -v use VLC as the media player
+    -U fetch update from github
 
   Episode selection:
     Add 'h' on beginning for episodes like '6.5' -> 'h6'
@@ -54,8 +55,10 @@ git
 ```
 mpv - The default video player (recommended)
 vlc - An alternative video player
+diff
+patch
 ```
-  
+
 ## Install
 
 ### Linux / Mac

--- a/ani-cli
+++ b/ani-cli
@@ -59,11 +59,11 @@ err () {
 
 update_script () {
 	# get the newest version of this script from github and replace it
-	update="$(curl -s "https://raw.githubusercontent.com/pystardust/ani-cli/master/ani-cli" | diff -u $0 -)"
+	update="$(curl -s "https://raw.githubusercontent.com/pystardust/ani-cli/master/ani-cli" | diff -u "$0" -)"
 	if [ -z "$update" ]; then
 		printf "$c_green%s$c_reset\n" "Script is up to date :)"
 	else
-		printf '%s\n' "$update" | patch $0 -
+		printf '%s\n' "$update" | patch "$0" -
 		printf "$c_green%s$c_reset\n" "Script has been updated"
 	fi
 }

--- a/ani-cli
+++ b/ani-cli
@@ -38,6 +38,7 @@ help_text () {
 	  -k on keypress navigation (previous/next/replay/quit episode)
 	  --dub play the dub version if present
 	  -v use VLC as the media player
+	  -U fetch update from github
 	Episode selection:
 	  Add 'h' on beginning for episodes like '6.5' -> 'h6'
 	  Multiple episodes can be chosen given a range
@@ -54,6 +55,17 @@ die () {
 
 err () {
 	printf "$c_red%s$c_reset\n" "$*" >&2
+}
+
+update_script () {
+	# get the newest version of this script from github and replace it
+	update="$(curl -s "https://raw.githubusercontent.com/pystardust/ani-cli/master/ani-cli" | diff -u $0 -)"
+	if [ -z "$update" ]; then
+		printf "$c_green%s$c_reset\n" "Script is up to date :)"
+	else
+		printf '%s\n' "$update" | patch $0 -
+		printf "$c_green%s$c_reset\n" "Script has been updated"
+	fi
 }
 
 search_new () {
@@ -368,7 +380,7 @@ navigation_type=0
 # navigation_type 0 - confirm selection by pressing enter
 # navigation_type 1 - no enter confirmation for selections
 
-while getopts 'hdDHknp:q:uv-:' OPT; do
+while getopts 'hdDHknp:q:uvU-:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -402,6 +414,10 @@ while getopts 'hdDHknp:q:uv-:' OPT; do
 			;;
 		v)
 			player_fn="vlc"
+			;;
+		U)
+			update_script
+			exit 0
 			;;
 		-)
 			case $OPTARG in


### PR DESCRIPTION
This snipet will allow you to update your ani-cli instance automatically
for _**future releases only**_

It's pretty handy for people who have their ani-cli inside `.local/bin` or something like that

Edit: Someone could say
>You could just symlink ani-cli from the git repo

But i think this make the script more usefull for people who only want to update without messing with git