### PR TITLE
refactor: remove -N flag in favor of -S + -e detection

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,6 @@
 
 version_number="4.5.7"
 
-
 # UI
 
 external_menu() {

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.5.5"
+version_number="4.5.7"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -65,8 +65,6 @@ help_info() {
         Use rofi instead of fzf for the interactive menu
       -U, --update
         Update the script
-      -N, --non-interactive
-        Disable the interactive menu
     Some example usages:
       %s -q 720p banana fish
       %s -d -e 2 cyberpunk edgerunners
@@ -267,10 +265,6 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
-    if [ "$no_menu" -eq 1 ]; then
-        printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no of $title"
-        exit 0
-    fi
     [ "$use_external_menu" = "1" ] && wait
 }
 
@@ -308,7 +302,6 @@ allanime_api="https://api.allanime.day"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
-no_menu=0
 case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;           # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;    # Android OS (termux)
@@ -372,7 +365,6 @@ while [ $# -gt 0 ]; do
             [ -n "$index" ] && ANI_CLI_NON_INTERACTIVE=1 #Checks for -S presence
             shift
             ;;
-        -N | --non-interactive) no_menu=1 ;;
         --dub) mode="dub" ;;
         --rofi) use_external_menu=1 ;;
         -U | --update) update_script ;;


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Refactor

## Description

Eliminated dead code

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
