### PR TITLE
fix: mac wc -l skill issue

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -235,7 +235,7 @@ play() {
 	start=$(printf "%s" "$ep_no" | grep -Eo "^[0-9]+(\.[0-9])?")
 	end=$(printf "%s" "$ep_no" | grep -Eo "[0-9]+(\.[0-9])?$")
 	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
-	line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]" )
+	line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")
 	if [ "$line_count" != 1 ] || [ -n "$start" ] ; then
 		[ -z "$start" ] && start=$(printf "%s\n" "$ep_no" | head -n1)
 		[ -z "$end" ] && end=$(printf "%s\n" "$ep_no" | tail -n1)

--- a/ani-cli
+++ b/ani-cli
@@ -235,7 +235,7 @@ play() {
 	start=$(printf "%s" "$ep_no" | grep -Eo "^[0-9]+(\.[0-9])?")
 	end=$(printf "%s" "$ep_no" | grep -Eo "[0-9]+(\.[0-9])?$")
 	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
-	line_count=$(printf "%s\n" "$ep_no" | wc -l)
+	line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]" )
 	if [ "$line_count" != 1 ] || [ -n "$start" ] ; then
 		[ -z "$start" ] && start=$(printf "%s\n" "$ep_no" | head -n1)
 		[ -z "$end" ] && end=$(printf "%s\n" "$ep_no" | tail -n1)


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
