### PR TITLE
Incorporated vidcdn updates

### DIFF
--- a/ani-cli-win
+++ b/ani-cli-win
@@ -89,6 +89,7 @@ decrypt_link() {
 
     #send the request to the ajax url
     curl -s -H 'x-requested-with:XMLHttpRequest' "$ajax_url" -d "id=$ajax" -d "time=69420691337800813569" \
+    		| jq '.' \
 		| tr '"' '\n' \
 		| sed -n -E 's/.*cdn.*/\0/p' \
 		| sed 's/\\//g' \
@@ -229,9 +230,7 @@ open_episode () {
 	printf "Getting data for episode %d\n" $episode
 
 	dpage_link=$(get_dpage_link "$anime_id" "$episode")
-	# printf "%s\n" "$dpage_link"
 	video_url=$(get_links "$dpage_link")
-	# printf "%s\n" "$video_url"
 
 	case $video_url in
 		*streamtape*)

--- a/ani-cli-win
+++ b/ani-cli-win
@@ -25,7 +25,7 @@ help_text () {
 	 -h	 show this help text
 	 -d	 download episode
 	 -H	 continue where you left off
-	 -q	 set video quality (best/worst/360/480/720/..)
+	 -q	 set video quality (best|worst|360|480|720|1080)
 	EOF
 }
 
@@ -72,20 +72,36 @@ get_dpage_link() {
 
 	# credits to fork: https://github.com/Dink4n/ani-cli for the fix
 	curl -4 -s "$base_url/$anime_id-episode-$ep_no" |
-	sed -n -E '
-		/^[[:space:]]*<li class="dowloads">/{
-		s/.*href="([^"]*)".*/\1/p
-		q
-		}'
+    sed -n -E 's/^[[:space:]]*<a href="#" rel="100" data-video="([^"]*)".*/\1/p' |
+	    sed 's/^/https:/g'
+}
+
+decrypt_link() {
+    ajax_url='https://gogoplay.io/encrypt-ajax.php'
+
+    #get the id from the url
+    video_id=$(printf "$1" | cut -d\? -f2 | cut -d\& -f1 | sed 's/id=//g')
+
+    #construct ajax parameters
+    secret_key='3235373436353338353932393338333936373634363632383739383333323838'
+    iv='34323036393133333738303038313335'
+    ajax=$(printf "$video_id" | openssl enc -aes256  -K "$secret_key" -iv "$iv" -a)
+
+    #send the request to the ajax url
+    curl -s -H 'x-requested-with:XMLHttpRequest' "$ajax_url" -d "id=$ajax" -d "time=69420691337800813569" \
+		| tr '"' '\n' \
+		| sed -n -E 's/.*cdn.*/\0/p' \
+		| sed 's/\\//g' \
+		| sed '/.vtt/d'
 }
 
 get_video_quality() {
 	dpage_url=$1
 
-	video_links=$(curl -4 -s "$dpage_url" | sed -n -E 's/.*href="([^"]*)" download>Download.*/\1/p' | sed 's/amp;//')
+	video_links=$(decrypt_link "$dpage_url")
 	case $quality in
 		best)
-			video_link=$(printf '%s' "$video_links" | tail -n 1)
+			video_link=$(printf '%s' "$video_links" | head -n 4 | tail -n 1)
 			;;
 
 		worst)
@@ -93,11 +109,11 @@ get_video_quality() {
 			;;
 
 		*)
-			video_link=$(printf '%s' "$video_links" | grep -i "${quality}p")
+			video_link=$(printf '%s' "$video_links" | grep -i "${quality}p" | head -n 1)
 			if [ -z "$video_link" ]; then
-				printf "$c_red%s$c_reset\n" "Current video quality is not available (defaulting to highest quality)" >&2
+				err "Current video quality is not available (defaulting to best quality)"
 				quality=best
-				video_link=$(printf '%s' "$video_links" | tail -n 1)
+				video_link=$(printf '%s' "$video_links" | head -n 4 | tail -n 1)
 			fi
 			;;
 	esac
@@ -213,7 +229,9 @@ open_episode () {
 	printf "Getting data for episode %d\n" $episode
 
 	dpage_link=$(get_dpage_link "$anime_id" "$episode")
+	# printf "%s\n" "$dpage_link"
 	video_url=$(get_links "$dpage_link")
+	# printf "%s\n" "$video_url"
 
 	case $video_url in
 		*streamtape*)
@@ -234,15 +252,16 @@ open_episode () {
 			s/^${selection_id}\t[0-9]+/${selection_id}\t$((episode+1))/
 		" "$logfile" > "${logfile}.new" && mv "${logfile}.new" "$logfile"
 
-		$player_fn "$video_url" "vlc://quit" --http-referrer="$dpage_link"  --http-user-agent="Mozilla/5.0" --adaptive-use-access  >/dev/null 2>&1
+		nohup "$player_fn" --http-referrer="$dpage_link" --http-user-agent="Mozilla/5.0" --adaptive-use-access "$video_url" "vlc://quit" > /dev/null 2>&1 &
 	else
 		printf "Downloading episode $episode ...\n"
 		printf "%s\n" "$video_url"
 		# add 0 padding to the episode name
 		episode=$(printf "%03d" $episode)
 		{
-			curl -4 -L -# -C - "$video_url" -G -e 'https://streamani.io/' \
-				-o "${anime_id}-${episode}.mp4" "$video_url" >/dev/null 2>&1 &&
+			(command -v aria2c &&
+			aria2c -x 16 -s 16 --referer="$dpage_link" "$video_url" --dir="$download_dir" -o "${anime_id}-${episode}.mp4" --download-result=hide ||
+			curl -4 -L -o "${anime_id}-${episode}.mp4" "$video_url" >/dev/null 2>&1 ) &&
 				printf "${c_green}Downloaded episode: %s${c_reset}\n" "$episode" ||
 				printf "${c_red}Download failed episode: %s${c_reset}\n" "$episode"
 		}


### PR DESCRIPTION
Improvements added:
 - Added ajax code matching current linux master
 - updated download code to use aria2c if user's got it on their path but if they don't it'll use curl
 - Filters out .vtt files that sometimes show up in the list of download links

Limitations:
 From my limited testing it still gets the odd 403 errors with some series and settings but not others:
 - Fine for the FLCL dubs but not subs
 - Fine for Serial Experiments Lain but not Legend of the Galactic Heroes
But with this it once again plays _many_ things as opposed to _no_ things. If these bugs also exist in linux version this'll get windows users back to that level of access.