### PR TITLE
readme: better adhere to unix/arch file hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ For more info on providers, please refer to [this](https://github.com/pystardust
 Install dependencies [(See below)](#Dependencies)
 
 ```sh
-sudo rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli" "/usr/local/bin/UI" /usr/local/bin/player_* #If some of these aren't found, it's not a problem
+sudo rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli" "/usr/local/bin/UI" /usr/local/bin/player_* "/usr/share/ani-cli" "/usr/bin/ani-cli" "/usr/bin/UI" /usr/bin/player_*  #If some of these aren't found, it's not a problem
 git clone "https://github.com/pystardust/ani-cli.git" && cd ./ani-cli
-sudo cp ./ani-cli /usr/local/bin
+sudo cp ./ani-cli /usr/bin
 cd .. && rm -rf "./ani-cli"
 ```
 *Also note that mpv installed through flatpak is not compatible*
@@ -151,7 +151,7 @@ referrer="https://animixplay.to/"
 
 * Linux:  
 ```sh
-sudo rm "/usr/local/bin/ani-cli"
+sudo rm "/usr/bin/ani-cli" "/usr/local/bin/ani-cli"
 ```
 * Mac:  
 ```sh


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ x ] Documentation update

## Description

The arch file hierarchy does not mention /usr/local at all(most likely because arch doesnt deal with local installs) and all of the distros I personally dealt with that do local installs do it in the home folder instead of /usr/local. If the user of ani-cli needs to do local installs they will most likely notice that we are doing installs in the /usr directory instead of wherever they place their binaries and will adjust the instructions to their needs.

The others forms were not applicable for a documentation update.
