### PR TITLE
fix : prevent exiting episode range by using previous episode

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -390,8 +390,9 @@ open_episode () {
 			err "Episode out of range"
 		fi
 		prompt "Choose episode" "[$first_ep_number-$last_ep_number]"
+		is_number "$REPLY"
 		episode="$REPLY"
-		ep_choice_start=$episode
+		ep_choice_start="$episode"
 	done
 	#processing half episodes
 	if [ "$half_ep" -eq 1 ]; then

--- a/ani-cli
+++ b/ani-cli
@@ -382,7 +382,7 @@ open_episode () {
 	# cool way of clearing screen
 	tput clear
 	# checking if episode is in range
-	while [ "$episode" -gt "$last_ep_number" ] || [ -z "$episode" ]; do
+	while [ "$episode" -gt "$last_ep_number" ] || [ -z "$episode" ] || [ "$episode" -lt "$first_ep_number" ]; do
 	is_number "$ep_choice_start"
 		if [ "$last_ep_number" -eq 0 ]; then
 			die "Episodes not released yet!"

--- a/ani-cli
+++ b/ani-cli
@@ -18,7 +18,7 @@
 # Project repository: https://github.com/pystardust/ani-cli
 
 # Version number
-VERSION="1.7.6"
+VERSION="1.7.7"
 
 #######################
 # AUXILIARY FUNCTIONS #

--- a/ani-cli
+++ b/ani-cli
@@ -390,7 +390,8 @@ open_episode () {
 			err "Episode out of range"
 		fi
 		prompt "Choose episode" "[$first_ep_number-$last_ep_number]"
-		episode="$REPLY $REPLY2"
+		episode="$REPLY"
+		ep_choice_start=$episode
 	done
 	#processing half episodes
 	if [ "$half_ep" -eq 1 ]; then


### PR DESCRIPTION
Prevent user escaping episode range by
1. Run `ani-cli evangelion`
2. Choose `1`
3. Choose `1`
4. Choose `p` (previous episode)