### PR TITLE
refactor: hls Decreasing the number will make download slower but stable.

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -232,7 +232,7 @@ download() {
     case $1 in
         *m3u8*)
             if command -v "hls"; then
-                hls -n 3 -ro "$download_dir/$2" "$1"
+                hls -ro "$download_dir/$2" "$1"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.4.4"
+version_number="4.4.5"
 
 # UI
 
@@ -232,7 +232,7 @@ download() {
     case $1 in
         *m3u8*)
             if command -v "hls"; then
-                hls -n 300 -ro "$download_dir/$2" "$1"
+                hls -n 3 -ro "$download_dir/$2" "$1"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
             fi


### PR DESCRIPTION
NOTE :- Increasing the number will make the download faster but less stable and Decreasing the number will make download slower but stable.
and how auto clean `${HOME}/.cache/hls-temp` after the download is complete

# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
