### PR TITLE
change shebag and remove `shellcheck disable=SC2046`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       env:
-        SHELLCHECK_OPTS: -s sh -o all -e 2250 -e 2016 -x
+        SHELLCHECK_OPTS: -s sh -o all -e 2250

--- a/ani-cli
+++ b/ani-cli
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # License preamble at the end of the file
 # Version number
@@ -552,7 +552,6 @@ while getopts 'svq:dp:chDUVa:xr:fn' OPT; do
 done
 shift $((OPTIND - 1))
 progress "Checking dependencies.."
-# shellcheck disable=SC2046
 dep_ch "curl" "sed" "grep" "openssl" || true
 
 if [ "$player_fn" = "download" ];then

--- a/ani-cli
+++ b/ani-cli
@@ -152,6 +152,7 @@ download () {
 search_anime () {
 	search=$(printf '%s' "$1" | tr ' ' '-' )
 	curl -s "https://gogoanime.lu//search.html?keyword=$search" -L |
+		# shellcheck disable=SC2016
 		sed -nE 's_^[[:space:]]*<a href="/category/([^"]*)" title.*">$_\1_p'
 }
 

--- a/ani-cli
+++ b/ani-cli
@@ -152,7 +152,7 @@ download () {
 search_anime () {
 	search=$(printf '%s' "$1" | tr ' ' '-' )
 	curl -s "https://gogoanime.lu//search.html?keyword=$search" -L |
-		# shellcheck disable=SC2016
+		# shellcheck disable=all
 		sed -nE 's_^[[:space:]]*<a href="/category/([^"]*)" title.*">$_\1_p'
 }
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

the reason the shebang is changed from `/bin/sh` to `/usr/bin/env sh` is so that `sh` does not need to be in `/bin`, the reason of removing `shellcheck disable=SC2046` is that shellcheck does not complain about that

## Checklist

- [ ] any anime playing
- [ ] bumped version
- [ ] next, prev and replay work
- [ ] quality works
- [ ] downloads work
- [ ] quality works with downloads
- [ ] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
