### PR TITLE
fix: search gogoanime with updated url

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.4.1"
+VERSION="3.4.2"
 
 
 #######################

--- a/ani-cli
+++ b/ani-cli
@@ -151,7 +151,7 @@ download () {
 # gets anime names along with its id for search term
 search_anime () {
 	search=$(printf '%s' "$1" | tr ' ' '-' )
-	curl -s "https://gogoanime.lu//search.html?keyword=$search" -L |
+	curl -s "https://gogoanime.dk//search.html?keyword=$search" -L |
 		sed -nE 's_^[[:space:]]*<a href="/category/([^"]*)" title.*">$_\1_p'
 }
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description
ani-cli currently displays the error "No search results found" when searching for an anime. It turns out the reason for this issue is that the domain name used, "https://gogoanime.lu" is no longer valid. Instead it tries to redirect you to a new domain, "https://gogoanime.dk". This new domain is now used in this bug fix.

## Checklist

- [X] any anime playing
- [ ] bumped version
