### PR TITLE
refactor: split long lines (and some minor stuff)

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -104,20 +104,13 @@ dep_ch() {
 
 # SCRAPING
 
-# curl wrapper to be used for getting data out of $allanime_base
-allanime_curl() {
-    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$*"
-}
-
 # extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
 get_links() {
-    episode_link="$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://allanimenews.com$*" -A "$agent" |
-        sed 's|},{|\n|g' |
+    episode_link="$($allanime_curl "https://allanimenews.com$*" | sed 's|},{|\n|g' |
         sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
     case "$episode_link" in
         *crunchyroll*)
-            curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$episode_link" -A "$agent" |
-                sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
+                $allanime_curl "$episode_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
             ;;
         *repackager.wixmp.com*)
             extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
@@ -131,8 +124,7 @@ get_links() {
             else
                 extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
                 relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
-                curl -e "https://${allanime_base}/" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" |
-                    sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
+                $allanime_curl "$extract_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
             fi
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
@@ -214,9 +206,8 @@ get_episode_url() {
             \"translationType\":\"$mode\",
             \"episodeString\":\"$ep_no\"
         }"
-    resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi"\
-        --data-urlencode "variables=$query_json" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' |
-        sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    resp=$($allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episode_embed_gql" |
+        tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     provider=1
     i=0
@@ -269,8 +260,7 @@ search_anime() {
             \"translationType\":\"$mode\",
             \"countryOrigin\":\"ALL\"
         }"
-    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi"\
-        --data-urlencode "variables=$query_json" --data-urlencode "query=$search_gql" -A "$agent" |
+    $allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$search_gql" |
         sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
@@ -292,8 +282,7 @@ episodes_list() {
         {
             \"showId\":\"$*\"
         }" 
-    curl -e "https://${allanime_base}" -s --cipher AES256-SHA256 -G "https://api.${allanime_base}/allanimeapi"\
-        --data-urlencode "variables=$query_json" --data-urlencode "query=$episodes_list_gql" -A "$agent" |
+    $allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episodes_list_gql" |
         sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 
@@ -390,6 +379,10 @@ play() {
 # setup
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
 allanime_base="allanime.to"
+api_url="https://api.${allanime_base}/allanimeapi"
+# curl wrapper to be used for getting data out of allanime
+allanime_curl="curl -e https://${allanime_base} -s --cipher AES256-SHA256 -A $agent"
+
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"

--- a/ani-cli
+++ b/ani-cli
@@ -115,7 +115,7 @@ get_links() {
         sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
     case "$episode_link" in
         *crunchyroll*)
-                allanime_curl "$episode_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
+            allanime_curl "$episode_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
             ;;
         *repackager.wixmp.com*)
             extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
@@ -286,7 +286,7 @@ episodes_list() {
     query_json="
         {
             \"showId\":\"$*\"
-        }" 
+        }"
     allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episodes_list_gql" |
         sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
@@ -318,7 +318,7 @@ download() {
             if uname -a | grep -q "ish"; then
                 curl --output-dir "$download_dir" -o "$2.mp4" "$1"
             else
-                aria2c --enable-rpc=false --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1"\
+                aria2c --enable-rpc=false --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" \
                     --dir="$download_dir" -o "$2.mp4" --download-result=hide
             fi
         fi ;;
@@ -331,8 +331,7 @@ play_episode() {
         debug) printf "All links:\n%s\nSelected link:\n%s\n" "$links" "$episode" ;;
         mpv*) nohup "$player_function" --force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
-        android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity\
-            -e "title" "${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
+        android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
         vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -106,10 +106,13 @@ dep_ch() {
 
 # extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
 get_links() {
-    episode_link="$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://allanimenews.com$*" -A "$agent" | sed 's|},{|\n|g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
+    episode_link="$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://allanimenews.com$*" -A "$agent" |
+        sed 's|},{|\n|g' |
+        sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
     case "$episode_link" in
         *crunchyroll*)
-            curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$episode_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
+            curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$episode_link" -A "$agent" |
+                sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
             ;;
         *repackager.wixmp.com*)
             extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
@@ -123,7 +126,8 @@ get_links() {
             else
                 extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
                 relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
-                curl -e "https://${allanime_base}/" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
+                curl -e "https://${allanime_base}/" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" |
+                    sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
             fi
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
@@ -183,9 +187,31 @@ select_quality() {
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
     # get the embed urls of the selected episode
-    episode_embed_gql="query (\$showId: String!, \$translationType: VaildTranslationTypeEnumType!, \$episodeString: String!) {    episode(        showId: \$showId        translationType: \$translationType        episodeString: \$episodeString    ) {        episodeString sourceUrls    }}"
-
-    resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    episode_embed_gql="
+        query (
+            \$showId: String!,
+            \$translationType: VaildTranslationTypeEnumType!,
+            \$episodeString: String!
+        ) 
+        {
+            episode(
+                showId: \$showId
+                translationType: \$translationType
+                episodeString: \$episodeString
+                )
+            {
+                episodeString sourceUrls
+            }
+        }"
+    query_json="
+        variables={
+            \"showId\":\"$id\",
+            \"translationType\":\"$mode\",
+            \"episodeString\":\"$ep_no\"
+        }"
+    resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi"\
+        --data-urlencode "$query_json" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' |
+        sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     provider=1
     i=0
@@ -203,16 +229,67 @@ get_episode_url() {
 
 # search the query and give results
 search_anime() {
-    search_gql="query(        \$search: SearchInput        \$limit: Int        \$page: Int        \$translationType: VaildTranslationTypeEnumType        \$countryOrigin: VaildCountryOriginEnumType    ) {    shows(        search: \$search        limit: \$limit        page: \$page        translationType: \$translationType        countryOrigin: \$countryOrigin    ) {        edges {            _id name availableEpisodes __typename       }    }}"
-
-    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
+    search_gql="
+        query(        
+            \$search: SearchInput
+            \$limit: Int
+            \$page: Int
+            \$translationType: VaildTranslationTypeEnumType
+            \$countryOrigin: VaildCountryOriginEnumType
+        )
+        {    
+            shows(
+            search: \$search
+            limit: \$limit
+            page: \$page
+            translationType: \$translationType
+            countryOrigin: \$countryOrigin
+            )
+            {
+                edges 
+                {
+                    _id name availableEpisodes __typename
+                }
+            }
+        }"
+    query_json="
+        variables={
+            \"search\":{
+                \"allowAdult\":false,
+                \"allowUnknown\":false,
+                \"query\":\"$1\"
+            },
+            \"limit\":40,
+            \"page\":1,
+            \"translationType\":\"$mode\",
+            \"countryOrigin\":\"ALL\"
+        }"
+    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi"\
+        --data-urlencode "$query_json" --data-urlencode "query=$search_gql" -A "$agent" |
+        sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
 # get the episodes list of the selected anime
 episodes_list() {
-    episodes_list_gql="query (\$showId: String!) {    show(        _id: \$showId    ) {        _id availableEpisodesDetail    }}"
-
-    curl -e "https://${allanime_base}" -s --cipher AES256-SHA256 -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
+    episodes_list_gql="
+        query (
+            \$showId: String!
+        )
+        {
+            show (
+                _id: \$showId
+            )
+            {
+                _id availableEpisodesDetail
+            }
+        }"
+    query_json="
+        variables={
+            \"showId\":\"$*\"
+        }" 
+    curl -e "https://${allanime_base}" -s --cipher AES256-SHA256 -G "https://api.${allanime_base}/allanimeapi"\
+        --data-urlencode "$query_json" --data-urlencode "query=$episodes_list_gql" -A "$agent" |
+        sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 
 # PLAYING
@@ -242,7 +319,8 @@ download() {
             if uname -a | grep -q "ish"; then
                 curl --output-dir "$download_dir" -o "$2.mp4" "$1"
             else
-                aria2c --enable-rpc=false --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+                aria2c --enable-rpc=false --check-certificate=false --continue --summary-interval=0 -x 16 -s 16 "$1"\
+                    --dir="$download_dir" -o "$2.mp4" --download-result=hide
             fi
         fi ;;
     esac
@@ -254,7 +332,8 @@ play_episode() {
         debug) printf "All links:\n%s\nSelected link:\n%s\n" "$links" "$episode" ;;
         mpv*) nohup "$player_function" --force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
-        android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
+        android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity\
+            -e "title" "${allanime_title}episode-${ep_no}-${mode}" >/dev/null 2>&1 & ;;
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
         vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
@@ -262,7 +341,8 @@ play_episode() {
         download) "$player_function" "$episode" "${allanime_title}episode-${ep_no}-${mode}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
         iSH)
-            printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=%s&filename=%sepisode-%s-%s\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode" "$allanime_title" "$ep_no" "$mode"
+            printf "\e]8;;vlc-x-callback://x-callback-url/stream?url=%s&filename=%sepisode-%s-%s\a~~~~~~~~~~~~~~~~~~~~\
+                \n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode" "$allanime_title" "$ep_no" "$mode"
             sleep 5
             ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.4.3"
+version_number="4.4.4"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -104,13 +104,18 @@ dep_ch() {
 
 # SCRAPING
 
+# curl wrapper to be used for getting data out of allanime
+allanime_curl() {
+    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -A "$agent" "$@"
+}
+
 # extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
 get_links() {
-    episode_link="$($allanime_curl "https://allanimenews.com$*" | sed 's|},{|\n|g' |
+    episode_link="$(allanime_curl "https://allanimenews.com$*" | sed 's|},{|\n|g' |
         sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
     case "$episode_link" in
         *crunchyroll*)
-                $allanime_curl "$episode_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
+                allanime_curl "$episode_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sort -nr
             ;;
         *repackager.wixmp.com*)
             extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
@@ -124,7 +129,7 @@ get_links() {
             else
                 extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
                 relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
-                $allanime_curl "$extract_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
+                allanime_curl "$extract_link" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
             fi
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
@@ -206,7 +211,7 @@ get_episode_url() {
             \"translationType\":\"$mode\",
             \"episodeString\":\"$ep_no\"
         }"
-    resp=$($allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episode_embed_gql" |
+    resp=$(allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episode_embed_gql" |
         tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     provider=1
@@ -260,7 +265,7 @@ search_anime() {
             \"translationType\":\"$mode\",
             \"countryOrigin\":\"ALL\"
         }"
-    $allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$search_gql" |
+    allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$search_gql" |
         sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
@@ -282,7 +287,7 @@ episodes_list() {
         {
             \"showId\":\"$*\"
         }" 
-    $allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episodes_list_gql" |
+    allanime_curl -G "$api_url" --data-urlencode "variables=$query_json" --data-urlencode "query=$episodes_list_gql" |
         sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 
@@ -380,8 +385,6 @@ play() {
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
 allanime_base="allanime.to"
 api_url="https://api.${allanime_base}/allanimeapi"
-# curl wrapper to be used for getting data out of allanime
-allanime_curl="curl -e https://${allanime_base} -s --cipher AES256-SHA256 -A $agent"
 
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"

--- a/ani-cli
+++ b/ani-cli
@@ -104,6 +104,11 @@ dep_ch() {
 
 # SCRAPING
 
+# curl wrapper to be used for getting data out of $allanime_base
+allanime_curl() {
+    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "$*"
+}
+
 # extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
 get_links() {
     episode_link="$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://allanimenews.com$*" -A "$agent" |
@@ -204,13 +209,13 @@ get_episode_url() {
             }
         }"
     query_json="
-        variables={
+        {
             \"showId\":\"$id\",
             \"translationType\":\"$mode\",
             \"episodeString\":\"$ep_no\"
         }"
     resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi"\
-        --data-urlencode "$query_json" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' |
+        --data-urlencode "variables=$query_json" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' |
         sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     provider=1
@@ -239,11 +244,11 @@ search_anime() {
         )
         {    
             shows(
-            search: \$search
-            limit: \$limit
-            page: \$page
-            translationType: \$translationType
-            countryOrigin: \$countryOrigin
+                search: \$search
+                limit: \$limit
+                page: \$page
+                translationType: \$translationType
+                countryOrigin: \$countryOrigin
             )
             {
                 edges 
@@ -253,7 +258,7 @@ search_anime() {
             }
         }"
     query_json="
-        variables={
+        {
             \"search\":{
                 \"allowAdult\":false,
                 \"allowUnknown\":false,
@@ -265,14 +270,14 @@ search_anime() {
             \"countryOrigin\":\"ALL\"
         }"
     curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi"\
-        --data-urlencode "$query_json" --data-urlencode "query=$search_gql" -A "$agent" |
+        --data-urlencode "variables=$query_json" --data-urlencode "query=$search_gql" -A "$agent" |
         sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
 # get the episodes list of the selected anime
 episodes_list() {
     episodes_list_gql="
-        query (
+        query ( 
             \$showId: String!
         )
         {
@@ -284,11 +289,11 @@ episodes_list() {
             }
         }"
     query_json="
-        variables={
+        {
             \"showId\":\"$*\"
         }" 
     curl -e "https://${allanime_base}" -s --cipher AES256-SHA256 -G "https://api.${allanime_base}/allanimeapi"\
-        --data-urlencode "$query_json" --data-urlencode "query=$episodes_list_gql" -A "$agent" |
+        --data-urlencode "variables=$query_json" --data-urlencode "query=$episodes_list_gql" -A "$agent" |
         sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 


### PR DESCRIPTION
# Refactor: split long lines (and some minor stuff)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Long lines are a pain, and while I was at it I made some small changes

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
