### PR TITLE
Switched to axel as the anime downloader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cd .. && rm -rf ./ani-cli
 *To install (with Homebrew) the dependencies required on Mac OS, you can run:* 
 
 ```sh
-brew install curl grep aria2 openssl@1.1 ffmpeg git && \
+brew install curl grep axel openssl@1.1 ffmpeg git && \
 brew install --cask iina
 ``` 
 *Why iina and not mpv? Drop-in replacement for mpv for MacOS. Integrates well with OSX UI. Excellent support for M1. Open Source.*  
@@ -181,7 +181,7 @@ rm -rf "$PREFIX/bin/ani-cli" "$PREFIX/lib/ani-cli"
 - openssl
 - mpv - Video Player
 - iina - mpv replacement for MacOS
-- aria2 - Download manager
+- axel - Download manager
 - ffmpeg - m3u8 Downloader
 
 ## Homies 

--- a/bin/ani-cli
+++ b/bin/ani-cli
@@ -77,8 +77,8 @@ dep_ch () {
 	for dep; do
 		if ! command -v "$dep" >/dev/null ; then
 			err "Program \"$dep\" not found. Please install it."
-			#aria2c is in the package aria2
-			[ "$dep" = "aria2c" ] && err "To install aria2c, Type <your_package_manager> aria2"
+			#axel is in the package axel
+			[ "$dep" = "axel" ] && err "To install aria2c, Type <your_package_manager> axel"
 			die
 		fi
 	done

--- a/lib/ani-cli/player_download
+++ b/lib/ani-cli/player_download
@@ -46,7 +46,7 @@ download () {
 			rm -f video.ts
 			;;
 		*)	
-			axel -a -k -n 20 --header=Referer:"$1" "$2" -o "$download_dir/$3.mp4" ;;
+			axel -a -k -n 30 --header=Referer:"$1" "$2" -o "$download_dir/$3.mp4" ;;
 			#aria2c --check-certificate=false --summary-interval=0 -x 16 -s 16 --referer="$1" "$2" --dir="$download_dir" -o "$3.mp4" --download-result=hide ;;
 	esac
 }

--- a/lib/ani-cli/player_download
+++ b/lib/ani-cli/player_download
@@ -46,7 +46,7 @@ download () {
 			rm -f video.ts
 			;;
 		*)	
-			axel -k -n 20 --header=Referer:"$1" "$2" -o "$download_dir/$3.mp4" ;;
+			axel -a -k -n 20 --header=Referer:"$1" "$2" -o "$download_dir/$3.mp4" ;;
 			#aria2c --check-certificate=false --summary-interval=0 -x 16 -s 16 --referer="$1" "$2" --dir="$download_dir" -o "$3.mp4" --download-result=hide ;;
 	esac
 }

--- a/lib/ani-cli/player_download
+++ b/lib/ani-cli/player_download
@@ -45,8 +45,9 @@ download () {
 			ffmpeg -loglevel error -stats -i "video.ts" -c copy "$download_dir/$3.mp4"
 			rm -f video.ts
 			;;
-		*)
-			aria2c --check-certificate=false --summary-interval=0 -x 16 -s 16 --referer="$1" "$2" --dir="$download_dir" -o "$3.mp4" --download-result=hide ;;
+		*)	
+			axel -k -n 20 --header=Referer:"$1" "$2" -o "$download_dir/$3.mp4" ;;
+			#aria2c --check-certificate=false --summary-interval=0 -x 16 -s 16 --referer="$1" "$2" --dir="$download_dir" -o "$3.mp4" --download-result=hide ;;
 	esac
 }
 


### PR DESCRIPTION
# Even faster downloading with AXEL

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Supports multi-threading and is lighter and loads faster than, aria2.