### PR TITLE
fix: allanime graphql

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@
 - [ ] `-q` quality works
 - [ ] `-v` vlc works
 - [ ] `-e` select episode works
+- [ ] `-S` select index works
 - [ ] `-r` range selection works
 - [ ] `--dub` both work
 - [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <h3 align="center">
-A cli to browse and watch anime (alone AND with friends). This tool scrapes the site <a href="https://allanime.co/">allanime.</a>
+A cli to browse and watch anime (alone AND with friends). This tool scrapes the site <a href="https://allanime.to/">allanime.</a>
 </h3>
 	
 <h1 align="center">

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.1.4"
+version_number="4.2.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -241,8 +241,9 @@ play_episode() {
 
 play() {
 	start=$(printf "%s" "$ep_no" | grep -Eo '^[0-9]+(\.[0-9])?')
-	end=$(printf "%s" "$ep_no" | grep -E '(-1|[0-9]+(\.[0-9])?)$')
+	end=$(printf "%s" "$ep_no" | grep -Eo '(-1|[0-9]+(\.[0-9])?)$')
 	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
+	[ "$end" = "-1" ] && end=$(printf "%s" "$ep_list" | tail -n1)
 	line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")
 	if [ "$line_count" != 1 ] || [ -n "$start" ]; then
 		[ -z "$start" ] && start=$(printf "%s\n" "$ep_no" | head -n1)

--- a/ani-cli
+++ b/ani-cli
@@ -47,8 +47,8 @@ help_info() {
         Delete history
       -s, --syncplay
         Use Syncplay to watch with friends
-      -S, --select-first
-        Select the first entry
+      -S, --select-nth
+        Select nth entry
       -q, --quality
         Specify the video quality
       -v, --vlc
@@ -311,7 +311,11 @@ while [ $# -gt 0 ]; do
 		quality="$2"
 		shift
 		;;
-	-S | --select-first) select_first=1 ;;
+	-S | --select-nth)
+		[ $# -lt 2 ] && die "missing argument!"
+		index="$2"
+		shift
+		;;
 	-c | --continue) search=history ;;
 	-d | --download) player_function=download ;;
 	-D | --delete)
@@ -372,8 +376,8 @@ history)
 	query=$(printf "%s" "$query" | sed "s| |+|g")
 	anime_list=$(search_anime "$query")
 	[ -z "$anime_list" ] && die "No results found!"
-	[ "$select_first" = 1 ] && result=$(printf "%s" "$anime_list" | head -n1)
-	[ -z "$select_first" ] && result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: ")
+	[ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
+	[ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: ")
 	[ -z "$result" ] && exit 1
 	title=$(printf "%s" "$result" | cut -f2)
 	allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | tr 'A-Z ' 'a-z-')"

--- a/ani-cli
+++ b/ani-cli
@@ -47,6 +47,8 @@ help_info() {
         Delete history
       -s, --syncplay
         Use Syncplay to watch with friends
+      -S, --select-first
+        Select the first entry
       -q, --quality
         Specify the video quality
       -v, --vlc

--- a/ani-cli
+++ b/ani-cli
@@ -240,8 +240,9 @@ play_episode() {
 }
 
 play() {
-	start=$(printf "%s" "$ep_no" | grep -Eo '^[0-9]+(\.[0-9])?')
+	start=$(printf "%s" "$ep_no" | grep -Eo '^(-1|[0-9]+(\.[0-9])?)')
 	end=$(printf "%s" "$ep_no" | grep -Eo '(-1|[0-9]+(\.[0-9])?)$')
+	[ "$start" = "-1" ] && ep_no=$(printf "%s" "$ep_list" | tail -n1) && unset start
 	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
 	[ "$end" = "-1" ] && end=$(printf "%s" "$ep_list" | tail -n1)
 	line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")

--- a/ani-cli
+++ b/ani-cli
@@ -159,7 +159,9 @@ select_quality() {
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
 	# get the embed urls of the selected episode
-	resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://api.${allanime_base}/allanimeapi?variables=%7B%22showId%22%3A%22$id%22%2C%22translationType%22%3A%22$mode%22%2C%22countryOrigin%22%3A%22ALL%22%2C%22episodeString%22%3A%22$ep_no%22%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%221f0a5d6c9ce6cd3127ee4efd304349345b0737fbf5ec33a60bbc3d18e3bb7c61%22%7D%7D" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":".*clock\?id=([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+	episode_embed_gql="query (\$showId: String!, \$translationType: VaildTranslationTypeEnumType!, \$episodeString: String!) {    episode(        showId: \$showId        translationType: \$translationType        episodeString: \$episodeString    ) {        episodeString sourceUrls    }}"
+
+	resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":".*clock\?id=([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
 	# generate links into sequential files
 	provider=1
 	i=0
@@ -177,12 +179,16 @@ get_episode_url() {
 
 # search the query and give results
 search_anime() {
-	curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://api.${allanime_base}/allanimeapi?variables=%7B%22search%22%3A%7B%22allowAdult%22%3Atrue%2C%22allowUnknown%22%3Atrue%2C%22query%22%3A%22$*%22%7D%2C%22limit%22%3A40%2C%22page%22%3A1%2C%22translationType%22%3A%22$mode%22%2C%22countryOrigin%22%3A%22ALL%22%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%229c7a8bc1e095a34f2972699e8105f7aaf9082c6e1ccd56eab99c2f1a971152c6%22%7D%7D" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.*)\",\"english.*\"$mode\":([1-9][^,]*).*|\1\t\2 (\3 episode)|p" | sed 's/\\//g;s/"//g'
+	search_gql="query(        \$search: SearchInput        \$limit: Int        \$page: Int        \$translationType: VaildTranslationTypeEnumType        \$countryOrigin: VaildCountryOriginEnumType    ) {    shows(        search: \$search        limit: \$limit        page: \$page        translationType: \$translationType        countryOrigin: \$countryOrigin    ) {        edges {            _id name availableEpisodes __typename       }    }}"
+
+	curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
 # get the episodes list of the selected anime
 episodes_list() {
-	curl -e "https://${allanime_base}" -s "https://api.${allanime_base}/allanimeapi?variables=%7B%22_id%22%3A%22$*%22%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22f73a8347df0e3e794f8955a18de6e85ac25dfc6b74af8ad613edf87bb446a854%22%7D%7D" -A "$agent" | sed 's|\\||g' | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
+	episodes_list_gql="query (\$showId: String!) {    show(        _id: \$showId    ) {        _id availableEpisodesDetail    }}"
+
+	curl -e "https://${allanime_base}" -s --cipher AES256-SHA256 -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 
 # PLAYING
@@ -316,7 +322,7 @@ while [ $# -gt 0 ]; do
 		;;
 	--dub) mode="dub" ;;
 	-U | --update) update_script ;;
-	*) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |%20|g")" ;;
+	*) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
 	esac
 	shift
 done
@@ -358,7 +364,7 @@ history)
 			query=$(: | external_menu "" "Search anime: ")
 		fi
 	done
-	query=$(printf "%s" "$query" | sed "s| |%20|g")
+	query=$(printf "%s" "$query" | sed "s| |+|g")
 	anime_list=$(search_anime "$query")
 	[ -z "$anime_list" ] && die "No results found!"
 	result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: ") || exit 1

--- a/ani-cli
+++ b/ani-cli
@@ -238,8 +238,8 @@ play_episode() {
 }
 
 play() {
-	start=$(printf "%s" "$ep_no" | grep -Eo "^[0-9]+(\.[0-9])?")
-	end=$(printf "%s" "$ep_no" | grep -Eo "[0-9]+(\.[0-9])?$")
+	start=$(printf "%s" "$ep_no" | grep -Eo '^[0-9]+(\.[0-9])?')
+	end=$(printf "%s" "$ep_no" | grep -E '(-1|[0-9]+(\.[0-9])?)$')
 	[ -z "$end" ] || [ "$end" = "$start" ] && unset start end
 	line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")
 	if [ "$line_count" != 1 ] || [ -n "$start" ]; then
@@ -307,6 +307,7 @@ while [ $# -gt 0 ]; do
 		quality="$2"
 		shift
 		;;
+	-S | --select-first) select_first=1 ;;
 	-c | --continue) search=history ;;
 	-d | --download) player_function=download ;;
 	-D | --delete)
@@ -367,7 +368,9 @@ history)
 	query=$(printf "%s" "$query" | sed "s| |+|g")
 	anime_list=$(search_anime "$query")
 	[ -z "$anime_list" ] && die "No results found!"
-	result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: ") || exit 1
+	[ "$select_first" = 1 ] && result=$(printf "%s" "$anime_list" | head -n1)
+	[ -z "$select_first" ] && result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: ")
+	[ -z "$result" ] && exit 1
 	title=$(printf "%s" "$result" | cut -f2)
 	allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | tr 'A-Z ' 'a-z-')"
 	id=$(printf "%s" "$result" | cut -f1)

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -28,6 +28,9 @@ Download episode.
 \fB\-D | --delete\fR
 Delete history.
 .TP
+\fB\-S | --select-first\fR
+Selects first entry.
+.TP
 \fB\-h | --help\fR
 Show summary of options.
 .TP

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -28,8 +28,8 @@ Download episode.
 \fB\-D | --delete\fR
 Delete history.
 .TP
-\fB\-S | --select-first\fR
-Selects first entry.
+\fB\-S | --select-nth\fR \fI\,<index>\/\fR
+Selects nth entry.
 .TP
 \fB\-h | --help\fR
 Show summary of options.


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
