### PR TITLE
fix: history selection will be read from histfile again

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -358,7 +358,7 @@ case "$search" in
         [ -z "$result" ] && exit 1
         resfile="$(mktemp)"
         grep "$result" "$histfile" > "$resfile"
-				read -r ep_no id title < "$resfile"
+        read -r ep_no id title < "$resfile"
         ep_list=$(episodes_list "$id")
         ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | tr 'A-Z ' 'a-z-')"

--- a/ani-cli
+++ b/ani-cli
@@ -356,8 +356,9 @@ case "$search" in
         [ -z "$anime_list" ] && die "No unwatched series in history!"
         result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: " | cut -f1)
         [ -z "$result" ] && exit 1
-        result=$(grep "$result" "$histfile")
-        read -r ep_no id title result
+        resfile="$(mktemp)"
+        grep "$result" "$histfile" > "$resfile"
+				read -r ep_no id title < "$resfile"
         ep_list=$(episodes_list "$id")
         ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | tr 'A-Z ' 'a-z-')"

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.2"
+version_number="4.2.3"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Addresses #1100 

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)