### PR TITLE
fix: list number bug on mac

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -400,7 +400,7 @@ case "$search" in
         anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
         wait
         [ -z "$anime_list" ] && die "No unwatched series in history!"
-        result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: " | cut -f1)
+        result=$(printf "%s" "$anime_list" | nl -w 2 | nth "Select anime: " | cut -f1)
         [ -z "$result" ] && exit 1
         resfile="$(mktemp)"
         grep "$result" "$histfile" >"$resfile"
@@ -422,7 +422,7 @@ case "$search" in
         anime_list=$(search_anime "$query")
         [ -z "$anime_list" ] && die "No results found!"
         [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
-        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 1 | nth "Select anime: ")
+        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | nth "Select anime: ")
         [ -z "$result" ] && exit 1
         title=$(printf "%s" "$result" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | tr 'A-Z ' 'a-z-')"

--- a/ani-cli
+++ b/ani-cli
@@ -140,17 +140,17 @@ provider_init() {
 hex_to_ascii() {
     hex="$1"
     len=$(printf "%s" "$hex" | wc -c)
-    bin=""
+    ascii=""
     i=1
     while [ "$i" -lt "$len" ]; do
         char=$(printf "%s" "$hex" | cut -c "$i-$((i + 1))")
         dec=$(printf "%d" "0x$char")
         oct=$(printf "%03o" "$dec")
         # shellcheck disable=SC2059
-        bin="$bin$(printf "\\$oct")"
+        ascii="$ascii$(printf "\\$oct")"
         i=$((i + 2))
     done
-    printf "%s" "$bin"
+    printf "%s" "$ascii"
 }
 
 # generates links based on given provider

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.4.1"
+version_number="4.4.2"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
