### PR TITLE
docs: remove matrix. discord only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 <img src="https://img.shields.io/badge/os-android-brightgreen">
 <br>
 <h1 align="center">
-<a href="https://matrix.to/#/#ani-cli:matrix.org"><img src="https://element.io/blog/content/images/2020/07/Logomark---white-on-green.png" width="80"></a>
-<a href="https://discord.gg/aqu7GpqVmR"><img src="https://pnggrid.com/wp-content/uploads/2021/05/Discord-Logo-Square-1024x1024.png" width="80"></a>
+<a href="https://discord.gg/aqu7GpqVmR">
+<img src="https://invidget.switchblade.xyz/aqu7GpqVmR">
+</a>
 <br>
 <a href="https://github.com/port19x"><img src="https://img.shields.io/badge/lead-port19x-lightblue"></a>
 <a href="https://github.com/CoolnsX"><img src="https://img.shields.io/badge/maintainer-CoolnsX-blue"></a>


### PR DESCRIPTION
# Pull Request Template

## Type of change

Governance

## Description

After a particularly disturbing toll from matrix this morning I'm proposing we officially close the matrix server.
~70% of messages coming from matrix are from users that also have active discord accounts.
20% from spammers and trolls in various intensities.
10% from actual legit users.

I'd rather alienate a small handful of free software maximalists than have another troll / crypto currency scammer / whatever.