### PR TITLE
Fix: working regex that gets the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ To see a list with all the arguments, use the -h or --help argument
 Install dependencies [(See below)](#Dependencies)
 
 ```sh
-sudo rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli" && \
-sudo mkdir -p "/usr/local/share/" "/usr/local/bin/" && \
-sudo git clone -b "master" "https://github.com/pystardust/ani-cli.git" "/usr/local/share/ani-cli" && \
-sudo ln -sf "/usr/local/share/ani-cli/ani-cli" "/usr/local/bin/ani-cli"
+sudo rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli"
+git clone -b "master" "https://github.com/pystardust/ani-cli.git" && cd "./ani-cli"
+mv "./ani-cli" "/usr/local/bin/ani-cli" 
+mv -a "./UI" "./players" "/usr/local/share"
+cd .. && rm -rf "./ani-cli"
+
 ```
 *Also note that mpv installed through flatpak is not compatible*
 
@@ -93,9 +95,11 @@ Install dependencies [(See below)](#Dependencies)
 Install [HomeBrew](https://docs.brew.sh/Installation) if not installed.
 
 ```sh
-rm -rf "$(brew --prefix)/share/ani-cli" "$(brew --prefix)/bin/ani-cli" && \
-git clone -b "master" "https://github.com/pystardust/ani-cli.git" "$(brew --prefix)/share/ani-cli" && \
-ln -sf "$(brew --prefix)/share/ani-cli/ani-cli" "$(brew --prefix)/bin/ani-cli"
+rm -rf "$(brew --prefix)/share/ani-cli" "$(brew --prefix)/bin/ani-cli"
+git clone -b "master" "https://github.com/pystardust/ani-cli.git" && cd "./ani-cli"
+mv "./ani-cli "$(brew --prefix)/bin/ani-cli"
+mv -a "./players" "./UI" "$(brew --prefix)/share/"
+cd .. && rm -rf "./ani-cli"
 ```
 
 *To install (with Homebrew) the dependencies required on Mac OS, you can run:* 
@@ -113,10 +117,11 @@ brew install --cask iina
 *Note that the installation instruction below must be done inside **Git Bash**, not in Command Prompt or Powershell*
 
 ```sh
-rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli" && \
-mkdir -p "/usr/local/share/" "/usr/local/bin/" && \
-git clone -b "master" "https://github.com/pystardust/ani-cli.git" "/usr/local/share/ani-cli" && \
-ln -sf "/usr/local/share/ani-cli/ani-cli" "/usr/local/bin/ani-cli"
+rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli"
+git clone -b "master" "https://github.com/pystardust/ani-cli.git" && cd ani-cli
+mv "./ani-cli" "/usr/local/bin/ani-cli"
+mv -a "./UI" "./players" "/usr/local/share/"
+cd .. && rm -rf "./ani-cli"
 ```
 
 *Run ani-cli in Git Bash (Running it in cmd or powershell may or may not work)*
@@ -126,10 +131,11 @@ ln -sf "/usr/local/share/ani-cli/ani-cli" "/usr/local/bin/ani-cli"
 Install termux [(Guide)](https://termux.com/)
 
 ```sh
-rm -rf "$PREFIX/share/ani-cli" "$PREFIX/bin/ani-cli" && \
-mkdir -p "$PREFIX/share/ani-cli" "$PREFIX/bin/ani-cli" && \
-git clone -b "master" "https://github.com/pystardust/ani-cli.git" "$PREFIX/share/ani-cli" && \
-ln -sf "$PREFIX/share/ani-cli/ani-cli" "$PREFIX/bin/ani-cli"
+rm -rf "$PREFIX/share/ani-cli" "$PREFIX/bin/ani-cli" 
+git clone -b "master" "https://github.com/pystardust/ani-cli.git" && cd "./ani-cli"
+mv "./ani-cli" "$PREFIX/bin/ani-cli"
+mv -a "./UI" "./players" "PREFIX/share/"
+cd .. && rm -rf "./ani-cli"
 ```
 For doodstream to work you need to add any referrer in mpv by opening mpv [(playstore version)](https://play.google.com/store/apps/details?id=is.xyz.mpv), going into Settings -> Advanced -> Edit mpv.conf and adding (for example):
 
@@ -152,20 +158,20 @@ echo 'am start --user 0 -a android.intent.action.VIEW -d "$1" -n is.xyz.mpv/.MPV
 
 * Linux:  
 ```sh
-sudo rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli"
+sudo rm -rf "/usr/local/share/UI" "/usr/local/share/players" "/usr/local/bin/ani-cli"
 ```
 * Mac:  
 ```sh
-rm -rf "$(brew --prefix)/share/ani-cli" "$(brew --prefix)/bin/ani-cli"
+rm -rf "$(brew --prefix)/share/UI" "$(brew --prefix)/share/players" "$(brew --prefix)/bin/ani-cli"
 ```
 * Windows:
 In **Git Bash** run:
 ```sh
-rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli"
+rm -rf "/usr/local/share/UI" "/usr/local/share/players" "/usr/local/bin/ani-cli"
 ```
 * Android:  
 ```sh
-rm -rf "/data/data/com.termux/files/usr/share/ani-cli" "/data/data/com.termux/files/usr/bin/ani-cli"
+rm -rf "/data/data/com.termux/files/usr/share/UI" "/data/data/com.termux/files/usr/share/players"  "/data/data/com.termux/files/usr/bin/ani-cli"
 ```
 
 ## Dependencies

--- a/ani-cli
+++ b/ani-cli
@@ -463,7 +463,7 @@ scrape=Query
 debug=0
 choice=
 auto_play=0
-project_root="$(dirname "$0" | sed 's/....$//')/share/ani-cli"
+project_root="${ANI_ROOT:-$(dirname "$0" | sed -E "s|\/[^\/]+$||")/share}"
 case "$(uname)" in
 	Darwin*) . "$project_root/players/player_iina" || die "No iina player script found";; #MacOS specific
 	*) . "$project_root/players/player_mpv" || die "No mpv player script found";;

--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.0.2"
+VERSION="3.0.3"
 
 
 #######################


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Working regex for ../share
Environment variable to change where files are sourced from: `$ANI_ROOT` (If left empty script will source from ../share)

## Checklist

- [ ] any anime playing
- [x] bumped version
- [ ] next, prev and replay work
- [ ] quality works
- [ ] downloads work
- [ ] quality works with downloads
- [ ] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works
Can't because script is broken

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
