### PR TITLE
Improve UX and slim down

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@v1.1.0
+      uses: ludeeus/action-shellcheck@master
+      with:
+        version: v0.7.2
       env:
         SHELLCHECK_OPTS: -s sh -e 1087 -e 2059 -o all -e 2250

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       env:
-        SHELLCHECK_OPTS: -s sh -e 1087 -e 2059 -o all -e 2250 -e 2312
+        SHELLCHECK_OPTS: -s sh -e 1087 -e 2059 -o all -e 2250

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@v1.1
       env:
         SHELLCHECK_OPTS: -s sh -e 1087 -e 2059 -o all -e 2250

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@v1.1
+      uses: ludeeus/action-shellcheck@v1.1.0
       env:
         SHELLCHECK_OPTS: -s sh -e 1087 -e 2059 -o all -e 2250

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Maintainer](https://img.shields.io/badge/maintainer-Dink4n-blue)](https://github.com/Dink4n)
 [![Maintainer](https://img.shields.io/badge/maintainer-CoolnsX-blue)](https://github.com/CoolnsX)
 ![Linux](https://img.shields.io/badge/os-linux-brightgreen)
-![Mac](https://img.shields.io/badge/os-mac-yellow)
+![Mac](https://img.shields.io/badge/os-mac-brightgreen)
 ![Windows](https://img.shields.io/badge/os-windows-yellow)
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
 ## Usage
   ```
     ani-cli [-vi] [-q <quality>] [-d | -p <download_dir>] [<query>]
-    ani-cli [-vi] [-q <quality>] -u | -n
+    ani-cli [-vi] [-q <quality>] -c | -n
     ani-cli -h | -D | -U | -V
   Options:
-    -u shows anime from history with unwatched episodes
-    -n show recent anime
+    -c continue watching anime from history
+    -n show new anime
     -h show helptext
     -d download episode
     -q set video quality (best|worst|360|480|720|1080)

--- a/README.md
+++ b/README.md
@@ -20,20 +20,21 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
 
 ## Usage
   ```
-    ani-cli [-kv] [--dub] [-q <quality>] [-d | -p <download_dir>] [<query>]
-    ani-cli [-kv] [--dub] [-q <quality>] -u | -n
-    ani-cli -h | -D | -U
+    ani-cli [-kvi] [-q <quality>] [-d | -p <download_dir>] [<query>]
+    ani-cli [-kvi] [-q <quality>] -u | -n
+    ani-cli -h | -D | -U | -V
   Options:
     -u shows anime from history with unwatched episodes
     -n show recent anime
     -h show helptext
     -d download episode
-    -D delete history
     -q set video quality (best|worst|360|480|720|1080)
     -k on keypress navigation (previous/next/replay/quit episode)
-    --dub play the dub version if present
+    -i use iina as the media player
     -v use VLC as the media player
+    -D delete history
     -U fetch update from github
+    -V print version number and exit
 
   Episode selection:
     Add 'h' on beginning for episodes like '6.5' -> 'h6'

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
 
 ## Usage
   ```
-    ani-cli [-kvi] [-q <quality>] [-d | -p <download_dir>] [<query>]
-    ani-cli [-kvi] [-q <quality>] -u | -n
+    ani-cli [-vi] [-q <quality>] [-d | -p <download_dir>] [<query>]
+    ani-cli [-vi] [-q <quality>] -u | -n
     ani-cli -h | -D | -U | -V
   Options:
     -u shows anime from history with unwatched episodes
@@ -29,7 +29,6 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
     -h show helptext
     -d download episode
     -q set video quality (best|worst|360|480|720|1080)
-    -k on keypress navigation (previous/next/replay/quit episode)
     -i use iina as the media player
     -v use VLC as the media player
     -D delete history

--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ A cli to browse and watch anime. This tool scrapes the site [gogoanime](https://
 ## Usage
   ```
     ani-cli [-kv] [--dub] [-q <quality>] [-d | -p <download_dir>] [<query>]
-    ani-cli [-kv] [--dub] [-q <quality>] -u | -n | -H
+    ani-cli [-kv] [--dub] [-q <quality>] -u | -n
     ani-cli -h | -D | -U
   Options:
     -u shows anime from history with unwatched episodes
     -n show recent anime
     -h show helptext
     -d download episode
-    -H continue with next unwatched episode from history of watched series
     -D delete history
     -q set video quality (best|worst|360|480|720|1080)
     -k on keypress navigation (previous/next/replay/quit episode)

--- a/ani-cli
+++ b/ani-cli
@@ -23,8 +23,8 @@ help_text () {
 	done <<-EOF
   
 	Usage:
-	  $prog [-kv] [--dub] [-q <quality>] [-d | -p <download_dir>] [<query>]
-	  $prog [-kv] [--dub] [-q <quality>] -u | -n | -H
+	  $prog [-kv] [-q <quality>] [-d | -p <download_dir>] [<query>]
+	  $prog [-kv] [-q <quality>] -u | -n | -H
 	  $prog -h | -D
 	Options:
 	  -u shows anime from history with unwatched episodes
@@ -35,7 +35,6 @@ help_text () {
 	  -D delete history
 	  -q set video quality (best|worst|360|480|720|1080)
 	  -k on keypress navigation (previous/next/replay/quit episode)
-	  --dub play the dub version if present
 	  -v use VLC as the media player
 	  -U fetch update from github
 	Episode selection:
@@ -111,10 +110,10 @@ get_dpage_link() {
 
 	# credits to fork: https://github.com/Dink4n/ani-cli for the fix
 	# dub prefix takes the value "-dub" when dub is needed else is empty
-	anime_page=$(curl -s "$base_url/$anime_id${dub_prefix}-$ep_no")
+	anime_page=$(curl -s "$base_url/$anime_id-$ep_no")
 
 	if printf '%s' "$anime_page" | grep -q "404" ; then
-		anime_page=$(curl -s "$base_url/$anime_id${dub_prefix}-episode-$ep_no")
+		anime_page=$(curl -s "$base_url/$anime_id-episode-$ep_no")
 	fi
 
 	printf '%s' "$anime_page" |
@@ -391,7 +390,7 @@ navigation_type=0
 # navigation_type 0 - confirm selection by pressing enter
 # navigation_type 1 - no enter confirmation for selections
 
-while getopts 'hdDknp:q:uvU-:' OPT; do
+while getopts 'hdDknp:q:uvU:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -426,17 +425,6 @@ while getopts 'hdDknp:q:uvU-:' OPT; do
 		U)
 			update_script
 			exit 0
-			;;
-		-)
-			case $OPTARG in
-				dub)
-					dub_prefix="-dub"
-					;;
-				*)
-					help_text
-					exit 1
-					;;
-			esac
 			;;
 		*)
 			help_text

--- a/ani-cli
+++ b/ani-cli
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-# dependencies: grep sed curl video_player
-# video_player ( needs to be able to play urls )
-player_fn="mpv"
-
-prog=$0
 logfile="${XDG_CACHE_HOME:-$HOME/.cache}/ani-hsts"
 base_url=$(curl -s -L -o /dev/null -w "%{url_effective}\n" https://gogoanime.cm)
 
@@ -16,26 +11,25 @@ c_magenta="\033[1;35m"
 c_cyan="\033[1;36m"
 c_reset="\033[0m"
 
-
 help_text () {
 	while IFS= read -r line; do
 		printf "%s\n" "$line"
 	done <<-EOF
   
 	Usage:
-	  $prog [-kv] [-q <quality>] [-d | -p <download_dir>] [<query>]
-	  $prog [-kv] [-q <quality>] -u | -n | -H
-	  $prog -h | -D
+	  $0 [-kv] [-q <quality>] [-d | -p <download_dir>] [<query>]
+	  $0 [-kv] [-q <quality>] -u | -n | -H
+	  $0 -h | -D | -U
 	Options:
-	  -u shows anime from history with unwatched episodes
+	  -u shows anime with unwatched episodes from history
 	  -n show recent anime
 	  -h show helptext
 	  -d download episode
 	  -p download episode to specified directory
-	  -D delete history
 	  -q set video quality (best|worst|360|480|720|1080)
 	  -k on keypress navigation (previous/next/replay/quit episode)
 	  -v use VLC as the media player
+	  -D delete history
 	  -U fetch update from github
 	Episode selection:
 	  Add 'h' on beginning for episodes like '6.5' -> 'h6'
@@ -381,6 +375,7 @@ open_episode () {
 trap 'printf "$c_reset"; exit 1' INT HUP
 
 # option parsing
+player_fn="mpv" #video player needs to be able to play urls
 is_download=0
 half_ep=0
 quality=best

--- a/ani-cli
+++ b/ani-cli
@@ -24,7 +24,7 @@ help_text () {
 	  $0 [-vi] [-q <quality>] -c | -n
 	  $0 -h | -D | -U | -V
 	Options:
-	  -c continue watching anime from your history
+	  -c continue watching anime from history
 	  -n show new anime
 	  -h show helptext
 	  -d download episode

--- a/ani-cli
+++ b/ani-cli
@@ -21,11 +21,11 @@ help_text () {
 
 	Usage:
 	  $0 [-vi] [-q <quality>] [-d | -p <download_dir>] [<query>]
-	  $0 [-vi] [-q <quality>] -u | -n
+	  $0 [-vi] [-q <quality>] -c | -n
 	  $0 -h | -D | -U | -V
 	Options:
-	  -u shows anime with unwatched episodes from history
-	  -n show recent anime
+	  -c continue watching anime from your history
+	  -n show new anime
 	  -h show helptext
 	  -d download episode
 	  -p download episode to specified directory
@@ -389,7 +389,7 @@ quality=best
 scrape=query
 download_dir="."
 
-while getopts 'viq:dp:unhDUV:' OPT; do
+while getopts 'viq:dp:cnhDUV:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -415,7 +415,7 @@ while getopts 'viq:dp:unhDUV:' OPT; do
 		q)
 			quality=$OPTARG
 			;;
-		u)
+		c)
 			scrape=history
 			;;
 		v)

--- a/ani-cli
+++ b/ani-cli
@@ -32,7 +32,6 @@ help_text () {
 	  -h show helptext
 	  -d download episode
 	  -p download episode to specified directory
-	  -H continue with next unwatched episode from history of watched series
 	  -D delete history
 	  -q set video quality (best|worst|360|480|720|1080)
 	  -k on keypress navigation (previous/next/replay/quit episode)
@@ -392,7 +391,7 @@ navigation_type=0
 # navigation_type 0 - confirm selection by pressing enter
 # navigation_type 1 - no enter confirmation for selections
 
-while getopts 'hdDHknp:q:uvU-:' OPT; do
+while getopts 'hdDknp:q:uvU-:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -404,9 +403,6 @@ while getopts 'hdDHknp:q:uvU-:' OPT; do
 		D)
 			: > "$logfile"
 			exit 0
-			;;
-		H)
-			scrape=history
 			;;
 		k)
 			navigation_type=1
@@ -422,7 +418,7 @@ while getopts 'hdDHknp:q:uvU-:' OPT; do
 			quality=$OPTARG
 			;;
 		u)
-			scrape=history_new
+			scrape=history
 			;;
 		v)
 			player_fn="vlc"
@@ -478,19 +474,13 @@ case $scrape in
 		anime_selection "$search_results"
 		episode_selection
 		;;
-	history)
-		search_results=$(sed -n -E 's/\t[0-9]*//p' "$logfile")
-		[ -z "$search_results" ] && die "History is empty"
-		anime_selection "$search_results"
-		ep_choice_start=$(sed -n -E "s/${selection_id}\t//p" "$logfile")
-		;;
 	new)
 		search_results=$(search_new)
 		# echo "$search_results"
 		anime_selection "$search_results"
 		episode_selection
 		;;
-	history_new)
+	history)
 		search_results=$(sed -n -E 's/\t[0-9]*//p' "$logfile")
 		[ -z "$search_results" ] && die "History is empty"
 		search_results=$(search_for_unwatched "$search_results")

--- a/ani-cli
+++ b/ani-cli
@@ -20,8 +20,8 @@ help_text () {
 	done <<-EOF
 
 	Usage:
-	  $0 [-kvi] [-q <quality>] [-d | -p <download_dir>] [<query>]
-	  $0 [-kvi] [-q <quality>] -u | -n
+	  $0 [-vi] [-q <quality>] [-d | -p <download_dir>] [<query>]
+	  $0 [-vi] [-q <quality>] -u | -n
 	  $0 -h | -D | -U | -V
 	Options:
 	  -u shows anime with unwatched episodes from history
@@ -30,7 +30,6 @@ help_text () {
 	  -d download episode
 	  -p download episode to specified directory
 	  -q set video quality (best|worst|360|480|720|1080)
-	  -k on keypress navigation (previous/next/replay/quit episode)
 	  -i use iina as the media player
 	  -v use VLC as the media player
 	  -D delete history
@@ -389,11 +388,8 @@ half_ep=0
 quality=best
 scrape=query
 download_dir="."
-navigation_type=0
-# navigation_type 0 - confirm selection by pressing enter
-# navigation_type 1 - no enter confirmation for selections
 
-while getopts 'kviq:dp:unhDUV:' OPT; do
+while getopts 'viq:dp:unhDUV:' OPT; do
 	case $OPT in
 		h)
 			help_text
@@ -405,9 +401,6 @@ while getopts 'kviq:dp:unhDUV:' OPT; do
 		D)
 			: > "$logfile"
 			exit 0
-			;;
-		k)
-			navigation_type=1
 			;;
 		n)
 			scrape=new
@@ -509,23 +502,8 @@ while :; do
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_magenta%s$c_reset\n" "h" "search history"
 	printf "$c_blue[${c_cyan}%s$c_blue] $c_red%s$c_reset\n" "q" "exit"
 	printf "${c_blue}Enter choice:${c_green} "
-
-	case "${navigation_type}" in
-		0)
-			read -r choice
-			;;
-		1)
-			stty_original="$(stty -g)"
-			stty cbreak
-			choice="$(dd bs=1 count=1 2> /dev/null)"
-			stty "${stty_original}"
-			;;
-		*)
-			die "navigation_type is invalid"
-			;;
-
-	esac
-
+	
+	read -r choice
 	printf "$c_reset"
 	case $choice in
 		n)

--- a/ani-cli
+++ b/ani-cli
@@ -393,7 +393,7 @@ navigation_type=0
 # navigation_type 0 - confirm selection by pressing enter
 # navigation_type 1 - no enter confirmation for selections
 
-while getopts 'kviq:dp:hDUV:' OPT; do
+while getopts 'kviq:dp:unhDUV:' OPT; do
 	case $OPT in
 		h)
 			help_text


### PR DESCRIPTION
- [x] `-H` is just a worse form of `-u` **(remove)**
- [x] `--dub` prompts you for selecting an anime, even if only one version was found **(remove)**
- [x] `-h` needs another sorting *(polish)*
~`-k` should become more consistent and maybe even default behaviour *(rewrite)*~
~`-p` should really be an optional arg for `-d` **(remove)**~
~`-v` should allow choice in any non-default video player as optarg, with vlc staying the default alternative.~

As always this tasklist is subject to change
