### PR TITLE
fix: grep error when selection_id starts with '-'

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -431,7 +431,7 @@ open_episode () {
 	fi
 	[ "$debug" -eq 1 ] && exit 0
 	# write anime and episode number and save to temporary history
-	grep -q "$selection_id" "$logfile" || printf "%s\t%s\n" "$selection_id" $((episode+1)) >> "$logfile"
+	grep -q -- "$selection_id" "$logfile" || printf "%s\t%s\n" "$selection_id" $((episode+1)) >> "$logfile"
 	sed -E "s/^${selection_id}\t[0-9]*/${selection_id}\t$((episode+1))/" "$logfile" > "${logfile}.new"
 	[ ! "$PID" = "0" ] && kill "$PID" >/dev/null 2>&1
 	[ -z "$video_url" ] && die "Video URL not found"

--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.4.3"
+VERSION="3.4.4"
 
 
 #######################


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Fixes issue #901.

This occurs because we are passing `selection_id` as is to `grep`.

Normally this wouldn't be an issue, except where the `selection_id` starts with `-` (_eg_, -code-geass-lelouch-of-the-rebellion-r2`).
Then `grep` would treat it as flags, causing the error.

## Checklist

- [x] any anime playing (tested on provided test case, `Code Geass Lelouch of The Rebelion R2`)
- [x] bumped version
- [x] next, prev and replay work
- [x] quality works
- [x] downloads work
- [x] quality works with downloads
- [x] select episode -a and rapid resume work
- [x] syncplay -s works
- [x] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
