### PR TITLE
Fix: Fix comparison with null returned ``PID``

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -18,7 +18,7 @@
 # Project repository: https://github.com/pystardust/ani-cli
 
 # Version number
-VERSION="1.9.2"
+VERSION="2.0.1"
 
 
 #######################

--- a/ani-cli
+++ b/ani-cli
@@ -440,7 +440,7 @@ open_episode () {
 		sed -E "
 			s/^${selection_id}\t[0-9]+/${selection_id}\t$((episode+1))/
 		" "$logfile" > "${logfile}.new"
-		[ "$PID" -ne 0 ] && kill "$PID" >/dev/null 2>&1
+		[ ! "$PID" = "0" ] && kill "$PID" >/dev/null 2>&1
 		[ -z "$video_url" ] && die "Video URL not found"
 		case "$player_fn" in
 			vlc)


### PR DESCRIPTION
While playing episodes following error is printed to stderr:
![Screenshot_31](https://user-images.githubusercontent.com/72691864/158598625-59391d1d-ffe6-431e-a62b-0e2e6b3189c8.png)
 
dunno the exact reason but maybe cuz the background job finishes or smth but shell var ``$!`` should at least be able to record the PID of the recently executed job.instead null is returned.well whatever.btw i reccom using string comparison instead of int for all shell vars cuz we don't always get wat we want cuz itzzz **Shell scripting**.

if anyone has a fix to null returned PID,please do edit the pr.