### PR TITLE
Change quality #1006

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -211,7 +211,7 @@ download() {
 }
 
 play_episode() {
-	get_episode_url
+	[ -z "$episode" ] && get_episode_url
 	case "$player_function" in
 	debug) printf "All links:\n%s\nSelected link:\n%s\n" "$links" "$episode" ;;
 	mpv*) nohup "$player_function" --force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
@@ -376,16 +376,19 @@ tput cuu1 && tput el
 play
 [ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
 
-while cmd=$(printf "quit\nselect\nprevious\nreplay\nnext" | nth "Playing episode $ep_no of $title... "); do
+while cmd=$(printf "quit\nselect\nprevious\nreplay\nnext\nchange_quality" | nth "Playing episode $ep_no of $title... "); do
 	case "$cmd" in
 	previous) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
 	replay) ;;
 	next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{g;1!p;};h") 2>/dev/null ;;
 	select) ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag") ;;
+	change_quality) episode=$(printf "%s" "$links" | sed -n '/^\([0-9]*p\)/p' | launcher)
+	episode=$(printf "%s" "$episode" | cut -d'>' -f2);;
 	*) exit 0 ;;
 	esac
 	[ -z "$ep_no" ] && die "Out of range"
 	play
+	episode=
 done
 
 # ani-cli

--- a/ani-cli
+++ b/ani-cli
@@ -383,6 +383,7 @@ while cmd=$(printf "quit\nselect\nprevious\nreplay\nnext\nchange_quality" | nth 
 	next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{g;1!p;};h") 2>/dev/null ;;
 	select) ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag") ;;
 	change_quality) episode=$(printf "%s" "$links" | sed -n '/^\([0-9]*p\)/p' | launcher)
+	quality=$(printf "%s" "$episode" | grep -oE "^[0-9]+")
 	episode=$(printf "%s" "$episode" | cut -d'>' -f2);;
 	*) exit 0 ;;
 	esac

--- a/ani-cli
+++ b/ani-cli
@@ -242,6 +242,7 @@ play() {
 		for i in $range; do
 			tput clear
 			ep_no=$i
+			unset episode
 			printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no"
 			play_episode
 		done
@@ -389,7 +390,7 @@ while cmd=$(printf "quit\nselect\nprevious\nreplay\nnext\nchange_quality" | nth 
 	esac
 	[ -z "$ep_no" ] && die "Out of range"
 	play
-	episode=
+	unset episode
 done
 
 # ani-cli

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.0.5"
+version_number="4.0.6"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Documentation update

## Description

Hi bros, Change quality feature,everything working, cant confirm syncplay tho I dont have it

only 3 LOC :)))))

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [ ] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-r` range selection works
- [X] `--dub` both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
