### PR TITLE
Changed installation steps for termux

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ git clone https://github.com/pystardust/ani-cli
 cd ani-cli
 cp ani-cli $PREFIX/bin/ani-cli
 chmod +x $PREFIX/bin/ani-cli
-echo 'termux-open --content-type video "$2"' > $PREFIX/bin/mpv
+echo 'termux-open "$2"' > $PREFIX/bin/mpv
 chmod +x $PREFIX/bin/mpv
 ```
 


### PR DESCRIPTION
`termux open --content-type video `
command not working perfectly instead of it `termux-open` works without specifying the content type . 
And it opens video player automatically when the link was video 