### PR TITLE
Various fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@
 - [ ] `-e` select episode works
 - [ ] `-S` select index works
 - [ ] `-r` range selection works
-- [ ] `--dub` both work
+- [ ] `--dub` and regular (sub) mode both work
 - [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
 ---
 - [ ] `-h` help info is up to date

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 <p align=center>
 <br>
 <a href="http://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"></a>
-<img src="https://img.shields.io/badge/os-linux-brightgreen">
-<img src="https://img.shields.io/badge/os-mac-brightgreen">
-<img src="https://img.shields.io/badge/os-windows-brightgreen">
-<img src="https://img.shields.io/badge/os-android-brightgreen">
-<img src="https://img.shields.io/badge/os-ios-brightgreen">
+<a href="#Linux"><img src="https://img.shields.io/badge/os-linux-brightgreen">
+<a href="#MacOS"><img src="https://img.shields.io/badge/os-mac-brightgreen">
+<a href="#Windows"><img src="https://img.shields.io/badge/os-windows-brightgreen">
+<a href="#Android"><img src="https://img.shields.io/badge/os-android-brightgreen">
+<a href="#iOS"><img src="https://img.shields.io/badge/os-ios-brightgreen">
+<a href="#Steam-deck"><img src="https://img.shields.io/badge/os-steamdeck-brightgreen">
 <br>
 <h1 align="center">
 <a href="https://discord.gg/aqu7GpqVmR">

--- a/ani-cli
+++ b/ani-cli
@@ -418,7 +418,6 @@ play
 [ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
 
 while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
-    printf "%s\n" "$links"
     case "$cmd" in
         next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
         replay) episode="$replay" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -254,7 +254,7 @@ play_episode() {
         printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no of $title"
         exit 0
     fi
-    wait
+    [ "$use_external_menu" = "1" ] && wait
 }
 
 play() {

--- a/ani-cli
+++ b/ani-cli
@@ -418,13 +418,14 @@ play
 [ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
 
 while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
+    printf "%s\n" "$links"
     case "$cmd" in
         next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
         replay) episode="$replay" ;;
         previous) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{g;1!p;};h") 2>/dev/null ;;
         select) ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag") ;;
         change_quality)
-            episode=$(printf "%s" "$links" | sed -n '/^\([0-9]*p\)/p' | launcher)
+            episode=$(printf "%s" "$links" | launcher)
             quality=$(printf "%s" "$episode" | grep -oE "^[0-9]+")
             episode=$(printf "%s" "$episode" | cut -d'>' -f2)
             ;;

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.2.7"
+version_number="4.2.8"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Undid a change that was merged in #993 but not documented (and thus deemed accidental): showing fzf during playing but not other launchers.
Modified the `change quality` menu point to display links that don't have a numeric resolution tag to help circumvent broken/slow links.

Also since I didn't do anything ground-breaking I'm willing to put the code to some testing and call it a major release. We have implemented a lot of small fixes lately, package maintainers should be able to package them now without problems. 

## Checklist

- [x] any anime playing
- [x] bumped version (bumped to 4.2.8 but I want to do a 4.3 stable release with only fixes)
---
- [ ] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [ ] `-s` syncplay works
- [x] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
