### PR TITLE
Add packaging status section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ yay -S ani-cli
 
 Available in the [NUR](https://github.com/nix-community/NUR): `nur.repos.willpower3309.ani-cli`. To install on nixOS, [add the NUR to your configuration](https://github.com/nix-community/NUR/blob/master/README.md#installation), and the ani-cli package to your `configuration.nix`:
 
-```nix
+```console
 # configuration.nix
 environment.systemPackages = with pkgs; [
   nur.repos.willpower3309.ani-cli

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Also consider ani-cli-git
 yay -S ani-cli
 ```
 
-### NixOS
+### Other native packages
 
-Available in the [NUR](https://github.com/nix-community/NUR): `nur.repos.willpower3309.ani-cli`
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg)](https://repology.org/project/ani-cli/versions)
 
 ### Linux & Mac OS
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ Also consider ani-cli-git
 yay -S ani-cli
 ```
 
+### Nix
+
+Available in the [NUR](https://github.com/nix-community/NUR): `nur.repos.willpower3309.ani-cli`. To install on nixOS, [add the NUR to your configuration](https://github.com/nix-community/NUR/blob/master/README.md#installation), and the ani-cli package to your `configuration.nix`:
+
+```nix
+# configuration.nix
+environment.systemPackages = with pkgs; [
+  nur.repos.willpower3309.ani-cli
+];
+```
+
 ### Other native packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg)](https://repology.org/project/ani-cli/versions)

--- a/README.md
+++ b/README.md
@@ -64,17 +64,6 @@ Also consider ani-cli-git
 yay -S ani-cli
 ```
 
-### Nix
-
-Available in the [NUR](https://github.com/nix-community/NUR): `nur.repos.willpower3309.ani-cli`. To install on nixOS, [add the NUR to your configuration](https://github.com/nix-community/NUR/blob/master/README.md#installation), and the ani-cli package to your `configuration.nix`:
-
-```console
-# configuration.nix
-environment.systemPackages = with pkgs; [
-  nur.repos.willpower3309.ani-cli
-];
-```
-
 ### Other native packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg)](https://repology.org/project/ani-cli/versions)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Also consider ani-cli-git
 ```sh
 yay -S ani-cli
 ```
+
+### NixOS
+
+Available in the [NUR](https://github.com/nix-community/NUR): `nur.repos.willpower3309.ani-cli`
+
 ### Linux & Mac OS
 
 Install dependencies [(See below)](#Dependencies)


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

I've been maintaining the ani-cli NUR (nix user repository) packaged ani-cli for a little while now, since noticing that a section in the readme exists for installation instructions, I'm offering up this update to the readme in case the maintainers are interested in mentioning its availability on Nix.
