### PR TITLE
refactor: add N_m3u8DL-RE

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -224,8 +224,8 @@ update_history() {
 download() {
     case $1 in
         *m3u8*)
-            if command -v "streamlink" >/dev/null; then
-                streamlink --stream-segment-threads 5 -o "$download_dir/$2.mp4" "$1" best
+            if command -v "N_m3u8DL-RE" >/dev/null; then
+                N_m3u8DL-RE --log-level ERROR --thread-count 10 --download-retry-count 10 "$1" --save-dir "$download_dir" --save-name "$2"
             elif command -v "yt-dlp" >/dev/null; then
                 yt-dlp "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
             else

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.6.1"
+version_number="4.6.2"
 
 # UI
 
@@ -224,7 +224,9 @@ update_history() {
 download() {
     case $1 in
         *m3u8*)
-            if command -v "yt-dlp" >/dev/null; then
+            if command -v "streamlink" >/dev/null; then
+                streamlink --stream-segment-threads 5 -o "$download_dir/$2.mp4" "$1" best
+            elif command -v "yt-dlp" >/dev/null; then
                 yt-dlp "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
