### PR TITLE
chore: bump version 2.1.4 -> 2.1.5

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -18,7 +18,7 @@
 # Project repository: https://github.com/pystardust/ani-cli
 
 # Version number
-VERSION="2.1.4"
+VERSION="2.1.5"
 
 
 


### PR DESCRIPTION
Forgot to check for version bump in previous merge, sorry