### PR TITLE
fix: redirect stdout for syncplay

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -474,7 +474,7 @@ play_episode () {
 			fi
 			;;
 		"syncplay"|"/Applications/Syncplay.app/Contents/MacOS/syncplay"|"/c/Program Files (x86)/Syncplay/Syncplay.exe")
-			nohup "$player_fn" "$video_url" -- --referrer="$refr" --force-media-title="$trackma_title" & ;;
+			nohup "$player_fn" "$video_url" -- --referrer="$refr" --force-media-title="$trackma_title" > /dev/null 2>&1 & ;;
 		*)
 			if uname -a | grep -qE '[Aa]ndroid';then
 				am start --user 0 -a android.intent.action.VIEW -d "$video_url" -n is.xyz.mpv/.MPVActivity > /dev/null 2>&1 &

--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.3.3"
+VERSION="3.3.4"
 
 
 #######################


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ x] any anime playing
- [ ] bumped version
- [ x] next, prev and replay work
- [ x] quality works
- [ x] downloads work
- [ x] quality works with downloads
- [ x] select episode -a and rapid resume work
- [ x] syncplay -s works
- [ x] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
