### PR TITLE
Better instructions for binary packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ For more info on providers, please refer to [this](https://github.com/pystardust
 ### Native packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg)](https://repology.org/project/ani-cli/versions)
+[![Copr build status](https://copr.fedorainfracloud.org/coprs/derisis13/ani-cli/package/ani-cli/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/derisis13/ani-cli/package/ani-cli/)
 
 *Native packages have a more robust update cycle, but sometimes they are slow to upgrade. If the one for your platform is up-to-date we suggest going with it.*
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ For more info on providers, please refer to [this](https://github.com/pystardust
 ### Native packages
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg)](https://repology.org/project/ani-cli/versions)
-[![Copr build status](https://copr.fedorainfracloud.org/coprs/derisis13/ani-cli/package/ani-cli/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/derisis13/ani-cli/package/ani-cli/)
+
+Fedora Copr
+[![Copr build status](https://copr.fedorainfracloud.org/coprs/derisis13/ani-cli/package/ani-cli/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/derisis13/ani-cli/)
 
 *Native packages have a more robust update cycle, but sometimes they are slow to upgrade. If the one for your platform is up-to-date we suggest going with it.*
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

When upgrading to v3 we have discarded all binary package installations.

Our package maintainers work hard to produce up-to-date binaries for all the different platforms. Most people would prefer installing from a package native to their system than to go trough the process of installing from source. Also some of our packages aren't tracked by repology.org (brew and copr come to my mind, but there could be more), and even if they are, not all package hosting sites come with instructions.

Other projects usually have instructions for binaries, so I don't see why we shouldn't.

## Checklist

- [x] any anime playing
- [ ] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [x] syncplay -s works
- [x] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
