### PR TITLE
fix: ani-cli cache_dir via mktemp (#1178, #1173)

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.5.1"
+version_number="4.5.2"
 
 # UI
 
@@ -179,7 +179,7 @@ get_episode_url() {
     # generate links into sequential files
     provider=1
     i=0
-    rm -f "$cache_dir/*"
+    cache_dir="$(mktemp --tmpdir -d tmp.ani-cli.XXXX)"
     while [ "$i" -lt 6 ]; do
         generate_link "$provider" >"$cache_dir"/"$i" &
         provider=$((provider % 6 + 1))
@@ -188,6 +188,7 @@ get_episode_url() {
     wait
     # select the link with matching quality
     links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g' | sort -g -r -s)
+    rm -r "$cache_dir"
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"
 }
@@ -316,8 +317,6 @@ use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 [ -t 0 ] || use_external_menu=1
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
-cache_dir="${ANI_CLI_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli}"
-[ ! -d "$cache_dir" ] && mkdir -p "$cache_dir"
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"

--- a/ani-cli
+++ b/ani-cli
@@ -179,15 +179,16 @@ get_episode_url() {
     # generate links into sequential files
     provider=1
     i=0
-    cache_links=""
-    while [ "$provider" -lt 7 ]; do
-        tmp99=$(generate_link "$provider")
-        cache_links=$(printf "%s\n%s" "$cache_links" "$tmp99")
+    cache_dir="$(mktemp --tmpdir -d tmp.ani-cli.XXXX)"
+    while [ "$i" -lt 6 ]; do
+        generate_link "$provider" >"$cache_dir"/"$i" &
         provider=$((provider % 6 + 1))
+        : $((i += 1))
     done
     wait
     # select the link with matching quality
-    links=$(printf "$cache_links" | sed 's|^Mp4-||g' | sort -g -r -s)
+    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g' | sort -g -r -s)
+    rm -r "$cache_dir"
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"
 }

--- a/ani-cli
+++ b/ani-cli
@@ -179,16 +179,15 @@ get_episode_url() {
     # generate links into sequential files
     provider=1
     i=0
-    cache_dir="$(mktemp --tmpdir -d tmp.ani-cli.XXXX)"
-    while [ "$i" -lt 6 ]; do
-        generate_link "$provider" >"$cache_dir"/"$i" &
+    cache_links=""
+    while [ "$provider" -lt 7 ]; do
+        tmp99=$(generate_link "$provider")
+        cache_links=$(printf "%s\n%s" "$cache_links" "$tmp99")
         provider=$((provider % 6 + 1))
-        : $((i += 1))
     done
     wait
     # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g' | sort -g -r -s)
-    rm -r "$cache_dir"
+    links=$(printf "$cache_links" | sed 's|^Mp4-||g' | sort -g -r -s)
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"
 }

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -78,9 +78,6 @@ Controls the frontend of ani-cli. Can be 0 (uses fzf) or 1 (uses rofi dmenu). De
 \fBANI_CLI_MULTI_SELECTION\fR
 Controls the multi flag for the chosen frontend. Default is -m for fzf and --multi-select for rofi dmenu.
 .TP
-\fBANI_CLI_CACHE_DIR\fR
-Controls the directory ani-cli uses for caching results. A /ani-cli subfolder is created there for the cache files if doesn't exists. Default is $XDG_CACHE_HOME if set, $HOME/.cache/ if not.
-.TP
 \fBANI_CLI_HIST_DIR\fR
 Controls the directory ani-cli uses for storing history. A /ani-cli subfolder is created there for the histfile if doesn't exists. Default is $XDG_STATE_HOME if set, $HOME/.local/state if not.
 .TP


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix

## Description

Our use of `cache_dir` didn't actually resemble cache in the traditional sense.
Cache would refer to semi-persistent storage that is reused between application runs.
In our use, we overwrote it on every run, making it working memory.
As such, it belongs in ram.

Ideally we can just concatenate right away.

This should fix #1178 and #1173, tho concatenation would be a more direct fix.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
