### PR TITLE
spellcheck, it's history not histroy

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -329,7 +329,7 @@ case "$search" in
 history)
 	anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
 	wait
-	[ -z "$anime_list" ] && die "No unwatched series in histroy!"
+	[ -z "$anime_list" ] && die "No unwatched series in history!"
 	result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: " | cut -f1)
 	[ -z "$result" ] && exit 1
 	result=$(grep "$result" "$histfile")


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
