### PR TITLE
refactor: use awk as hex2ascii converter

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.4.3"
+version_number="4.4.4"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -138,19 +138,9 @@ provider_init() {
 }
 
 hex_to_ascii() {
-    hex="$1"
-    len=$(printf "%s" "$hex" | wc -c)
-    ascii=""
-    i=1
-    while [ "$i" -lt "$len" ]; do
-        char=$(printf "%s" "$hex" | cut -c "$i-$((i + 1))")
-        dec=$(printf "%d" "0x$char")
-        oct=$(printf "%03o" "$dec")
-        # shellcheck disable=SC2059
-        ascii="$ascii$(printf "\\$oct")"
-        i=$((i + 2))
-    done
-    printf "%s" "$ascii"
+    printf '%s' "$1" | awk 'BEGIN{FS="";}{
+      for (i=1;i<=NF;i+=2) printf "%c", strtonum("0x" $i $(i+1))
+    }'
 }
 
 # generates links based on given provider


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
