### PR TITLE
Update player_download

### DIFF
--- a/lib/ani-cli/player_download
+++ b/lib/ani-cli/player_download
@@ -45,8 +45,9 @@ download () {
 			ffmpeg -loglevel error -stats -i "video.ts" -c copy "$download_dir/$3.mp4"
 			rm -f video.ts
 			;;
-		*)
-			aria2c --check-certificate=false --summary-interval=0 -x 16 -s 16 --referer="$1" "$2" --dir="$download_dir" -o "$3.mp4" --download-result=hide ;;
+		*)			
+			axel -k -n 20 --header=Referer:"$1" "$2" -o "$download_dir/$3.mp4" ;;
+			#aria2c --check-certificate=false --summary-interval=0 -x 16 -s 16 --referer="$1" "$2" --dir="$download_dir" -o "$3.mp4" --download-result=hide ;;
 	esac
 }
 


### PR DESCRIPTION
Use `axel` as the downloader instead of `aria2` as it supports multiple threads, and is way faster.

# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
- [ ] next, prev and replay work
- [ ] quality works
- [ ] downloads work
- [ ] quality works with downloads
- [ ] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
