### PR TITLE
refactor: mktemp POSIX violation

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.5.2"
+version_number="4.5.3"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -179,7 +179,7 @@ get_episode_url() {
     # generate links into sequential files
     provider=1
     i=0
-    cache_dir="$(mktemp --tmpdir -d tmp.ani-cli.XXXX)"
+    cache_dir="$(mktemp -d)"
     while [ "$i" -lt 6 ]; do
         generate_link "$provider" >"$cache_dir"/"$i" &
         provider=$((provider % 6 + 1))


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
