### PR TITLE
docs: Add iOS uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,6 @@ rm -rf "~/.fzf"
 flatpak uninstall io.mpv.Mpv
 ```
 * iOS
-To uninstall ani-cli:
 ```
 rm -rf /usr/local/bin/ani-cli
 ```

--- a/README.md
+++ b/README.md
@@ -384,7 +384,20 @@ rm -rf "~/.aria2"
 rm -rf "~/.fzf"
 flatpak uninstall io.mpv.Mpv
 ```
-
+* iOS
+To uninstall ani-cli:
+```
+rm -rf /usr/local/bin/ani-cli
+```
+To uninstall FFmpeg:
+```
+rm -rf /usr/local/lib/libavutil.a /usr/local/lib/libavcodec.a /usr/local/lib/libavformat.a /usr/local/lib/pkgconfig/libavutil.a /usr/local/lib/pkgconfig/libavcodec.a /usr/local/lib/pkgconfig/libavformat.a
+apk del ffmpeg
+```
+To uninstall other dependencies:
+```
+apk del grep sed curl fzf git aria2 alpine-sdk ncurses
+```
 ## Dependencies
 
 - grep

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.3.1"
+version_number="4.3.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.3.0"
+version_number="4.3.1"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Documentation update

## Description

*ramble here*

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-S` select index works
- [X] `-r` range selection works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
