### PR TITLE
fix: replace colors with color variable.

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -4,6 +4,17 @@
 # Version number
 VERSION="3.3.3"
 
+# Foreground colors
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[1;34m'
+MAGENTA='\033[1;35m'
+CYAN='\033[1;36m'
+NC='\033[0m' # No Color
+
+#reset line
+RESETLINE='\33[2K\r'
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -53,7 +64,7 @@ retry () {
 
 # display an error message to stderr (in red)
 err () {
-	printf "\33[2K\r\033[1;31m%s\033[0m\n" "$*" >&2
+	printf "${RESETLINE} ${RED}%s${NC}\n" "$*" >&2
 }
 
 #display error message and exit
@@ -64,21 +75,21 @@ die () {
 
 # display an informational message (first argument in green, second in magenta)
 inf () {
-	printf "\33[2K\r\033[1;35m%s \033[1;35m%s\033[0m\n" "$1" "$2"
+	printf "${RESETLINE} ${GREEN}%s ${MAGENTA}%s${NC}\n" "$1" "$2"
 }
 
 progress() {
-	printf "\33[2K\r\033[1;34m%s\033[0m" "$1"
+	printf "${RESETLINE} ${BLUE}%s${NC}" "$1"
 }
 
 debug () {
-	printf "\n\033[1;32mReferrer :\033[0m %s\n\033[1;32mlinks >>\n\033[0m%s\n" "$1" "$2"
+	printf "\n${GREEN}Referrer :${NC} %s\n${GREEN}links >>\n${NC}%s\n" "$1" "$2"
 }
 
 # prompts the user with message in $1-2 ($1 in blue, $2 in magenta) and saves the input to the variables in $REPLY and $REPLY2
 prompt () {
-	[ -n "$*" ] && printf "\33[2K\r\033[1;35m%s\n" "$*"
-	printf "\033[1;35m> \033[0m"
+	[ -n "$*" ] && printf "${RESETLINE} ${MAGENTA}%s\n" "$*"
+	printf "${MAGENTA}%s${NC}" ">"
 	read -r REPLY REPLY2
 }
 
@@ -86,13 +97,13 @@ selection_menu() {
 	menu_line_parity=0
 	while read -r option line; do
 		if [ "$option" = "q" ]; then
-			printf "\033[1;31m(\033[1;31m%s\033[1;31m) \033[1;31m%s\033[0m\n" "$option" "$line"
+			printf "${RED}(${RED}%s${RED}) ${RED}%s${NC}\n" "$option" "$line"
 		else
 			if [ "$menu_line_parity" -eq 0 ]; then
-				printf "\033[1;33m(\033[1;33m%s\033[1;33m) \033[1;33m%s\033[0m\n" "$option" "$line"
+				printf "${YELLOW}(${YELLOW}%s${YELLOW}) ${YELLOW}%s${NC}\n" "$option" "$line"
 				menu_line_parity=1
 			else
-				printf "\033[1;36m(\033[1;36m%s\033[1;36m) \033[1;36m%s\033[0m\n" "$option" "$line"
+				printf "${CYAN}(${CYAN}%s${CYAN}) ${CYAN}%s${NC}\n" "$option" "$line"
 				menu_line_parity=0
 			fi
 		fi
@@ -490,7 +501,7 @@ play_episode () {
 ############
 
 # clears the colors and deletes temporary logfile when exited using SIGINT
-trap 'printf "\033[0m";rm -f "$logfile".new;exit 1' INT HUP
+trap 'printf "${NC}";rm -f "$logfile".new;exit 1' INT HUP
 
 # default options
 agent="Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/100.0"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description
add variable for repetitive value

*ramble here*

## Checklist

- [x] any anime playing
- [ ] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
