### PR TITLE
wget2 info for debian package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Otherwise you're likely to see an error like the following: ` "/usr/bin/ani-cli:
 
 #### Debian
 
-Because Debian, has on the stable releases, not the newest version of wget (v1.21.3) it is replaced with wget2 for the time being.
+Wget is replaced with wget2 to ensure compatibility with all Debian releases.
 
 ```sh
 wget -qO- https://Wiener234.github.io/ani-cli-ppa/KEY.gpg | sudo tee /etc/apt/trusted.gpg.d/ani-cli.asc
@@ -349,7 +349,7 @@ flatpak uninstall io.mpv.Mpv
 
 - grep
 - sed
-- wget
+- wget (v.1.21.3)
 - mpv - Video Player
 - iina - mpv replacement for MacOS
 - aria2c - Download manager

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Otherwise you're likely to see an error like the following: ` "/usr/bin/ani-cli:
 
 #### Debian
 
-Because Debian has on the stable releases not the newest version of wget (v1.21.3) it is replaced with wget2 for the time being.
+Because Debian, has on the stable releases, not the newest version of wget (v1.21.3) it is replaced with wget2 for the time being.
 
 ```sh
 wget -qO- https://Wiener234.github.io/ani-cli-ppa/KEY.gpg | sudo tee /etc/apt/trusted.gpg.d/ani-cli.asc

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Otherwise you're likely to see an error like the following: ` "/usr/bin/ani-cli:
 
 #### Debian
 
+Because Debian has on the stable releases not the newest version of wget (v1.21.3) it is replaced with wget2 for the time being.
+
 ```sh
 wget -qO- https://Wiener234.github.io/ani-cli-ppa/KEY.gpg | sudo tee /etc/apt/trusted.gpg.d/ani-cli.asc
 wget -qO- https://Wiener234.github.io/ani-cli-ppa/ani-cli-debian.list | sudo tee /etc/apt/sources.list.d/ani-cli-debian.list


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

In the Install section of the readme an info about the change of wget to wget2 for the debian package was added.
That change was made because it makes the install process easier for the user. They dont have to build wget from source.

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [x] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
