### PR TITLE
feat: add rofi flag

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.5.3"
+version_number="4.5.4"
 
 # UI
 
@@ -60,7 +60,9 @@ help_info() {
       -e, --episode, -r, --range
         Specify the number of episodes to watch
       --dub
-        play dubbed version
+        Play dubbed version
+      -- rofi
+        Use rofi instead of fzf for the interactive menu
       -U, --update
         Update the script
       -N, --non-interactive
@@ -180,10 +182,10 @@ get_episode_url() {
     provider=1
     i=0
     cache_dir="$(mktemp -d)"
-    while [ "$i" -lt 6 ]; do
+    providers="1 2 3 4 5 6"
+    for provider in $providers; do
         generate_link "$provider" >"$cache_dir"/"$i" &
         provider=$((provider % 6 + 1))
-        : $((i += 1))
     done
     wait
     # select the link with matching quality
@@ -368,6 +370,7 @@ while [ $# -gt 0 ]; do
             ;;
         -N | --non-interactive) no_menu=1 ;;
         --dub) mode="dub" ;;
+        --rofi) use_external_menu=1 ;;
         -U | --update) update_script ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
     esac
@@ -408,7 +411,7 @@ case "$search" in
                 printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
             done
         else
-            query=$(printf "" | external_menu "" "Search anime: ")
+            [ -z "$query" ] && query=$(printf "" | external_menu "" "Search anime: ")
             [ -z "$query" ] && exit 1
         fi
         query=$(printf "%s" "$query" | sed "s| |+|g")

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -54,6 +54,9 @@ Selects nth entry.
 .TP
 \fB\--dub\fR
 Play the dubbed version. Without this flag, it'll always play the subbed version.
+.TP
+\fB\--rofi\fR
+Use rofi instead of fzf for the interactive menu 
 .PP
 .SH
 ENVIRONMENT VARIABLES


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
