### PR TITLE
Add iOS support to ani-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.nix
+.replit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.nix
-.replit

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note
 
 ### iOS
 Make sure apk is updated using
-```sh apk update```
+```apk update```
 then install
 ```sh
 apk add grep sed curl fzf git ffmpeg aria2

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <img src="https://img.shields.io/badge/os-mac-brightgreen">
 <img src="https://img.shields.io/badge/os-windows-brightgreen">
 <img src="https://img.shields.io/badge/os-android-brightgreen">
+<img src="https://img.shields.io/badge/os-ios-brightgreen">
 <br>
 <h1 align="center">
 <a href="https://discord.gg/aqu7GpqVmR">

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A cli to browse and watch anime (alone AND with friends). This tool scrapes the 
   - [Windows](#Windows)
   - [Android](#Android)
   - [Steam Deck](#Steam-deck)
+  - [iOS](#iOS)
 - [Uninstall](#Uninstall)
 - [Dependencies](#Dependencies)
 - [Homies](#Homies)
@@ -211,6 +212,16 @@ rm -rf ani-cli
 ```
 
 For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note that these cannot be checked from termux so a warning is generated when checking dependencies.
+
+### iOS
+Make sure apk is updated using
+```sh apk update```
+then install
+```sh
+apk add grep sed curl fzf git ffmpeg aria2
+git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli
+cp ~/.ani-cli/ani-cli /usr/local/bin/ani-cli
+```
 
 ### Steam Deck
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note
 ### iOS
 Make sure apk is updated using
 ```apk update```
-then install
+then paste this
 ```sh
 apk add grep sed curl fzf git ffmpeg aria2
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note
 ### iOS
 Make sure apk is updated using
 ```apk update```
-then paste this
+then paste this:
 ```sh
 apk add grep sed curl fzf git ffmpeg aria2
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli

--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ rm -rf ani-cli
 For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note that these cannot be checked from termux so a warning is generated when checking dependencies.
 
 ### iOS
+Install VLC from app store
+-
 Make sure apk is updated using
 ```apk update```
 then paste this:

--- a/ani-cli
+++ b/ani-cli
@@ -231,7 +231,7 @@ play_episode() {
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}episode-${ep_no}-${mode}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
-	iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=${episode}&filename=${allanime_title}episode-${ep_no}-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n";sleep 5 ;;
+	    iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=%s&filename=%sepisode-%s-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode" "$allanime_title" "$ep_no" "$mode";sleep 5 ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
     esac
     replay="$episode"

--- a/ani-cli
+++ b/ani-cli
@@ -276,7 +276,7 @@ case "$(uname -a)" in
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;    # Android OS (termux)
     *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;; # steamdeck OS
     *MINGW*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;         # Windows OS
-    *iSH*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;	    	   # iOS (iSH)
+    *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;	    	   # iOS (iSH)
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                   # Linux OS
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -231,7 +231,7 @@ play_episode() {
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}episode-${ep_no}-${mode}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
-	  iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=$episode&filename=${allanime_title}episode-${ep_no}-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n";sleep 5 ;;
+	iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=$episode&filename=${allanime_title}episode-${ep_no}-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n";sleep 5 ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
     esac
     replay="$episode"

--- a/ani-cli
+++ b/ani-cli
@@ -231,7 +231,7 @@ play_episode() {
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}episode-${ep_no}-${mode}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
-	iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=$episode&filename=${allanime_title}episode-${ep_no}-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n";sleep 5 ;;
+	iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=${episode}&filename=${allanime_title}episode-${ep_no}-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n";sleep 5 ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
     esac
     replay="$episode"

--- a/ani-cli
+++ b/ani-cli
@@ -231,7 +231,7 @@ play_episode() {
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}episode-${ep_no}-${mode}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
-	    iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=%s&filename=%sepisode-%s-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode" "$allanime_title" "$ep_no" "$mode";sleep 5 ;;
+	    iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=%s&filename=%sepisode-%s-%s\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode" "$allanime_title" "$ep_no" "$mode";sleep 5 ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
     esac
     replay="$episode"

--- a/ani-cli
+++ b/ani-cli
@@ -231,6 +231,7 @@ play_episode() {
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}episode-${ep_no}-${mode}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
+	  iSH) printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=$episode&filename=${allanime_title}episode-${ep_no}-${mode}\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n";sleep 5 ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
     esac
     replay="$episode"
@@ -275,6 +276,7 @@ case "$(uname -a)" in
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;    # Android OS (termux)
     *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;; # steamdeck OS
     *MINGW*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;         # Windows OS
+    *iSH*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;	    	   # iOS (iSH)
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                   # Linux OS
 esac
 
@@ -296,6 +298,7 @@ while [ $# -gt 0 ]; do
             case "$(uname -a)" in
                 *ndroid*) player_function="android_vlc" ;;
                 MINGW*) player_function="vlc.exe" ;;
+		    *iSH*) player_function="iSH" ;;
                 *) player_function="vlc" ;;
             esac
             ;;
@@ -345,6 +348,7 @@ case "$player_function" in
         flatpak info io.mpv.Mpv >/dev/null 2>&1 || die "Program \"mpv (flatpak)\" not found. Please install it."
         ;;
     android*) printf "Checking of players on Android is disabled\n" ;;
+    *iSH*) printf "Checking of players on iOS is disabled\n" ;;
     *) dep_ch "$player_function" ;;
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.3"
+version_number="4.2.4"
 
 # UI
 


### PR DESCRIPTION
Pull Request Template
Type of change
[ ] Bug fix
[X] Feature
[ ] Documentation update

Description
added iSH detection, and used x-callback (Thanks [RubenPonce](https://github.com/RubenPonce) for telling me about that!) when iSH is detected. Oh, also adjusted readme to include iOS installation instructions.

Checklist
[X] any anime playing
[X] bumped version
---
[X] next, prev and replay work
[X] -c history and continue work
[X] -d downloads work
[X] -s syncplay works (Not on iOS)
[X] -q quality works
[X] -v vlc works
[X] -e select episode works
[X] -S select index works
[X] -r range selection works
[X] --dub both work
[X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
[X] -h help info is up to date
[X] Readme is up to date
[X] Man page is up to date

Additional Testcases
The safe bet: One Piece
Episode 0: Saenai Heroine no Sodatekata ♭
Unicode: Saenai Heroine no Sodatekata ♭
Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)