### PR TITLE
Menu options for history

### DIFF
--- a/bin/ani-cli
+++ b/bin/ani-cli
@@ -547,7 +547,6 @@ open_selection
 ########
 
 while : ; do
-if [ -z "$select_first" ]; then
 	auto_play=0
 	unset menu
 	unset options
@@ -584,10 +583,6 @@ if [ -z "$select_first" ]; then
 	generate_ep_list
 	append_history
 	open_selection
-else
-	wait $!
-	exit
-fi
 done
 
 # ani-cli

--- a/bin/ani-cli
+++ b/bin/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.2.1"
+VERSION="3.2.2"
 
 
 #######################


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Menu options were not appearing due to an if statement that checked if "select_first" was empty. Hopefully not needed.

## Checklist

- [x] any anime playing
- [x] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
