### PR TITLE
fix: account for syncplay in either default location or windows path

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.9"
+version_number="4.3.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.7"
+version_number="4.2.8"
 
 # UI
 
@@ -323,7 +323,10 @@ while [ $# -gt 0 ]; do
         -s | --syncplay)
             case "$(uname -s)" in
                 Darwin*) player_function="/Applications/Syncplay.app/Contents/MacOS/syncplay" ;;
-                MINGW* | *Msys) player_function="/c/Program Files (x86)/Syncplay/Syncplay.exe" ;;
+                MINGW* | *Msys)
+                    player_function="/c/Program Files (x86)/Syncplay/Syncplay.exe"
+                    command -v "$player_function" >/dev/null || player_function="syncplay.exe"
+                    ;;
                 *) player_function="syncplay" ;;
             esac
             ;;

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.8"
+version_number="4.2.9"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -324,8 +324,8 @@ while [ $# -gt 0 ]; do
             case "$(uname -s)" in
                 Darwin*) player_function="/Applications/Syncplay.app/Contents/MacOS/syncplay" ;;
                 MINGW* | *Msys)
-                    player_function="/c/Program Files (x86)/Syncplay/Syncplay.exe"
-                    command -v "$player_function" >/dev/null || player_function="syncplay.exe"
+                    export PATH=$PATH:"/c/Program Files (x86)/Syncplay/"
+                    player_function="syncplay.exe"
                     ;;
                 *) player_function="syncplay" ;;
             esac


### PR DESCRIPTION
…or on the path for Windows

# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description
This fixes #1114.
This fix accounts for Syncplay being at either the default location (used by the Syncplay installer and the chocolatey package manager) or on the path.
If Syncplay doesn't exist in the default location, it will set `player_function` to "syncplay.exe", expecting it to come from the path.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date
