### PR TITLE
Add custom UI support and dmenu UI

### DIFF
--- a/bin/ani-cli
+++ b/bin/ani-cli
@@ -29,6 +29,7 @@ help_text () {
 	  -c continue watching anime from history
 	  -h show helptext
 	  -D delete history
+	  -u load UI
 	  -U fetch update from github
 	  -V print version number and exit
 	  -f select provider to scrape first [1-7]
@@ -482,7 +483,7 @@ logdir="${XDG_CACHE_HOME:-$HOME/.cache}"
 # source the UI
 . "$lib_dir/UI" || die "No UI file"
 
-while getopts 'svq:dp:chDUVa:xf:' OPT; do
+while getopts 'svq:dp:chDUVa:xf:u:' OPT; do
 	case $OPT in
 		d) . "$lib_dir/player_download" || die "No download player script found" ;;
 		a) ep_choice_to_start=$OPTARG ;;
@@ -504,6 +505,7 @@ while getopts 'svq:dp:chDUVa:xf:' OPT; do
 			update "$bin_dir/ani-cli" "$lib_dir/UI" "$lib_dir"/player_*
 			exit 0
 			;;
+		u) . "$lib_dir/UI_$OPTARG" || die "No UI_$OPTARG script found" ;;
 		V)
 			version_text
 			ui_version_text

--- a/bin/ani-cli
+++ b/bin/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.2.1"
+VERSION="3.2.2"
 
 
 #######################

--- a/lib/ani-cli/UI_dmenu
+++ b/lib/ani-cli/UI_dmenu
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+UI_NAME="dmenu <- $UI_NAME"
+UI_VERSION="1.0.0"
+
+dep_ch "dmenu" || true
+
+# prompts the user with message in $1-2 ($1 in blue, $2 in magenta) and saves the input to the variables in $REPLY and $REPLY2
+prompt () {
+	choice=$(printf '' | dmenu -p "$*" | sed -E 's/ +/\n/')
+	[ -z "$choice" ] && exit 0
+	REPLY=$(printf '%s' "$choice" | sed -n 1p)
+	REPLY2=$(printf '%s' "$choice" | sed -n 2p)
+
+	[ -n "$*" ] && printf "\33[2K\r\033[1;35m%s\n" "$*"
+	printf "\033[1;35m> \033[0m%s\n" "$REPLY $REPLY2"
+}
+
+selection_menu() {
+	if [ -n "$PID" ]; then
+		wait "$PID"
+		PID=
+	fi
+	choice=$(printf '%s' "$*" | sed 's/[^ ]* //' | dmenu -l 10)
+	[ -z "$choice" ] && exit 0
+	REPLY=$(printf '%s' "$*" | grep -F "$choice" | sed 's/ .*//')
+	REPLY2=
+
+	printf "\033[1;35m> \033[0m%s\n" "$choice"
+}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

With the UI section being in a separate file, it is easy to apply additional UI's over it.
This adds an option for that along with a custom UI to make use of it

This extra UI is for `dmenu`
With this: 
- `dmenu` handles the selection menu.
- it also takes the prompt input which is then split into `REPLY` and `REPLY2` same as what `read` does
- selection menu is shown only after the player closes
- input is still printed to console to not change the look of it

The new UI is used with `ani-cli -u dmenu`

## Checklist

- [x] any anime playing
- [x] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [x] syncplay -s works
- [x] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
