### PR TITLE
feat: menu autoplay option

### DIFF
--- a/bin/ani-cli
+++ b/bin/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.2.1"
+VERSION="3.2.3"
 
 
 #######################
@@ -352,6 +352,34 @@ anime_selection () {
 	al_episode_list
 }
 
+# Autoplays the anime till the end.
+infinite_autoplay() {
+	[ "$last_ep_number" -eq 0 ] && die "Episodes not released yet!"
+	if [ "$last_ep_number" -gt "$first_ep_number" ]; then
+		[ "$ep_choice_to_start" = "-1" ] && ep_choice_to_start="$last_ep_number"
+		if [ -z "$ep_choice_to_start" ]; then
+			# if branches, because order matters this time
+			while : ; do
+
+        # if final episode, don't increment
+        if [ "$last_ep_number" -gt "$episode" ]; then 
+          ep_choice_start=$((episode + 1))
+        else 
+          ep_choice_start="$episode"
+        fi
+        ep_choice_end="$last_ep_number"
+				break
+			done
+		else
+			ep_choice_start="$ep_choice_to_start" && unset ep_choice_to_start
+		fi
+	else
+		# In case the anime contains only a single episode
+		ep_choice_start=1
+	fi
+  auto_play=1
+}
+
 # gets episode number from user, makes sure it's in range, skips input if only one episode exists
 episode_selection () {
 	[ "$last_ep_number" -eq 0 ] && die "Episodes not released yet!"
@@ -367,8 +395,7 @@ episode_selection () {
 				[ "$ep_choice_start" = "-1" ] && ep_choice_start="$last_ep_number"
 				[ "$ep_choice_end" = "-1" ] && ep_choice_end="$last_ep_number"
 				if ! [ "$ep_choice_start" -eq "$ep_choice_start" ] 2>/dev/null || { [ -n "$ep_choice_end" ] && ! [ "$ep_choice_end" -eq "$ep_choice_end" ] 2>/dev/null; }; then
-					err "Invalid number(s)"
-					continue
+					err "Invalid number(s)" continue
 				fi
 				if [ "$ep_choice_start" -gt "$last_ep_number" ] 2>/dev/null || [ "$ep_choice_end" -gt "$last_ep_number" ] 2>/dev/null || [ "$ep_choice_start" -lt "$first_ep_number" ] 2>/dev/null; then
 					err "Episode out of range"
@@ -547,7 +574,6 @@ open_selection
 ########
 
 while : ; do
-if [ -z "$select_first" ]; then
 	auto_play=0
 	unset menu
 	unset options
@@ -555,6 +581,7 @@ if [ -z "$select_first" ]; then
 	[ "$episode" -ne "$first_ep_number" ] && menu=$(append "$menu" 'previous' 'p')
 	menu=$(append "$menu" 'replay' 'r')
 	[ "$first_ep_number" -ne "$last_ep_number" ] && menu=$(append "$menu" 'select' 's')
+  [ "$episode" -ne "$last_ep_number" ] && menu=$(append "$menu" 'autoplay' 'a')
 	menu=$(append "$menu" 'exit' 'q')
 	selection_menu "$menu"
 		choice="$REPLY"
@@ -573,6 +600,8 @@ if [ -z "$select_first" ]; then
 			;;
 		s)
 			episode_selection ;;
+    a)
+      infinite_autoplay ;;
 		q)
 			break ;;
 		*)
@@ -584,10 +613,6 @@ if [ -z "$select_first" ]; then
 	generate_ep_list
 	append_history
 	open_selection
-else
-	wait $!
-	exit
-fi
 done
 
 # ani-cli

--- a/lib/ani-cli/player_vlc
+++ b/lib/ani-cli/player_vlc
@@ -13,6 +13,6 @@ play_episode () {
 	if uname -a | grep -qE '[Aa]ndroid';then
 		am start --user 0 -a android.intent.action.VIEW -d "$video_url" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "$trackma_title" > /dev/null 2>&1 &
 	else
-		vlc "$video_url"  --http-referrer="$refr" --meta-title "$trackma_title" --play-and-exit &
+		vlc "$video_url"  --http-referrer="$refr" --meta-title "$trackma_title" --play-and-exit &> /dev/null & ## Redirect all output to /dev/null to make selection menu remain visible
 	fi
 }


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

This allows users to select an autoplay option from the menu. It will keep autoplaying until the anime has reached the final episode. Just like next, it is hidden on the final episode.

## Checklist

- [x] any anime playing
- [x] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
