### PR TITLE
feat: add support for windows wsl2

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,22 +192,6 @@ Note that curl can cause issues.
 ani-cli has been tested unsuccessfully with curl `7.83.1` and successfully with `7.86.0`.
 If you run into issues, try the scoop install or grab the newest curl you can find.
 
-### Windows WSL2
-
-#### Linux Part:
-
-Follow the Linux section and install from source.
-
-#### Windows Terminal Part:
-
-Ensure mpv is installed on Windows. When you type mpv.exe in the terminal, it should open an mpv window. 
-
-Simplest way to do it is:
-
-```sh
-winget install mpv
-```
-
 ### Android
 
 Install termux [(Guide)](https://termux.com/)

--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ Note that curl can cause issues.
 ani-cli has been tested unsuccessfully with curl `7.83.1` and successfully with `7.86.0`.
 If you run into issues, try the scoop install or grab the newest curl you can find.
 
+### Windows WSL2
+
+#### Linux Part:
+
+Follow the Linux section and install from source.
+
+#### Windows Terminal Part:
+
+Ensure mpv is installed on Windows. When you type mpv.exe in the terminal, it should open an mpv window. 
+
+Simplest way to do it is:
+
+```sh
+winget install mpv
+```
+
 ### Android
 
 Install termux [(Guide)](https://termux.com/)

--- a/ani-cli
+++ b/ani-cli
@@ -310,9 +310,8 @@ case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;           # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;    # Android OS (termux)
     *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;; # steamdeck OS
-    *MINGW*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;         # Windows OS
+    *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;         # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;               # iOS (iSH)
-    *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;          # Windows wsl2
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                   # Linux OS
 esac
 
@@ -331,7 +330,7 @@ while [ $# -gt 0 ]; do
         -v | --vlc)
             case "$(uname -a)" in
                 *ndroid*) player_function="android_vlc" ;;
-                MINGW*) player_function="vlc.exe" ;;
+                MINGW* | *WSL2*) player_function="vlc.exe" ;;
                 *ish*) player_function="iSH" ;;
                 *) player_function="vlc" ;;
             esac

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.5.4"
+version_number="4.5.5"
 
 # UI
 
@@ -307,12 +307,12 @@ download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
 no_menu=0
 case "$(uname -a)" in
-    *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;           # mac OS
-    *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;    # Android OS (termux)
-    *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;; # steamdeck OS
-    *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;         # Windows OS
-    *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;               # iOS (iSH)
-    *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                   # Linux OS
+    *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
+    *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
+    *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;  # steamdeck OS
+    *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
+    *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
+    *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                    # Linux OS
 esac
 
 use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"

--- a/ani-cli
+++ b/ani-cli
@@ -312,6 +312,7 @@ case "$(uname -a)" in
     *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;; # steamdeck OS
     *MINGW*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;         # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;               # iOS (iSH)
+    *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;;          # Windows wsl2
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                   # Linux OS
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -255,6 +255,11 @@ play_episode() {
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        /mnt/c/*)
+            cd "/mnt/c/Program Files (x86)/Syncplay" || return 1 # cannot use fullpath and set title in wsl2
+            nohup cmd.exe /C "syncplay.exe" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 &
+            cd - || return 1
+            ;;
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
@@ -345,7 +350,16 @@ while [ $# -gt 0 ]; do
                     export PATH="$PATH":"/c/Program Files (x86)/Syncplay/"
                     player_function="syncplay.exe"
                     ;;
-                *) player_function="syncplay" ;;
+                *)
+                    case "$(uname -r)" in
+                        *WSL2*)
+                            player_function="/mnt/c/Program Files (x86)/Syncplay/syncplay.exe"
+                            ;;
+                        *)
+                            player_function="syncplay"
+                            ;;
+                    esac
+                    ;;
             esac
             ;;
         -q | --quality)

--- a/ani-cli
+++ b/ani-cli
@@ -255,11 +255,6 @@ play_episode() {
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
-        /mnt/c/*)
-            cd "/mnt/c/Program Files (x86)/Syncplay" || return 1 # cannot use fullpath and set title in wsl2
-            nohup cmd.exe /C "syncplay.exe" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 &
-            cd - || return 1
-            ;;
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
@@ -350,16 +345,7 @@ while [ $# -gt 0 ]; do
                     export PATH="$PATH":"/c/Program Files (x86)/Syncplay/"
                     player_function="syncplay.exe"
                     ;;
-                *)
-                    case "$(uname -r)" in
-                        *WSL2*)
-                            player_function="/mnt/c/Program Files (x86)/Syncplay/syncplay.exe"
-                            ;;
-                        *)
-                            player_function="syncplay"
-                            ;;
-                    esac
-                    ;;
+                *) player_function="syncplay" ;;
             esac
             ;;
         -q | --quality)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.5.5"
+version_number="4.5.6"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description
This update provides a simpler method for Windows users to use the application when utilizing WSL2. 
A current issue exists with syncplay. It does not work correctly. Simple way to reproduce it is to run it from WSL2 using:
```sh
"/mnt/c/Program Files (x86)/Syncplay/syncplay.exe"
```
It silently fails if a URL is specified(even during runtime), causing the window to close unexpectedly. A workaround for this is: (**not currently applied**)
```sh
cmd.exe /C "C:\Program Files (x86)\Syncplay\syncplay.exe" "$URL"
```
Moreover, using uname -s to switch cases for syncplay is insufficient and requires modification.
```sh
-s | --syncplay)
            case "$(uname -s)" in
                Darwin*) player_function="/Applications/Syncplay.app/Contents/MacOS/syncplay" ;;
                MINGW* | *Msys)
                    export PATH="$PATH":"/c/Program Files (x86)/Syncplay/"
                    player_function="syncplay.exe"
                    ;;
                *) case "$(uname -r)" in
                    *WSL2*)
                        export PATH="$PATH:/mnt/c/Program Files (x86)/Syncplay/"
                        player_function="syncplay.exe"
                        ;;
                    *)
                        player_function="syncplay"
                        ;;
                esac

                ;; 
            esac
            ;;
 ```
The checks I've confirmed manually are already marked. Other checks, not yet verified, should function correctly given that only the display program is being modified. I will complete the rest after resolving the **syncplay** issue.
## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
