### PR TITLE
fix: .5 episodes

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.0.0"
+version_number="4.0.1"
 
 # UI
 
@@ -22,8 +22,8 @@ nth() {
 	prompt="$1"
 	multi_flag=""
 	[ $# -ne 1 ] && shift && multi_flag="$1"
-	line=$(printf "%s" "$stdin" | cut -f1,3 --output-delimiter " " | launcher "$multi_flag" "$prompt" | cut -d " " -f 2-)
-	[ -n "$line" ] && printf "%s" "$stdin" | grep -w "${line}$" | cut -f2,3 || exit 1
+	line=$(printf "%s" "$stdin" | cut -f1,3 --output-delimiter " " | launcher "$multi_flag" "$prompt" | cut -d " " -f 1)
+	[ -n "$line" ] && printf "%s" "$stdin" | grep -w "^${line}" | cut -f2,3 || exit 1
 }
 
 die() {
@@ -227,11 +227,11 @@ play_episode() {
 }
 
 play() {
-	start=$(printf "%s" "$ep_no" | sed "s/[^0-9]*\([0-9]*\).*/\1/")
-	end=$(printf "%s" "$ep_no" | sed "s/[^0-9]*[0-9]*[^0-9]*\([0-9]*\).*/\1/")
-	[ -z "$start" ] || [ -z "$end" ] && unset start end
+	start=$(printf "%s" "$ep_no" | grep -Eo "^[0-9]+(.5)?")
+	end=$(printf "%s" "$ep_no" | grep -Eo "[0-9]+(.5)?$")
+	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
 	line_count=$(printf "%s\n" "$ep_no" | wc -l)
-	if [ "$line_count" != 1 ] || [ -n "$start" ] || [ -n "$end" ]; then
+	if [ "$line_count" != 1 ] || [ -n "$start" ] ; then
 		[ -z "$start" ] && start=$(printf "%s\n" "$ep_no" | tail -n1)
 		[ -z "$end" ] && end=$(printf "%s\n" "$ep_no" | head -n1)
 		range=$(printf "%s\n" "$ep_list" | sed '1!G;h;$!d' | sed -nE "/^${start}\$/,/^${end}\$/p")

--- a/ani-cli
+++ b/ani-cli
@@ -227,8 +227,8 @@ play_episode() {
 }
 
 play() {
-	start=$(printf "%s" "$ep_no" | grep -Eo "^[0-9]+(.5)?")
-	end=$(printf "%s" "$ep_no" | grep -Eo "[0-9]+(.5)?$")
+	start=$(printf "%s" "$ep_no" | grep -Eo "^[0-9]+(.[0-9])?")
+	end=$(printf "%s" "$ep_no" | grep -Eo "[0-9]+(.[0-9])?$")
 	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
 	line_count=$(printf "%s\n" "$ep_no" | wc -l)
 	if [ "$line_count" != 1 ] || [ -n "$start" ] ; then


### PR DESCRIPTION
refactor: grep by line number for accuracy
chore: v4.0.0 -> v4.0.1

# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
