### PR TITLE
Fix tput and Illegal Number

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -18,7 +18,7 @@
 # Project repository: https://github.com/pystardust/ani-cli
 
 # Version number
-VERSION="2.2.0"
+VERSION="2.2.1"
 
 
 #######################

--- a/ani-cli
+++ b/ani-cli
@@ -68,6 +68,13 @@ die () {
 	exit 1
 }
 
+# tput is part of ncurses which is not installed by default on termux
+command -v tput >/dev/null || tput() {
+	if [ "$1" = 'clear' ]; then
+            printf '\033c'
+	fi
+}
+
 # get the newest version of this script from github and replace it
 update_script () {
 	update="$(curl -A "$agent" -s "https://raw.githubusercontent.com/pystardust/ani-cli/master/ani-cli")" || die "Connection error"
@@ -398,6 +405,7 @@ episode_selection () {
 					err "Episode out of range"
 					continue
 				fi
+				[ "$ep_choice_end" = "" ] && break
 				if [ "$ep_choice_end" -le "$ep_choice_start" ]; then
 					err "Invalid range"
 					continue


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

- `tput` is a tool from ncurses which is not install by default on Android
- `$ep_choice_end` is empty when compared to a number
  - `"" <= 8`

## Checklist

- [x] any anime playing
- [x] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [x] syncplay -s works
- [x] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
