### PR TITLE
Provider priorities

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.4.2"
+VERSION="3.4.3"
 
 
 #######################

--- a/ani-cli
+++ b/ani-cli
@@ -190,7 +190,7 @@ search_history () {
 
 generate_link() {
 	case $1 in
-		1)
+		2)
 			provider_name='Xstreamcdn'
 			progress "Fetching $provider_name links.."
 			fb_id=$(printf "%s" "$resp" | sed -n "s_.*fembed.*/v/__p")
@@ -199,7 +199,7 @@ generate_link() {
 			result_links="$(curl -A "$agent" -s -X POST "https://fembed-hd.com/api/source/$fb_id" -H "x-requested-with:XMLHttpRequest" |
 				sed -e 's/\\//g' -e 's/.*data"://' | tr "}" "\n" | sed -nE 's/.*file":"(.*)","label":"(.*)","type.*/\2>\1/p')"
 			;;
-		2)
+		1)
 			provider_name='Animixplay'
 			progress "Fetching $provider_name Direct link.."
 			refr="$base_url"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

The current order for scraping is: 1: Xstreamcdn, 2: Animixplay, 3: Gogoanime. I'm sure there was a reason why we decided on this order, but recently Xstreamcdn has some hickups: it gets very slow sometimes. It can be an intentional throttle or a 'natural' server overload. A quick and dirty solution is to rank it one lower, maybe even two.

## Checklist

- [x] any anime playing
- [x] bumped version
- [ ] next, prev and replay work
- [ ] quality works
- [ ] downloads work
- [ ] quality works with downloads
- [ ] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
