### PR TITLE
Add old version warning for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Install homebrew [(Guide)](https://brew.sh/)
 brew tap iamchokerman/ani-cli
 brew install ani-cli
 ```
+*If you are upgrading from the old manual install process, you may have to remove the old ani-cli by running `rm /usr/local/bin/ani-cli`*
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Install homebrew [(Guide)](https://brew.sh/)
 brew tap iamchokerman/ani-cli
 brew install ani-cli
 ```
-*If you are upgrading from the old manual install process, you may have to remove the old ani-cli by running `rm /usr/local/bin/ani-cli`*
+*If you are upgrading from the old manual install process, you may have to remove the old ani-cli by running `sudo rm /usr/local/bin/ani-cli`*
 
 ### Windows
 


### PR DESCRIPTION
Adds a warning about having an older, manually installed, version of ani-cli. Executables in `/usr/local/bin` can have precedence over those in `/opt/homebrew/bin`, meaning that users would continue using the older version, despite having the newer version installed.