### PR TITLE
change the order of providers

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -137,8 +137,8 @@ provider_init() {
 generate_link() {
 	case $1 in
 	1) provider_init 'gogoanime' '/Luf-mp4 :/p' ;; # gogoanime(m3u8)(multi)
-	2) provider_init 'sharepoint' '/S-mp4 :/p' ;;  # sharepoint(mp4)(single)
-	3) provider_init 'pstatic' '/Default B :/p' ;; # pstatic(default backup)(mp4)(multi)
+	2) provider_init 'pstatic' '/Default B :/p' ;; # pstatic(default backup)(mp4)(multi)
+	3) provider_init 'sharepoint' '/S-mp4 :/p' ;;  # sharepoint(mp4)(single)
 	4) provider_init 'usercloud' '/Uv-mp4 :/p' ;;  # usercloud(mp4)(single)
 	5) provider_init 'vrv' '/Ac :/p' ;; # vrv(crunchyroll)(m3u8)(multi)
 	*) provider_init 'wixmp' '/Default :/p' ;; # wixmp(default)(m3u8)(multi) -> (mp4)(multi)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.0.5"
+version_number="4.0.6"
 
 # UI
 
@@ -136,12 +136,12 @@ provider_init() {
 # generates links based on given provider
 generate_link() {
 	case $1 in
-	1) provider_init 'wixmp' '/Default :/p' ;; # wixmp(default)(m3u8)(multi) -> (mp4)(multi)
-	2) provider_init 'pstatic' '/Default B :/p' ;; # pstatic(default backup)(mp4)(multi)
-	3) provider_init 'vrv' '/Ac :/p' ;; # vrv(crunchyroll)(m3u8)(multi)
-	4) provider_init 'sharepoint' '/S-mp4 :/p' ;;  # sharepoint(mp4)(single)
-	5) provider_init 'usercloud' '/Uv-mp4 :/p' ;;  # usercloud(mp4)(single)
-	*) provider_init 'gogoanime' '/Luf-mp4 :/p' ;; # gogoanime(m3u8)(multi)
+	1) provider_init 'gogoanime' '/Luf-mp4 :/p' ;; # gogoanime(m3u8)(multi)
+	2) provider_init 'sharepoint' '/S-mp4 :/p' ;;  # sharepoint(mp4)(single)
+	3) provider_init 'pstatic' '/Default B :/p' ;; # pstatic(default backup)(mp4)(multi)
+	4) provider_init 'usercloud' '/Uv-mp4 :/p' ;;  # usercloud(mp4)(single)
+	5) provider_init 'vrv' '/Ac :/p' ;; # vrv(crunchyroll)(m3u8)(multi)
+	*) provider_init 'wixmp' '/Default :/p' ;; # wixmp(default)(m3u8)(multi) -> (mp4)(multi)
 	esac
 	[ -n "$provider_id" ] && get_links "$provider_id"
 }


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
