### PR TITLE
Set user-agent

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -442,6 +442,8 @@ play_episode () {
 # clears the colors and deletes temporary logfile when exited using SIGINT
 trap 'printf "\033[0m";[ -f "$logfile".new ] && rm "$logfile".new;exit 1' INT HUP
 
+alias curl="curl -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36'"
+
 # default options
 player_fn="mpv" #video player needs to be able to play urls
 is_download=0


### PR DESCRIPTION
By default curl sets the header `user-agent` to `curl/<version>`
This means that the script announces itself as unwanted curl traffic

Setting this to a new value does not mean that the site will not figure out that this is not a browser

The `user-agent` in this PR is from my browser