### PR TITLE
feat: add non-interactive flag to disable menu

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.4"
+version_number="4.2.5"
 
 # UI
 
@@ -63,6 +63,8 @@ help_info() {
         play dubbed version
       -U, --update
         Update the script
+      -N, --non-interactive
+        Disable the interactive menu
     Some example usages:
       %s -q 720p banana fish
       %s -d -e 2 cyberpunk edgerunners
@@ -237,6 +239,9 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
+    if [ $no_menu -eq 1 ]; then
+      die "Playing episode $ep_no of $title"
+    fi
     wait
 }
 
@@ -271,6 +276,7 @@ allanime_base="allanime.to"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
+no_menu=0
 case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;           # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;    # Android OS (termux)
@@ -332,6 +338,7 @@ while [ $# -gt 0 ]; do
             ep_no="$2"
             shift
             ;;
+        -N | --non-interactive) no_menu=1 ;;
         --dub) mode="dub" ;;
         -U | --update) update_script ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -239,7 +239,7 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
-    if [ $no_menu -eq 1 ]; then
+    if [ "$no_menu" -eq 1 ]; then
       printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no of $title"
       exit 0
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -240,7 +240,8 @@ play_episode() {
     unset episode
     update_history
     if [ $no_menu -eq 1 ]; then
-      die "Playing episode $ep_no of $title"
+      printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no of $title"
+      exit 0
     fi
     wait
 }


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

add a `--non-interactive` and `-N` flag to disable the menu. Mentioned in #1104
[demo](https://user-images.githubusercontent.com/43939942/235757212-beb75f64-7c36-47d7-9937-bb9bc91b7a07.webm)

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
