### PR TITLE
Http agent from linux to windows for privacy

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -252,7 +252,6 @@ play() {
 # MAIN
 
 # setup
-firefox_version=$(shuf -i '106-109' -n1)
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"

--- a/ani-cli
+++ b/ani-cli
@@ -253,7 +253,7 @@ play() {
 
 # setup
 firefox_version=$(shuf -i '106-109' -n1)
-agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:${firefox_version}.0) Gecko/20100101 Firefox/${firefox_version}.0"
+agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"

--- a/ani-cli
+++ b/ani-cli
@@ -253,7 +253,7 @@ play() {
 
 # setup
 firefox_version=$(shuf -i '106-109' -n1)
-agent="Mozilla/5.0 (X11; Linux x86_64; rv:${firefox_version}.0) Gecko/20100101 Firefox/${firefox_version}.0"
+agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:${firefox_version}.0) Gecko/20100101 Firefox/${firefox_version}.0"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"


### PR DESCRIPTION
Changed http agent from linux to windows in order to minimized browser fingerprinting

# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Enhanced privacy, since linux systems are easily browser fingerprintable. Certain that it will interfere with the rest of the code, I made a pull request to avoid changing it manual after each update.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
