### PR TITLE
Added gentoo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ yay -S ani-cli
 ```
 Also consider `ani-cli-git`
 
+#### Gentoo
+
+Build and install from the GURU:
+```sh
+sudo eselect repository enable guru
+sudo emaint sync -r guru
+sudo emerge -a ani-cli
+```
+Consider using the 9999 ebuild.
+```sh
+sudo emerge -a =app-misc/ani-cli-9999
+```
+
 #### OpenSuse Tumbleweed and Leap
 
 On Suse the provided MPV and VLC packages are missing features that are used by ani-cli. The only required is the "Only Essentials" repository which has versions for each Suse release.


### PR DESCRIPTION
# Gentoo installation instructions

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Documentation update

## Description
I copied the instructions on [nheko](https://nheko-reborn.github.io/repositories/) and replaced the name of the package.

Note that due to the forth regulation of the [guru regulations](https://wiki.gentoo.org/wiki/Project:GURU#The_regulations). People on stable will have to accept the unstable keyword for the package (which is not in the installation instructions)