### PR TITLE
Dead links check for wixmp

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -110,6 +110,7 @@ get_links() {
 		curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$episode_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
 		;;
 	*repackager.wixmp.com*)
+		curl -s -X HEAD "$(printf '%s' "$episode_link" | cut -d'>' -f2)" || return 0
 		extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
 		for j in $(printf "%s" "$episode_link" | sed -nE 's|.*/,([^/]*),/mp4.*|\1|p' | sed 's|,|\n|g'); do
 			printf "%s >%s\n" "$j" "$extract_link" | sed "s|,[^/]*|${j}|g"

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.1"
+version_number="4.2.2"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -110,8 +110,9 @@ get_links() {
 		curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$episode_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
 		;;
 	*repackager.wixmp.com*)
-		curl -s -X HEAD "$(printf '%s' "$episode_link" | cut -d'>' -f2)" || return 0
-		extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
+		wixmp_link=$(printf '%s' "$episode_link" | cut -d'>' -f2)
+		curl -s -X HEAD "$wixmp_link" || return 0
+		extract_link=$(printf "%s" "$wixmp_link" | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
 		for j in $(printf "%s" "$episode_link" | sed -nE 's|.*/,([^/]*),/mp4.*|\1|p' | sed 's|,|\n|g'); do
 			printf "%s >%s\n" "$j" "$extract_link" | sed "s|,[^/]*|${j}|g"
 		done | sort -nr


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Self Explainatory

## Checklist

- [X] any anime playing
- [x] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-S` select index works
- [X] `-r` range selection works
- [X] `--dub` both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
