### PR TITLE
docs: updating termux installation, now works with both mpv and vlc (-v option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ Install termux [(Guide)](https://termux.com/)
 pkg install git make termux-tools ncurses-utils openssl-tool -y
 git clone https://github.com/pystardust/ani-cli && cd ani-cli
 cp ani-cli $PREFIX/bin/ani-cli
-echo 'termux-open "$2"' > $PREFIX/bin/mpv
+echo 'am start --user 0 -a android.intent.action.VIEW -d "$2" -n is.xyz.mpv/.MPVActivity' > $PREFIX/bin/mpv
+chmod +x $PREFIX/bin/mpv
+echo 'am start --user 0 -a android.intent.action.VIEW -d "$2" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity' > $PREFIX/bin/vlc
+chmod +x $PREFIX/bin/vlc
 ```
 
 ## Uninstall


### PR DESCRIPTION
using 'am start' again due to termux-open having different problems in different devices