### PR TITLE
fix: missing linebreak in quality-miss printf

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.1.2"
+version_number="4.1.3"
 
 # UI
 
@@ -33,7 +33,7 @@ die() {
 
 help_info() {
 	printf "
-    Usage: 
+    Usage:
     %s [options] [query]
     %s [query] [options]
     %s [options] [query] [options]
@@ -152,7 +152,7 @@ select_quality() {
 	worst) result=$(printf "%s" "$links" | grep -E '^[0-9]{3,4}' | tail -n1) ;;
 	*) result=$(printf "%s" "$links" | grep -m 1 "$1") ;;
 	esac
-	[ -z "$result" ] && printf "Specified quality not found, defaulting to best" 1>&2 && result=$(printf "%s" "$links" | head -n1)
+	[ -z "$result" ] && printf "Specified quality not found, defaulting to best\n" 1>&2 && result=$(printf "%s" "$links" | head -n1)
 	printf "%s" "$result" | cut -d'>' -f2
 }
 


### PR DESCRIPTION
- [X] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

The "Specified quality not found, defaulting to best" message was missing a line-break causing the next message to appear on the same line.
I only added a /n to a string. The test I've done are marked below.
It appears my settings removed a trailing white-space as well. If that's a nuisance then sorry about that.

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [X] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date