### PR TITLE
Fix typo in install commands (win & termux) - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ scoop install ani-cli
 rm -rf "/usr/local/share/ani-cli" "/usr/local/bin/ani-cli" "/usr/local/bin/UI" /usr/local/bin/player_* #If some of these aren't found, it's not a problem
 git clone "https://github.com/pystardust/ani-cli.git"
 cp ani-cli/ani-cli /usr/bin
-rm -rf /ani-cli
+rm -rf ani-cli
 ```
 
 #### Dependencies
@@ -192,7 +192,7 @@ pkg up -y
 rm -rf "$PREFIX/share/ani-cli" "$PREFIX/bin/ani-cli" "$PREFIX/bin/UI" "$PREFIX"/local/bin/player_* #If some of these aren't found, it's not a problem
 git clone "https://github.com/pystardust/ani-cli.git"
 cp ani-cli/ani-cli "$PREFIX"/bin
-rm -rf /ani-cli
+rm -rf ani-cli
 ```
 
 For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note that these cannot be checked from termux so a warning is generated when checking dependencies.


### PR DESCRIPTION
First off, congratulations for creating and maintaining this project!!
It's great and I really enjoy it!!

This pull request is simply to remove of two out-of-place forward slashes 
( / ) in README.md, in the install instructions for Windows and Termux.

I know it's a small detail, but it was never fixed, and those forward slashes 
cause the command to not execute properly, resulting in an useless 
command that should delete a folder, but does nothing instead.

# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Documentation update

## Description

In README.md - Install From Source,
for both Windows and Termux, 
the last command 'rm -rf /ani-cli' doesn't work,
since there is no 'ani-cli' folder in the '/' directory. 
It doesn't throw error because of the -f flag, but it 
also fails to remove the intended folder. This commit 
fixes this by removing the slash. Previous commands 
use 'ani-cli' instead of './ani-cli', so removing the slash 
seems to make more sense than adding a dot before it.
