### PR TITLE
test: bump actions/checkout version to v3

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,7 +9,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       env:


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

- Bump the `actions/checkout` version to `v3` to fix the Node 12 deprecation warning displayed under Actions as the newer version uses Node 16.

## Checklist

- [ ] any anime playing
- [x] bumped version
---

