### PR TITLE
refactor: disable aria2 rpc

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -222,7 +222,7 @@ download() {
             if uname -a | grep -q "ish"; then
                 curl --output-dir "$download_dir" -o "$2.mp4" "$1"
             else
-                aria2c --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+                aria2c --no-conf=true --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
             fi
         fi ;;
     esac

--- a/ani-cli
+++ b/ani-cli
@@ -222,7 +222,7 @@ download() {
             if uname -a | grep -q "ish"; then
                 curl --output-dir "$download_dir" -o "$2.mp4" "$1"
             else
-                aria2c --no-conf=true --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+                aria2c --enable-rpc=false --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
             fi
         fi ;;
     esac

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.3.0"
+version_number="4.3.1"
 
 # UI
 


### PR DESCRIPTION
Disable loading aria2.conf file. to Disable `enable-rpc=true` from `${HOME}/.aria2/aria2.aria2.conf`

# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
