### PR TITLE
set iina as default for MacOS instead of mpv

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ yay -S ani-cli
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg)](https://repology.org/project/ani-cli/versions)
 
-### Linux & Mac OS
+### Linux
 
 Install dependencies [(See below)](#Dependencies)
 
@@ -82,11 +82,26 @@ sudo chmod +x /usr/local/bin/ani-cli
 
 *Note that mpv installed through flatpak is not compatible*
 
+### Mac OS
+
+Install dependencies [(See below)](#Dependencies)
+
+Install [HomeBrew](https://docs.brew.sh/Installation) if not installed.
+
+```sh
+bash
+curl -sL github.com/pystardust/ani-cli/raw/master/ani-cli -o "$(brew --prefix)/bin/ani-cli"
+chmod +x "$(brew --prefix)/bin/ani-cli"
+exit
+```
+
 *To install (with Homebrew) the dependencies required on Mac OS, you can run:*
 
 ```sh
-brew install curl grep aria2 mpv openssl@1.1 ffmpeg git
+brew install curl grep aria2 iina openssl@1.1 ffmpeg git
 ```
+*Most likely you'll need to install only iina as the rest are probably already there.
+*Why iina and not mpv? Drop-in replacement for mpv for MacOS. Integrates well with OSX UI. Excellent support for M1. Open Source.
 
 ### Windows
 
@@ -123,12 +138,6 @@ Make sure to update your packages:
 pkg up
 ```
 
-In the case mpv only plays audio, you can try running this command:
-```sh
-echo 'am start --user 0 -a android.intent.action.VIEW -d "$1" -n is.xyz.mpv/.MPVActivity' > $PREFIX/bin/mpv
-```
-
-
 ## Uninstall
 
 * Arch Linux: ```yay -R ani-cli```
@@ -145,6 +154,7 @@ echo 'am start --user 0 -a android.intent.action.VIEW -d "$1" -n is.xyz.mpv/.MPV
 - curl
 - openssl
 - mpv - Video Player
+- iina - mpv replacement for MacOS
 - aria2 - Download manager
 - ffmpeg - m3u8 Downloader
 

--- a/ani-cli
+++ b/ani-cli
@@ -398,7 +398,7 @@ episode_selection () {
 					err "Episode out of range"
 					continue
 				fi
-				if [ "$ep_choice_end" -le "$ep_choice_start" ]; then
+				if [ -n "$ep_choice_end" ] && [ "$ep_choice_end" -le "$ep_choice_start" ]; then
 					err "Invalid range"
 					continue
 				fi
@@ -485,6 +485,9 @@ play_episode () {
 		"syncplay"|"/Applications/Syncplay.app/Contents/MacOS/syncplay"|"/c/Program Files (x86)/Syncplay/Syncplay.exe")
 			set -- "$player_fn" "$video_url" -- --referrer="$refr" --force-media-title="$trackma_title $episode"
 			;;
+        iina)
+            set -- "$player_fn" "$video_url" --no-stdin --keep-running --mpv-vid="$idx" --mpv-referrer="$refr" --mpv-force-media-title="$trackma_title $episode"
+            ;;
 		*)
 			set -- "$player_fn" "$video_url" --vid="$idx" --referrer="$refr" --force-media-title="$trackma_title $episode" ;;
 	esac
@@ -510,7 +513,10 @@ play_episode () {
 trap 'printf "\033[0m";[ -f "$logfile".new ] && rm "$logfile".new;exit 1' INT HUP
 
 # default options
-player_fn="mpv" #video player needs to be able to play urls
+case "$OSTYPE" in
+    darwin*) player_fn="iina";; #MacOS specific
+    *)       player_fn="mpv";; #video player needs to be able to play urls
+esac
 agent="Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/100.0"
 is_download=0
 PID=0


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

- iina is an opensource alternative to mpv for MacOS with a more OSX-like UI
- this pull req sets iina as default for macos using a case statement
- ensures compatibility with mpv flags and that all features of this script works with iina
### &&
```
if  [ "$ep_choice_end" -le "$ep_choice_start" ]; then
        err "Invalid range"
        continue
fi
```
👆bug fix for when $ep_choice_end is undefined [expected: number].

## Checklist

- [x] any anime playing
- [x] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [x] syncplay -s works
- [x] autoplay, aka range selection, works
