### PR TITLE
fix: missing check for fzf

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -253,7 +253,7 @@ while [ $# -gt 0 ]; do
 	esac
 done
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
-dep_ch "wget" "sed" "grep" || true
+dep_ch "wget" "sed" "grep" "fzf" || true
 case "$player_function" in
 debug) ;;
 download) dep_ch "ffmpeg" "aria2c" ;;


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
- [ ] next, prev and replay work
- [ ] quality works
- [ ] downloads work
- [ ] quality works with downloads
- [ ] select episode -a and rapid resume work
- [ ] syncplay -s works
- [ ] autoplay, aka range selection, works

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Not uploaded: one piece dub episode 590
- Unreleased: soredemo ayumu wa yosetekuru
- Short id (for decryption): Log Horizon episode 1-2
