### PR TITLE
fix: drop gnu style long options on base64

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,7 @@
 
 # License preamble at the end of the file
 # Version number
-VERSION="3.4.5"
+VERSION="3.4.6"
 
 
 #######################
@@ -206,7 +206,7 @@ generate_link() {
 			[ -z "$id" ] && return 0
 			enc_id=$(printf "%s" "$id" | base64)
 			ani_id=$(printf "%sLTXs3GrU8we9O%s" "$id" "$enc_id" | base64)
-			result_links="$(curl -s "$base_url/api/cW9${ani_id}" -A "$agent" -I | sed -nE 's_[L|l]ocation: https?://[^#]*#([^#]*).*_\1_p' | base64 --decode)"
+			result_links="$(curl -s "$base_url/api/cW9${ani_id}" -A "$agent" -I | sed -nE 's_[L|l]ocation: https?://[^#]*#([^#]*).*_\1_p' | base64 -d)"
 			;;
 		*)
 			provider_name='Gogoanime'
@@ -216,10 +216,10 @@ generate_link() {
 			secret_key=$(printf "%s" "$resp" | sed -n '2p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
 			iv=$(printf "%s" "$resp" | sed -n '3p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
 			second_key=$(printf "%s" "$resp" | sed -n '4p' | tr -d "\n" | od -A n -t x1 | tr -d " |\n")
-			token=$(printf "%s" "$resp" | head -1 | base64 --decode | openssl enc -d -aes256 -K "$secret_key" -iv "$iv" | sed -nE 's/.*&(token.*)/\1/p')
+			token=$(printf "%s" "$resp" | head -1 | base64 -d | openssl enc -d -aes256 -K "$secret_key" -iv "$iv" | sed -nE 's/.*&(token.*)/\1/p')
 			ajax=$(printf '%s' "$id" | openssl enc -e -aes256 -K "$secret_key" -iv "$iv" -a)
 			data=$(curl -A "$agent" -sL -H "X-Requested-With:XMLHttpRequest" "${gogohd_url}encrypt-ajax.php?id=${ajax}&alias=${id}&${token}" | sed -e 's/{"data":"//' -e 's/"}/\n/' -e 's/\\//g')
-			result_links="$(printf '%s' "$data" | base64 --decode 2>/dev/null | openssl enc -d -aes256 -K "$second_key" -iv "$iv" 2>/dev/null |
+			result_links="$(printf '%s' "$data" | base64 -d 2>/dev/null | openssl enc -d -aes256 -K "$second_key" -iv "$iv" 2>/dev/null |
 				tr -d \\\\ | sed -nE "s_.*file\":\"([^\"]*)\".*source.*_\1_p")"
 			;;
 	esac


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

busybox base64 doesn't support gnu style long options

## Checklist

- [x] any anime playing
- [x] bumped version
- [ ] next, prev and replay work
- [ ] quality works
- [ ] downloads work
- [ ] quality works with downloads
- [ ] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
