### PR TITLE
refactor: add paths temp: "${HOME}/.cache/yt-dlp-temp"

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cd .. && rm -rf ./ani-cli
 *To install (with Homebrew) the dependencies required on Mac OS, you can run:*
 
 ```sh
-brew install curl grep aria2 ffmpeg git fzf && \
+brew install curl grep aria2 ffmpeg git fzf yt-dlp && \
 brew install --cask iina
 ```
 *Why iina and not mpv? Drop-in replacement for mpv for MacOS. Integrates well with OSX UI. Excellent support for M1. Open Source.*
@@ -299,6 +299,13 @@ cp ~/.aria2c/aria2-1.36.0-linux-gnu-64bit-build1/aria2c ~/.local/bin/
 chmod +x ~/.local/bin/aria2c
 ```
 
+##### Install [yt-dlp](https://github.com/yt-dlp/yt-dlp) (needed for download feature only):
+
+```sh
+curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
+chmod +x ~/.local/bin/yt-dlp
+```
+
 ##### Install ani-cli:
 
 ```sh
@@ -380,6 +387,7 @@ rm -rf ~/.ani-cli
 optionally: remove dependencies:
 ```sh
 rm ~/.local/bin/aria2c
+rm ~/.local/bin/yt-dlp
 rm -rf "~/.aria2"
 rm -rf "~/.fzf"
 flatpak uninstall io.mpv.Mpv
@@ -405,7 +413,8 @@ apk del grep sed curl fzf git aria2 alpine-sdk ncurses
 - mpv - Video Player
 - iina - mpv replacement for MacOS
 - aria2c - Download manager
-- ffmpeg - m3u8 Downloader
+- yt-dlp - m3u8 Downloader
+- ffmpeg - m3u8 Downloader (fallback)
 - fzf - User interface
 
 ## Homies

--- a/ani-cli
+++ b/ani-cli
@@ -317,11 +317,7 @@ use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 cache_dir="${ANI_CLI_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli}"
-if [ ! -d "$cache_dir" ]; then
-    mkdir -p "$cache_dir"
-else
-    rm -f "$cache_dir/*"
-fi
+[ ! -d "$cache_dir" ] && mkdir -p "$cache_dir"
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"

--- a/ani-cli
+++ b/ani-cli
@@ -228,7 +228,7 @@ update_history() {
 download() {
     case $1 in
         *m3u8*)
-            if command -v "hls"; then
+            if command -v "hls" >/dev/null; then
                 hls -ro "$download_dir/$2" "$1"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.4.6"
+version_number="4.5.0"
 
 # UI
 
@@ -322,7 +322,11 @@ use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 cache_dir="${ANI_CLI_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli}"
-[ ! -d "$cache_dir" ] && mkdir -p "$cache_dir"
+if [ ! -d "$cache_dir" ];then
+	mkdir -p "$cache_dir"
+else
+	rm -f "$cache_dir/*"
+fi
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
@@ -383,16 +387,15 @@ printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m"
 dep_ch "curl" "sed" "grep" "fzf" || true
 case "$player_function" in
     debug) ;;
-    download) dep_ch "ffmpeg" "aria2c" ;;
+    download) 	dep_ch "ffmpeg" "aria2c" ;;
     flatpak*)
         dep_ch "flatpak"
         flatpak info io.mpv.Mpv >/dev/null 2>&1 || die "Program \"mpv (flatpak)\" not found. Please install it."
         ;;
-    android*) printf "\33[2K\rChecking of players on Android is disabled" ;;
-    *iSH*) printf "\33[2K\rChecking of players on iOS is disabled" ;;
+    android*) printf "\33[2K\rChecking of players on Android is disabled\n" ;;
+    *iSH*) printf "\33[2K\rChecking of players on iOS is disabled\n" ;;
     *) dep_ch "$player_function" ;;
 esac
-printf "\n"
 
 # searching
 case "$search" in
@@ -413,7 +416,7 @@ case "$search" in
     *)
         if [ "$use_external_menu" = "0" ]; then
             while [ -z "$query" ]; do
-                printf "Search anime: " && read -r query
+                printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
             done
         else
             query=$(printf "" | external_menu "" "Search anime: ")

--- a/ani-cli
+++ b/ani-cli
@@ -134,8 +134,16 @@ provider_init() {
     provider_id=$(printf "%s" "$resp" | sed -n "$2" | head -1 | cut -d':' -f2)
 }
 
+bypass_debug() {
+	if printf "%s" "$-" | grep -q 'x';then
+		set +x
+	elif [ "$1" -eq "0" ];then
+		set -x
+	fi
+}
+
 hex_to_ascii() {
-    printf "%s" "$-" | grep -q 'x' && set +x
+    bypass_debug "1"
     hex="$1"
     len="${#hex}"
     i=1
@@ -147,11 +155,11 @@ hex_to_ascii() {
         printf "\\$oct"
         i=$((i + 2))
     done
-    printf "%s" "$-" | grep -q 'x' && set +x || set -x
+    bypass_debug "0"
 }
 
 decrypt_allanime() {
-    printf "%s" "$-" | grep -q 'x' && set +x
+    bypass_debug "1"
     for result in $(hex_to_ascii "$1" | od -An -v -t u1); do
         for char in $(printf "%s" "1234567890123456789" | grep -o .); do
             decimal_char="$(printf "%02d" "'$char'")"
@@ -161,7 +169,7 @@ decrypt_allanime() {
         #shellcheck disable=SC2059
         printf "\\$(printf "%03o" "$result")"
     done
-    printf "%s" "$-" | grep -q 'x' && set +x || set -x
+    bypass_debug "0"
 }
 
 # generates links based on given provider

--- a/ani-cli
+++ b/ani-cli
@@ -142,32 +142,14 @@ bypass_debug() {
     fi
 }
 
-hex_to_ascii() {
-    bypass_debug "1"
-    hex="$1"
-    len="${#hex}"
-    i=1
-    while [ "$i" -le "$len" ]; do
-        char=$(echo "$hex" | cut -c "$i-$((i + 1))")
-        dec=$(printf "%d" "0x$char")
-        oct=$(printf "%03o" "$dec")
-        #shellcheck disable=SC2059
-        printf "\\$oct"
-        i=$((i + 2))
-    done
-    bypass_debug "0"
-}
-
 decrypt_allanime() {
     bypass_debug "1"
-    for result in $(hex_to_ascii "$1" | od -An -v -t u1); do
-        for char in $(printf "%s" "1234567890123456789" | grep -o .); do
-            decimal_char="$(printf "%02d" "'$char'")"
-            : $((result ^= decimal_char))
-        done
-
+    for hex in $(printf '%s' "$1" | sed 's/../&\n/g'); do
+        dec=$(printf '%d' "0x$hex")
+        xor=$((dec ^ 48))
+        oct=$(printf "%03o" "$xor")
         #shellcheck disable=SC2059
-        printf "\\$(printf "%03o" "$result")"
+        printf "\\$oct"
     done
     bypass_debug "0"
 }
@@ -206,6 +188,7 @@ get_episode_url() {
     # generate links into sequential files
     provider=1
     i=0
+    rm "$cache_dir/*"
     while [ "$i" -lt 6 ]; do
         generate_link "$provider" >"$cache_dir"/"$i" &
         provider=$((provider % 6 + 1))

--- a/ani-cli
+++ b/ani-cli
@@ -228,8 +228,8 @@ update_history() {
 download() {
     case $1 in
         *m3u8*)
-            if command -v "hls" >/dev/null; then
-                hls -ro "$download_dir/$2" "$1"
+            if command -v "yt-dlp" >/dev/null; then
+                yt-dlp "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -125,7 +125,7 @@ get_links() {
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
     esac
-    printf "\033[1;32m %s\033[0m Links Fetched\n" "$provider_name" 1>&2
+    printf "\033[1;32m%s\033[0m Links Fetched\n" "$provider_name" 1>&2
 }
 
 # innitialises provider_name and provider_id. First argument is the provider name, 2nd is the regex that matches that provider's link
@@ -154,6 +154,7 @@ generate_link() {
         3) provider_init "wetransfer" "/Kir :/p" ;;    # wetransfer(mp4)(single)
         4) provider_init "pstatic" "/Default B :/p" ;; # pstatic(default backup)(mp4)(multi)
         5) provider_init "sharepoint" "/S-mp4 :/p" ;;  # sharepoint(mp4)(single)
+        6) provider_init "rab" "/Rab :/p" ;;           # rab(mp4)(multi)
         *) provider_init "gogoanime" "/Luf-mp4 :/p" ;; # gogoanime(m3u8)(multi)
     esac
     provider_id="$(decrypt_allanime "$provider_id" | sed "s/\/clock/\/clock\.json/")"
@@ -180,9 +181,9 @@ get_episode_url() {
     provider=1
     i=0
     rm -f "$cache_dir/*"
-    while [ "$i" -lt 6 ]; do
+    while [ "$i" -lt 7 ]; do
         generate_link "$provider" >"$cache_dir"/"$i" &
-        provider=$((provider % 6 + 1))
+        provider=$((provider % 7 + 1))
         : $((i += 1))
     done
     wait
@@ -289,6 +290,7 @@ play() {
     else
         play_episode
     fi
+    tput rc && tput ed
 }
 
 # MAIN
@@ -375,7 +377,7 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
-printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m"
+printf "\33[2K\r\033[1;34mChecking dependencies...\033\n[0m"
 dep_ch "curl" "sed" "grep" "fzf" || true
 case "$player_function" in
     debug) ;;
@@ -431,6 +433,7 @@ esac
 
 # moves the cursor up one line and clears that line
 tput cuu1 && tput el
+tput sc
 
 # playback & loop
 play

--- a/ani-cli
+++ b/ani-cli
@@ -135,6 +135,7 @@ provider_init() {
 }
 
 hex_to_ascii() {
+    printf "%s" "$-" | grep -q 'x' && set +x
     hex="$1"
     len="${#hex}"
     i=1
@@ -146,9 +147,11 @@ hex_to_ascii() {
         printf "\\$oct"
         i=$((i + 2))
     done
+    printf "%s" "$-" | grep -q 'x' || set -x
 }
 
 decrypt_allanime() {
+    printf "%s" "$-" | grep -q 'x' && set +x
     for result in $(hex_to_ascii "$1" | od -An -v -t u1); do
         for char in $(printf "%s" "1234567890123456789" | grep -o .); do
             decimal_char="$(printf "%02d" "'$char'")"
@@ -158,6 +161,7 @@ decrypt_allanime() {
         #shellcheck disable=SC2059
         printf "\\$(printf "%03o" "$result")"
     done
+    printf "%s" "$-" | grep -q 'x' || set +x
 }
 
 # generates links based on given provider

--- a/ani-cli
+++ b/ani-cli
@@ -106,7 +106,7 @@ dep_ch() {
 
 # extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
 get_links() {
-    episode_link="$(curl -e "https://allanime.to" -s --cipher "AES256-SHA256" "https://embed.ssbcontent.site$*" -A "$agent" | sed 's|},{|\n|g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
+    episode_link="$(curl -e "$allanime_base" -s --cipher "AES256-SHA256" "https://embed.ssbcontent.site$*" -A "$agent" | sed 's|},{|\n|g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
     case "$episode_link" in
         *repackager.wixmp.com*)
             extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
@@ -120,7 +120,7 @@ get_links() {
             else
                 extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
                 relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
-                curl -e "https://allanime.to/" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
+                curl -e "$allanime_base" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
             fi
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
@@ -176,7 +176,7 @@ get_episode_url() {
     # get the embed urls of the selected episode
     episode_embed_gql="query (\$showId: String!, \$translationType: VaildTranslationTypeEnumType!, \$episodeString: String!) {    episode(        showId: \$showId        translationType: \$translationType        episodeString: \$episodeString    ) {        episodeString sourceUrls    }}"
 
-    resp=$(curl -e "https://allanime.to" -s --cipher "AES256-SHA256" -G "https://${allanime_base}/api" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"##([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    resp=$(curl -e "$allanime_base" -s --cipher "AES256-SHA256" -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"##([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     provider=1
     i=0
@@ -197,14 +197,14 @@ get_episode_url() {
 search_anime() {
     search_gql="query(        \$search: SearchInput        \$limit: Int        \$page: Int        \$translationType: VaildTranslationTypeEnumType        \$countryOrigin: VaildCountryOriginEnumType    ) {    shows(        search: \$search        limit: \$limit        page: \$page        translationType: \$translationType        countryOrigin: \$countryOrigin    ) {        edges {            _id name availableEpisodes __typename       }    }}"
 
-    curl -e "https://allanime.to" -s --cipher "AES256-SHA256" -G "https://${allanime_base}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
+    curl -e "$allanime_base" -s --cipher "AES256-SHA256" -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
 # get the episodes list of the selected anime
 episodes_list() {
     episodes_list_gql="query (\$showId: String!) {    show(        _id: \$showId    ) {        _id availableEpisodesDetail    }}"
 
-    curl -e "https://allanime.to" -s --cipher AES256-SHA256 -G "https://${allanime_base}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
+    curl -e "$allanime_base" -s --cipher AES256-SHA256 -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 
 # PLAYING
@@ -298,7 +298,8 @@ play() {
 
 # setup
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
-allanime_base="api.allanime.day"
+allanime_base="https://allanime.to"
+allanime_api="https://api.allanime.day"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"

--- a/ani-cli
+++ b/ani-cli
@@ -147,7 +147,7 @@ hex_to_ascii() {
         printf "\\$oct"
         i=$((i + 2))
     done
-    printf "%s" "$-" | grep -q 'x' || set -x
+    printf "%s" "$-" | grep -q 'x' && set +x || set -x
 }
 
 decrypt_allanime() {
@@ -161,7 +161,7 @@ decrypt_allanime() {
         #shellcheck disable=SC2059
         printf "\\$(printf "%03o" "$result")"
     done
-    printf "%s" "$-" | grep -q 'x' || set +x
+    printf "%s" "$-" | grep -q 'x' && set +x || set -x
 }
 
 # generates links based on given provider
@@ -389,7 +389,7 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
-printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
+printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m"
 dep_ch "curl" "sed" "grep" "fzf" || true
 case "$player_function" in
     debug) ;;
@@ -398,10 +398,11 @@ case "$player_function" in
         dep_ch "flatpak"
         flatpak info io.mpv.Mpv >/dev/null 2>&1 || die "Program \"mpv (flatpak)\" not found. Please install it."
         ;;
-    android*) printf "Checking of players on Android is disabled\n" ;;
-    *iSH*) printf "Checking of players on iOS is disabled\n" ;;
+    android*) printf "\33[2K\rChecking of players on Android is disabled" ;;
+    *iSH*) printf "\33[2K\rChecking of players on iOS is disabled" ;;
     *) dep_ch "$player_function" ;;
 esac
+printf "\n"
 
 # searching
 case "$search" in

--- a/ani-cli
+++ b/ani-cli
@@ -322,10 +322,10 @@ use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 cache_dir="${ANI_CLI_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli}"
-if [ ! -d "$cache_dir" ];then
-	mkdir -p "$cache_dir"
+if [ ! -d "$cache_dir" ]; then
+    mkdir -p "$cache_dir"
 else
-	rm -f "$cache_dir/*"
+    rm -f "$cache_dir/*"
 fi
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
@@ -387,7 +387,7 @@ printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m"
 dep_ch "curl" "sed" "grep" "fzf" || true
 case "$player_function" in
     debug) ;;
-    download) 	dep_ch "ffmpeg" "aria2c" ;;
+    download) dep_ch "ffmpeg" "aria2c" ;;
     flatpak*)
         dep_ch "flatpak"
         flatpak info io.mpv.Mpv >/dev/null 2>&1 || die "Program \"mpv (flatpak)\" not found. Please install it."

--- a/ani-cli
+++ b/ani-cli
@@ -229,7 +229,7 @@ download() {
     case $1 in
         *m3u8*)
             if command -v "yt-dlp" >/dev/null; then
-                yt-dlp "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
+                yt-dlp "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 --paths "$download_dir" --paths temp: "${HOME}/.cache/yt-dlp-temp" --output "$2.mp4"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.4.5"
+version_number="4.4.6"
 
 # UI
 
@@ -135,31 +135,29 @@ provider_init() {
 }
 
 hex_to_ascii() {
-	hex="$1"
-	len=$(echo "$hex" | awk '{print length}')
-	i=1
-	while [ "$i" -le "$len" ]; do
-	  char=$(echo "$hex" | cut -c "$i-$((i+1))")
-	  dec=$(printf "%d" "0x$char")
-	  oct=$(printf "%03o" "$dec")
-	  #shellcheck disable=SC2059
-	  printf "\\$oct"
-	  i=$((i + 2))
-	done
+    hex="$1"
+    len=$(echo "$hex" | awk '{print length}')
+    i=1
+    while [ "$i" -le "$len" ]; do
+        char=$(echo "$hex" | cut -c "$i-$((i + 1))")
+        dec=$(printf "%d" "0x$char")
+        oct=$(printf "%03o" "$dec")
+        #shellcheck disable=SC2059
+        printf "\\$oct"
+        i=$((i + 2))
+    done
 }
 
 decrypt_allanime() {
-	for result in $(hex_to_ascii "$1" | od -An -v -t u1)
-	do
-		for char in $(printf "%s" "1234567890123456789" | grep -o .)
-		do
-			decimal_char="$(printf "%02d" "'$char'")"
-			: $((result ^= decimal_char))
-		done
+    for result in $(hex_to_ascii "$1" | od -An -v -t u1); do
+        for char in $(printf "%s" "1234567890123456789" | grep -o .); do
+            decimal_char="$(printf "%02d" "'$char'")"
+            : $((result ^= decimal_char))
+        done
 
-		#shellcheck disable=SC2059
-		printf "\\$(printf "%03o" "$result")"
-	done
+        #shellcheck disable=SC2059
+        printf "\\$(printf "%03o" "$result")"
+    done
 }
 
 # generates links based on given provider
@@ -173,7 +171,6 @@ generate_link() {
         *) provider_init "gogoanime" "/Luf-mp4 :/p" ;; # gogoanime(m3u8)(multi)
     esac
     bin=$(decrypt_allanime "$provider_id" | tr -d ':')
-    printf '\n%s\n' "$bin" >> x
     provider_id="$(printf "%s" "$bin" | sed "s/\/clock/\/clock\.json/")"
     [ -n "$provider_id" ] && get_links "$provider_id"
 }
@@ -194,7 +191,6 @@ get_episode_url() {
     episode_embed_gql="query (\$showId: String!, \$translationType: VaildTranslationTypeEnumType!, \$episodeString: String!) {    episode(        showId: \$showId        translationType: \$translationType        episodeString: \$episodeString    ) {        episodeString sourceUrls    }}"
 
     resp=$(curl -e "https://allanime.to" -s --cipher "AES256-SHA256" -G "https://${allanime_base}/api" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"##([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
-    printf '%s' "$resp" > y
     # generate links into sequential files
     provider=1
     i=0

--- a/ani-cli
+++ b/ani-cli
@@ -136,7 +136,7 @@ provider_init() {
 
 hex_to_ascii() {
     hex="$1"
-    len=$(echo "$hex" | awk '{print length}')
+    len="${#hex}"
     i=1
     while [ "$i" -le "$len" ]; do
         char=$(echo "$hex" | cut -c "$i-$((i + 1))")

--- a/ani-cli
+++ b/ani-cli
@@ -291,7 +291,7 @@ play() {
         play_episode
     fi
     # moves upto stored positon and deletes to end
-    tput rc && tput ed
+    [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && tput rc && tput ed
 }
 
 # MAIN

--- a/ani-cli
+++ b/ani-cli
@@ -106,7 +106,7 @@ dep_ch() {
 
 # extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
 get_links() {
-    episode_link="$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" "https://allanimenews.com$*" -A "$agent" | sed 's|},{|\n|g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
+    episode_link="$(curl -e "https://allanime.to" -s --cipher "AES256-SHA256" "https://embed.ssbcontent.site$*" -A "$agent" | sed 's|},{|\n|g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
     case "$episode_link" in
         *repackager.wixmp.com*)
             extract_link=$(printf "%s" "$episode_link" | cut -d'>' -f2 | sed 's|repackager.wixmp.com/||g;s|\.urlset.*||g')
@@ -120,7 +120,7 @@ get_links() {
             else
                 extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
                 relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
-                curl -e "https://${allanime_base}/" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
+                curl -e "https://allanime.to/" -s --cipher "AES256-SHA256" "$extract_link" -A "$agent" | sed 's|^#.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|' | sed "s|>|>${relative_link}|g" | sort -nr
             fi
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
@@ -135,19 +135,31 @@ provider_init() {
 }
 
 hex_to_ascii() {
-    hex="$1"
-    len=$(printf "%s" "$hex" | wc -c)
-    ascii=""
-    i=1
-    while [ "$i" -lt "$len" ]; do
-        char=$(printf "%s" "$hex" | cut -c "$i-$((i + 1))")
-        dec=$(printf "%d" "0x$char")
-        oct=$(printf "%03o" "$dec")
-        # shellcheck disable=SC2059
-        ascii="$ascii$(printf "\\$oct")"
-        i=$((i + 2))
-    done
-    printf "%s" "$ascii"
+	hex="$1"
+	len=$(echo "$hex" | awk '{print length}')
+	i=1
+	while [ "$i" -le "$len" ]; do
+	  char=$(echo "$hex" | cut -c "$i-$((i+1))")
+	  dec=$(printf "%d" "0x$char")
+	  oct=$(printf "%03o" "$dec")
+	  #shellcheck disable=SC2059
+	  printf "\\$oct"
+	  i=$((i + 2))
+	done
+}
+
+decrypt_allanime() {
+	for result in $(hex_to_ascii "$1" | od -An -v -t u1)
+	do
+		for char in $(printf "%s" "1234567890123456789" | grep -o .)
+		do
+			decimal_char="$(printf "%02d" "'$char'")"
+			: $((result ^= decimal_char))
+		done
+
+		#shellcheck disable=SC2059
+		printf "\\$(printf "%03o" "$result")"
+	done
 }
 
 # generates links based on given provider
@@ -160,7 +172,8 @@ generate_link() {
         5) provider_init "sharepoint" "/S-mp4 :/p" ;;  # sharepoint(mp4)(single)
         *) provider_init "gogoanime" "/Luf-mp4 :/p" ;; # gogoanime(m3u8)(multi)
     esac
-    bin=$(hex_to_ascii "$provider_id")
+    bin=$(decrypt_allanime "$provider_id" | tr -d ':')
+    printf '\n%s\n' "$bin" >> x
     provider_id="$(printf "%s" "$bin" | sed "s/\/clock/\/clock\.json/")"
     [ -n "$provider_id" ] && get_links "$provider_id"
 }
@@ -180,7 +193,8 @@ get_episode_url() {
     # get the embed urls of the selected episode
     episode_embed_gql="query (\$showId: String!, \$translationType: VaildTranslationTypeEnumType!, \$episodeString: String!) {    episode(        showId: \$showId        translationType: \$translationType        episodeString: \$episodeString    ) {        episodeString sourceUrls    }}"
 
-    resp=$(curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"#([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    resp=$(curl -e "https://allanime.to" -s --cipher "AES256-SHA256" -G "https://${allanime_base}/api" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"##([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    printf '%s' "$resp" > y
     # generate links into sequential files
     provider=1
     i=0
@@ -200,14 +214,14 @@ get_episode_url() {
 search_anime() {
     search_gql="query(        \$search: SearchInput        \$limit: Int        \$page: Int        \$translationType: VaildTranslationTypeEnumType        \$countryOrigin: VaildCountryOriginEnumType    ) {    shows(        search: \$search        limit: \$limit        page: \$page        translationType: \$translationType        countryOrigin: \$countryOrigin    ) {        edges {            _id name availableEpisodes __typename       }    }}"
 
-    curl -e "https://${allanime_base}" -s --cipher "AES256-SHA256" -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
+    curl -e "https://allanime.to" -s --cipher "AES256-SHA256" -G "https://${allanime_base}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1\t\2 (\3 episodes)|p"
 }
 
 # get the episodes list of the selected anime
 episodes_list() {
     episodes_list_gql="query (\$showId: String!) {    show(        _id: \$showId    ) {        _id availableEpisodesDetail    }}"
 
-    curl -e "https://${allanime_base}" -s --cipher AES256-SHA256 -G "https://api.${allanime_base}/allanimeapi" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
+    curl -e "https://allanime.to" -s --cipher AES256-SHA256 -G "https://${allanime_base}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\n|g; s|"||g' | sort -n -k 1
 }
 
 # PLAYING
@@ -299,7 +313,7 @@ play() {
 
 # setup
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
-allanime_base="allanime.to"
+allanime_base="api.allanime.day"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"

--- a/ani-cli
+++ b/ani-cli
@@ -164,8 +164,7 @@ generate_link() {
         5) provider_init "sharepoint" "/S-mp4 :/p" ;;  # sharepoint(mp4)(single)
         *) provider_init "gogoanime" "/Luf-mp4 :/p" ;; # gogoanime(m3u8)(multi)
     esac
-    bin=$(decrypt_allanime "$provider_id" | tr -d ':')
-    provider_id="$(printf "%s" "$bin" | sed "s/\/clock/\/clock\.json/")"
+    provider_id="$(decrypt_allanime "$provider_id" | sed "s/\/clock/\/clock\.json/")"
     [ -n "$provider_id" ] && get_links "$provider_id"
 }
 

--- a/ani-cli
+++ b/ani-cli
@@ -135,11 +135,11 @@ provider_init() {
 }
 
 bypass_debug() {
-	if printf "%s" "$-" | grep -q 'x';then
-		set +x
-	elif [ "$1" -eq "0" ];then
-		set -x
-	fi
+    if printf "%s" "$-" | grep -q 'x'; then
+        set +x
+    elif [ "$1" -eq "0" ]; then
+        set -x
+    fi
 }
 
 hex_to_ascii() {

--- a/ani-cli
+++ b/ani-cli
@@ -188,7 +188,7 @@ get_episode_url() {
     # generate links into sequential files
     provider=1
     i=0
-    rm "$cache_dir/*"
+    rm -f "$cache_dir/*"
     while [ "$i" -lt 6 ]; do
         generate_link "$provider" >"$cache_dir"/"$i" &
         provider=$((provider % 6 + 1))

--- a/ani-cli
+++ b/ani-cli
@@ -290,6 +290,7 @@ play() {
     else
         play_episode
     fi
+    # moves upto stored positon and deletes to end
     tput rc && tput ed
 }
 
@@ -405,7 +406,6 @@ case "$search" in
         ep_list=$(episodes_list "$id")
         ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | tr 'A-Z ' 'a-z-')"
-        tput cuu1 && tput el
         ;;
     *)
         if [ "$use_external_menu" = "0" ]; then
@@ -433,6 +433,7 @@ esac
 
 # moves the cursor up one line and clears that line
 tput cuu1 && tput el
+# stores the positon of cursor
 tput sc
 
 # playback & loop

--- a/ani-cli
+++ b/ani-cli
@@ -134,16 +134,8 @@ provider_init() {
     provider_id=$(printf "%s" "$resp" | sed -n "$2" | head -1 | cut -d':' -f2)
 }
 
-bypass_debug() {
-    if printf "%s" "$-" | grep -q 'x'; then
-        set +x
-    elif [ "$1" -eq "0" ]; then
-        set -x
-    fi
-}
-
 decrypt_allanime() {
-    bypass_debug "1"
+    printf "%s" "$-" | grep -q 'x' && set +x
     for hex in $(printf '%s' "$1" | sed 's/../&\n/g'); do
         dec=$(printf '%d' "0x$hex")
         xor=$((dec ^ 48))
@@ -151,7 +143,7 @@ decrypt_allanime() {
         #shellcheck disable=SC2059
         printf "\\$oct"
     done
-    bypass_debug "0"
+    printf "%s" "$-" | grep -q 'x' || set -x
 }
 
 # generates links based on given provider


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
