### PR TITLE
fix: previous,next,replay bug

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.0.8"
+version_number="4.0.9"
 
 # UI
 
@@ -226,6 +226,8 @@ play_episode() {
 	*) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
 	esac
 	update_history
+	replay="$episode"
+	unset episode
 	wait
 }
 
@@ -242,7 +244,6 @@ play() {
 		for i in $range; do
 			tput clear
 			ep_no=$i
-			unset episode
 			printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no"
 			play_episode
 		done
@@ -380,7 +381,7 @@ play
 while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
 	case "$cmd" in
 	next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
-	replay) ;;
+	replay) episode="$replay";;
 	previous) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{g;1!p;};h") 2>/dev/null ;;
 	select) ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag") ;;
 	change_quality) episode=$(printf "%s" "$links" | sed -n '/^\([0-9]*p\)/p' | launcher)
@@ -390,7 +391,6 @@ while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth 
 	esac
 	[ -z "$ep_no" ] && die "Out of range"
 	play
-	unset episode
 done
 
 # ani-cli


### PR DESCRIPTION

# Pull Request Template

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Whoops

## Checklist 

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-r` range selection works
- [X] `--dub` both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
