### PR TITLE
Episode timestamp tracking script which also picks where left off & removes episodes from tracker file when completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Install [HomeBrew](https://docs.brew.sh/Installation) if not installed.
 git clone "https://github.com/pystardust/ani-cli.git" && cd ./ani-cli
 cp ./ani-cli "$(brew --prefix)"/bin
 cd .. && rm -rf ./ani-cli
+
 ```
 
 *To install (with Homebrew) the dependencies required on Mac OS, you can run:*
@@ -314,6 +315,8 @@ Install dependencies [(See below)](#dependencies-1)
 ```sh
 git clone "https://github.com/pystardust/ani-cli.git"
 sudo cp ani-cli/ani-cli /usr/local/bin
+mkdir "${HOME}/.config/ani-cli"
+cp -rfv ani-cli/scripts "${HOME}/.config/ani-cli"
 rm -rf ani-cli
 ```
 

--- a/ani-cli
+++ b/ani-cli
@@ -264,7 +264,8 @@ play_episode() {
             printf "%s\n" "$episode"
             ;;
 
-        mpv*) nohup "$player_function" --script="$HOME/.config/ani-cli/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        mpv*) "$player_function" --script="${PWD}/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" ;;
+        # mpv*) nohup "$player_function" --script="${PWD}/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         # mpv*) nohup "$player_function" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -264,7 +264,7 @@ play_episode() {
             printf "%s\n" "$episode"
             ;;
 
-        mpv*) "$player_function" --script="${PWD}/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" ;;
+        mpv*) nohup "$player_function" --script="${HOME}/.config/ani-cli/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         # mpv*) nohup "$player_function" --script="${PWD}/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         # mpv*) nohup "$player_function" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -5,7 +5,7 @@ version_number="4.6.1"
 # directory for anime episode timestamp files
 
 # directory to store files named as anime titles with episodes mapped with time left on it
-ep_timestamp_dir="${HOME}/.local/state/ani-cli/ani-eps-hsts/" 
+ep_timestamp_dir="${HOME}/.local/state/ani-cli/ani-eps-hsts/"
 
 # mpv lua script for ani-cli that keeps track of episodes
 ani_cli_scripts_dir="${HOME}/.config/ani-cli/scripts/"

--- a/ani-cli
+++ b/ani-cli
@@ -265,8 +265,6 @@ play_episode() {
             ;;
 
         mpv*) nohup "$player_function" --script="${HOME}/.config/ani-cli/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
-        # mpv*) nohup "$player_function" --script="${PWD}/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
-        # mpv*) nohup "$player_function" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -2,6 +2,26 @@
 
 version_number="4.6.1"
 
+# directory for anime episode timestamp files
+
+# directory to store files named as anime titles with episodes mapped with time left on it
+ep_timestamp_dir="${HOME}/.local/state/ani-cli/ani-eps-hsts/" 
+
+# mpv lua script for ani-cli that keeps track of episodes
+ani_cli_scripts_dir="${HOME}/.config/ani-cli/scripts/"
+for dir in $ep_timestamp_dir $ani_cli_scripts_dir
+do
+    [[ ! -e "$dir" ]] && mkdir -p "$dir"
+    if [[ ! -d "$dir" ]]
+    then
+        rm -rf "$dir"
+        mkdir -p "$dir"
+    fi
+done
+unset ep_timestamp_dir ani_cli_scripts_dir
+
+
+
 # UI
 
 external_menu() {
@@ -243,7 +263,9 @@ play_episode() {
             [ -z "$ANI_CLI_NON_INTERACTIVE" ] && printf "All links:\n%s\nSelected link:\n" "$links"
             printf "%s\n" "$episode"
             ;;
-        mpv*) nohup "$player_function" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+
+        mpv*) nohup "$player_function" --script="$HOME/.config/ani-cli/scripts/continue_ep.lua" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        # mpv*) nohup "$player_function" --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
@@ -302,7 +324,7 @@ case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
     *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;  # steamdeck OS
-    *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
+    *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}";; # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                    # Linux OS
 esac

--- a/scripts/continue_ep.lua
+++ b/scripts/continue_ep.lua
@@ -131,7 +131,6 @@ function AnimeEpTimestamp:WriteTimeStampOnQuit()
 
     local ep_found = 0
     for index in ipairs(self.content_table) do
-      print(self.content_table[index])
       if self.content_table[index]:match(self.anime_ep.." - ") then
 
         ep_found = 1

--- a/scripts/continue_ep.lua
+++ b/scripts/continue_ep.lua
@@ -120,36 +120,43 @@ end
 
 
 function AnimeEpTimestamp:WriteTimeStampOnQuit()
-  if #self.content_table == 0 then
-    self.content_table = { self.anime_ep.." - "..self.ep_timestamp }
+  if (self.ep_timestamp >= self.ep_duration_without_ed) and (#self.content_table == 0) then
+    os.remove(self.anime_ep_timestamp_file_path)
   end
 
-  local ep_found = 0
-  for index in ipairs(self.content_table) do
-    print(self.content_table[index])
-    if self.content_table[index]:match(self.anime_ep.." - ") then
-
-      ep_found = 1
-      if self.ep_timestamp >= self.ep_duration_without_ed then
-        table.remove(self.content_table, index)
-
-      elseif self.ep_timestamp < self.ep_duration_without_ed then
-        self.content_table[index] = self.anime_ep.." - "..self.ep_timestamp
-      end
-
-      break
+  if self.ep_timestamp <= self.ep_duration_without_ed then
+    if #self.content_table == 0 then
+      self.content_table = { self.anime_ep.." - "..self.ep_timestamp }
     end
-  end
 
-  if ep_found == 0 then
-    table.insert(self.content_table, self.anime_ep.." - "..self.ep_timestamp)
-  end
+    local ep_found = 0
+    for index in ipairs(self.content_table) do
+      print(self.content_table[index])
+      if self.content_table[index]:match(self.anime_ep.." - ") then
 
-  self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "w+"))
-  for index in ipairs(self.content_table) do
-    self.anime_ep_timestamp_file_obj:write(self.content_table[index].."\n")
+        ep_found = 1
+        if self.ep_timestamp >= self.ep_duration_without_ed then
+          table.remove(self.content_table, index)
+
+        elseif self.ep_timestamp < self.ep_duration_without_ed then
+          self.content_table[index] = self.anime_ep.." - "..self.ep_timestamp
+        end
+
+        break
+      end
+    end
+
+    if ep_found == 0 then
+      table.insert(self.content_table, self.anime_ep.." - "..self.ep_timestamp)
+    end
+
+    self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "w+"))
+    for index in ipairs(self.content_table) do
+      self.anime_ep_timestamp_file_obj:write(self.content_table[index].."\n")
+    end
+    self.anime_ep_timestamp_file_obj:close()
+
   end
-  self.anime_ep_timestamp_file_obj:close()
 
   -- AnimeEpTimestampObj:EditEpHistoryOnQuit()
 end

--- a/scripts/continue_ep.lua
+++ b/scripts/continue_ep.lua
@@ -1,0 +1,158 @@
+local mp = require("mp")
+local io = require("io")
+local os = require("os")
+local math = require("math")
+
+local ani_cli_state_dir = os.getenv("HOME").."/.local/state/ani-cli/"
+local anime_eps_history_file_loc = ani_cli_state_dir.."ani-eps-hsts/"
+local anime_tmp_history_file_loc = ani_cli_state_dir.."tmp/"
+
+AnimeEpTimestamp = {
+    media_title = "",
+    anime_name = "",
+    anime_ep = 0,
+    ep_timestamp = 0,
+    ep_duration_with_op_ed = 0,
+    ep_duration_without_op_ed = 0,
+    anime_ep_timestamp_file_path = "",
+}
+
+function AnimeEpTimestamp:new()
+    local obj = {}
+    setmetatable(obj, self)
+    self.__index = self
+
+    return obj
+end
+
+function AnimeEpTimestamp:GetProps()
+    -- get props from video
+    self.media_title = mp.get_property("media-title").." Episode 3"
+    self.anime_name = string.gsub(self.media_title, " [Ee]pisode [0-9]+", "")
+    self.anime_ep = string.gsub(self.media_title, ".*[Ee]pisode ", "")
+    self.ep_timestamp = math.floor(mp.get_property("time-pos"))
+    self.ep_duration_with_op_ed = math.floor(mp.get_property("duration"))
+    self.ep_duration_without_op_ed = self.ep_duration_with_op_ed - 90
+
+    -- string representing file locations
+    self.anime_ep_timestamp_file_path = ani_cli_state_dir.."ani-eps-hsts/"..self.anime_name
+    self.anime_ep_hist_file_path = ani_cli_state_dir.."ani-hsts"
+end
+
+function AnimeEpTimestamp:ShowDeets()
+  print("self.media_title ->",self.media_title)
+  print("self.anime_name ->",self.anime_name)
+  print("self.anime_ep ->",self.anime_ep)
+  print("self.anime_ep_timestamp_file ->",self.anime_ep_timestamp_file)
+  print("self.ep_timestamp ->",self.ep_timestamp)
+  print("self.ep_duration_with_op_ed ->",self.ep_duration_with_op_ed)
+  print("self.ep_duration_without_op_ed ->",self.ep_duration_without_op_ed)
+end
+
+
+
+function AnimeEpTimestamp:UpdateTimeStampVars()
+
+  if (mp.get_property("filename") == nil) or (self.ep_timestamp == nil ) then
+    return
+  end
+
+  while ((self.ep_timestamp <= self.ep_duration_with_op_ed) and
+         (mp.get_property_bool("pause") == false) and
+         (mp.get_property("time-pos") ~= nil))
+  do
+    print(self.ep_timestamp)
+    self.ep_timestamp = math.floor(mp.get_property("time-pos"))
+    os.execute("sleep 1")
+  end
+
+  while (mp.get_property_bool("pause", nil) == true) do
+    os.execute("sleep 1")
+  end
+  self:UpdateTimeStampVars()
+
+end
+
+
+
+function AnimeEpTimestamp:ReadFromTimeStampFile()
+  local anime_ep_timestamp_file_obj = io.open(self.anime_ep_timestamp_file_path, "a+")
+  -- ep_timestamp = io.open("timestamp_file", "r")[-1]
+  -- ep = ep_timestamp[1]
+  -- if ep == curr_ep
+  --  start_pos = ep_timestamp[1]
+  --  self.start_pos = start_pos
+  if anime_ep_timestamp_file_obj ~= nil then anime_ep_timestamp_file_obj:close() end
+end
+
+
+function ()
+end
+
+
+function AnimeEpTimestamp:edit_file_at_content_pos(f_path, line_pos, write_content)
+
+  local file_obj = assert(io.open(f_path, "a+"))
+  local curr_line_pos = 0 -- Start at the beginning of the file
+
+  for _ = 1, line_pos - 1 do
+      f_path:read("*line")
+      curr_line_pos = f_path:seek()
+  end
+
+  f_path:seek("set", curr_line_pos)
+  f_path:write(write_content)
+  file_obj:close()
+
+end
+
+
+function AnimeEpTimestamp:WriteTimeStampOnQuit()
+  -- self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "a+"))
+  -- self.anime_ep_timestamp_file_obj:write(self.anime_ep.." - "..self.ep_timestamp)
+  -- -- self.anime_ep in timestamp_file.readlines()
+  -- -- string.replace("self.anime_ep - self.anime_ep_timestamp", "self.anime_ep - self.curr_pos")
+  -- self.anime_ep_timestamp_file_obj:close()
+end
+
+
+function AnimeEpTimestamp:EditEpHistoryOnQuit()
+  print("string =>", self.anime_ep_hist_file_path)
+  local watch_hist_f_obj = assert(io.open(self.anime_ep_hist_file_path, "r+"))
+
+  -- ani_hsts replace & match regex
+  local ep_num_regex = "^%d+%.?%d*"
+  local anime_hash_regex = "%w+%s"
+  local total_eps_in_bracket = "%([0-9]+ episodes%)"
+  -- end of regex def.s
+
+  for i in watch_hist_f_obj:lines()
+  do
+    local anime_name = i:gsub(ep_num_regex.."%s", ""):gsub("^"..anime_hash_regex, ""):gsub(total_eps_in_bracket, "")
+    local anime_ep = i:match(ep_num_regex)
+    print(anime_name)
+  end
+  watch_hist_f_obj:close()
+end
+
+
+-- AnimeEpTimestampObj = {}
+AnimeEpTimestampObj = AnimeEpTimestamp:new()
+function Onload()
+  AnimeEpTimestampObj:GetProps()
+  AnimeEpTimestampObj:ShowDeets()
+  -- AnimeEpTimestampObj:ReadFromTimeStampFile()
+  -- AnimeEpTimestampObj:UpdateTimeStampVars()
+  -- AnimeEpTimestampObj:EditEpHistoryOnQuit()
+
+  -- write to file on shutdown
+  mp.register_event("shutdown", AnimeEpTimestampObj:WriteTimeStampOnQuit())
+end
+
+mp.set_property("save-position-on-quit", "yes")
+mp.set_property("watch-later-directory", "/home/blank/.local/state/ani-cli/watch_later_tmp/")
+-- mp.set_property("", "")
+
+mp.register_event("file-loaded", Onload)
+
+

--- a/scripts/continue_ep.lua
+++ b/scripts/continue_ep.lua
@@ -5,7 +5,6 @@ local math = require("math")
 
 local ani_cli_state_dir = os.getenv("HOME").."/.local/state/ani-cli/"
 local anime_eps_history_file_loc = ani_cli_state_dir.."ani-eps-hsts/"
-local anime_tmp_history_file_loc = ani_cli_state_dir.."tmp/"
 
 AnimeEpTimestamp = {
     media_title = "",
@@ -14,7 +13,9 @@ AnimeEpTimestamp = {
     ep_timestamp = 0,
     ep_duration_with_ed = 0,
     ep_duration_without_ed = 0,
+    ep_start_pos_timestamp = 0,
     anime_ep_timestamp_file_path = "",
+    content_table = { }
 }
 
 function AnimeEpTimestamp:new()
@@ -26,21 +27,39 @@ function AnimeEpTimestamp:new()
 end
 
 function AnimeEpTimestamp:GetProps()
-    -- get props from video
-    self.media_title = mp.get_property("media-title").." Episode 3"
-    self.anime_name = string.gsub(self.media_title, " [Ee]pisode [0-9]+", "")
-    self.anime_ep = string.gsub(self.media_title, ".*[Ee]pisode ", "")
-    -- self.ep_timestamp = math.floor(mp.get_property("time-pos"))
-    self.ep_duration_with_ed = math.floor(mp.get_property("duration"))
-    self.ep_duration_without_ed = self.ep_duration_with_ed - 60
+  -- get props from video
+  self.media_title = mp.get_property("media-title"):gsub(".mp4", "")
+  -- self.media_title = mp.get_property("media-title")
+  self.anime_name = string.gsub(self.media_title, " [Ee]pisode [0-9]+", "")
+  self.anime_ep = string.gsub(self.media_title, ".*[Ee]pisode ", "")
+  -- self.ep_timestamp = math.floor(mp.get_property("time-pos"))
+  self.ep_duration_with_ed = math.floor(mp.get_property("duration"))
+  self.ep_duration_without_ed = self.ep_duration_with_ed - 60
 
-    -- string representing file locations
-    self.anime_ep_timestamp_file_path = ani_cli_state_dir.."ani-eps-hsts/"..self.anime_name
-    self.anime_ep_hist_file_path = ani_cli_state_dir.."ani-hsts"
+  -- string representing file locations
+  self.anime_ep_timestamp_file_path = ani_cli_state_dir.."ani-eps-hsts/"..self.anime_name
+  self.anime_ep_hist_file_path = ani_cli_state_dir.."ani-hsts"
 
-    -- function to read from timestamp file
-    AnimeEpTimestamp:ReadFromTimeStampFile()
+  self.content_table = AnimeEpTimestampObj:ReadFromTimeStampFile()
+
+
+  if next(self.content_table) == nil then
+    print("shit")
+  end
+
+  if next(self.content_table) ~= nil then
+    for index in ipairs(self.content_table) do
+      if self.content_table[index]:match(self.anime_ep.." - ") then
+        self.ep_start_pos_timestamp = self.content_table[index]:gsub("^"..self.anime_ep.." %- ", "")
+        break
+      end
+    end
+  end
+
 end
+
+
+
 
 function AnimeEpTimestamp:ShowDeets()
   print("self.media_title ->",self.media_title)
@@ -56,6 +75,7 @@ end
 
 function AnimeEpTimestamp:UpdateTimeStampVars()
 
+  -- function to read from timestamp file
   if (mp.get_property("filename") == nil) or (self.ep_timestamp == nil ) then
     return
   end
@@ -80,55 +100,81 @@ end
 
 function AnimeEpTimestamp:ReadFromTimeStampFile()
   local anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "a+"))
-  local content_table = { }
 
   if anime_ep_timestamp_file_obj:read("l") == nil then
-    content_table = { self.anime_ep.." - "..self.ep_timestamp }
+    self.content_table = { self.anime_ep.." - "..self.ep_timestamp }
   end
 
-  -- if anime_ep_timestamp_file_obj:read("l") ~= nil then
-  --   for i in io.lines(self.anime_ep_timestamp_file_path) do
-  --    print(i)
-  --    content_table.insert(i)
-  --   end
-  -- end
-  --
-  -- anime_ep_timestamp_file_obj:close()
+  if anime_ep_timestamp_file_obj:read("l") ~= nil then
+    for i in io.lines(self.anime_ep_timestamp_file_path) do
+     table.insert(self.content_table, i)
+    end
+  end
 
-  return content_table
+  anime_ep_timestamp_file_obj:close()
+
+  return self.content_table
 end
 
 
 
 function AnimeEpTimestamp:WriteTimeStampOnQuit()
-  self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "a+"))
-  self.anime_ep_timestamp_file_obj:write(self.anime_ep.." - "..self.ep_timestamp.."\n")
-  -- self.anime_ep in timestamp_file.readlines()
-  -- string.replace("self.anime_ep - self.anime_ep_timestamp", "self.anime_ep - self.curr_pos")
+  if next(self.content_table) == nil then
+    self.content_table = { self.anime_ep.." - "..self.ep_timestamp }
+  end
+
+  if next(self.content_table) ~= nil then
+    for index in ipairs(self.content_table) do
+      if self.content_table[index]:match(self.anime_ep.." - ") then
+
+        if self.ep_timestamp >= self.ep_duration_without_ed then
+          table.remove(self.content_table, index)
+
+        elseif self.ep_timestamp < self.ep_duration_without_ed then
+          self.content_table[index] = self.anime_ep.." - "..self.ep_timestamp
+        end
+
+        break
+      end
+    end
+  end
+
+  self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "w+"))
+  for index in ipairs(self.content_table) do
+    self.anime_ep_timestamp_file_obj:write(self.content_table[index].."\n")
+  end
   self.anime_ep_timestamp_file_obj:close()
+
+  -- AnimeEpTimestampObj:EditEpHistoryOnQuit()
 end
 
 
 function AnimeEpTimestamp:EditEpHistoryOnQuit()
-  -- local watch_hist_f_obj = assert(io.open(self.anime_ep_hist_file_path, "r+"))
+  local ani_hsts_table = {}
+  print("mofo ==> ",self.anime_ep_hist_file_path)
+  for i in io.lines(self.anime_ep_hist_file_path) do
+    ani_hsts_table.insert(i)
+  end
 
-  -- -- ani_hsts replace & match regex
-  -- local ep_num_regex = "^%d+%.?%d*"
-  -- local anime_hash_regex = "%w+%s"
-  -- local total_eps_in_bracket = "%([0-9]+ episodes%)"
-  -- -- end of regex def.s
-
-  -- watch_hist_f_obj:close()
+  print("fuck")
+  for index in ipairs(ani_hsts_table) do
+    if ani_hsts_table[index]:match(self.anime_name) then
+      print(ani_hsts_table[index].." => subbing")
+      if self.ep_timestamp >= self.ep_duration_without_ed then
+        local curr_ep ani_hsts_table[index]:gsub("^%d+", self.anime_ep)
+        print(curr_ep)
+      end
+    end
+  end
 end
 
 
 AnimeEpTimestampObj = AnimeEpTimestamp:new()
 function Onload()
   AnimeEpTimestampObj:GetProps()
-  -- AnimeEpTimestampObj:ShowDeets()
-  AnimeEpTimestampObj:ReadFromTimeStampFile()
+  AnimeEpTimestampObj:ShowDeets()
+  mp.set_property("time-pos", AnimeEpTimestampObj.ep_start_pos_timestamp)
   AnimeEpTimestampObj:UpdateTimeStampVars()
-  -- AnimeEpTimestampObj:EditEpHistoryOnQuit()
 
   -- write to file on shutdown
   mp.register_event("shutdown", AnimeEpTimestampObj:WriteTimeStampOnQuit())

--- a/scripts/continue_ep.lua
+++ b/scripts/continue_ep.lua
@@ -12,8 +12,8 @@ AnimeEpTimestamp = {
     anime_name = "",
     anime_ep = 0,
     ep_timestamp = 0,
-    ep_duration_with_op_ed = 0,
-    ep_duration_without_op_ed = 0,
+    ep_duration_with_ed = 0,
+    ep_duration_without_ed = 0,
     anime_ep_timestamp_file_path = "",
 }
 
@@ -30,13 +30,16 @@ function AnimeEpTimestamp:GetProps()
     self.media_title = mp.get_property("media-title").." Episode 3"
     self.anime_name = string.gsub(self.media_title, " [Ee]pisode [0-9]+", "")
     self.anime_ep = string.gsub(self.media_title, ".*[Ee]pisode ", "")
-    self.ep_timestamp = math.floor(mp.get_property("time-pos"))
-    self.ep_duration_with_op_ed = math.floor(mp.get_property("duration"))
-    self.ep_duration_without_op_ed = self.ep_duration_with_op_ed - 90
+    -- self.ep_timestamp = math.floor(mp.get_property("time-pos"))
+    self.ep_duration_with_ed = math.floor(mp.get_property("duration"))
+    self.ep_duration_without_ed = self.ep_duration_with_ed - 60
 
     -- string representing file locations
     self.anime_ep_timestamp_file_path = ani_cli_state_dir.."ani-eps-hsts/"..self.anime_name
     self.anime_ep_hist_file_path = ani_cli_state_dir.."ani-hsts"
+
+    -- function to read from timestamp file
+    AnimeEpTimestamp:ReadFromTimeStampFile()
 end
 
 function AnimeEpTimestamp:ShowDeets()
@@ -45,8 +48,8 @@ function AnimeEpTimestamp:ShowDeets()
   print("self.anime_ep ->",self.anime_ep)
   print("self.anime_ep_timestamp_file ->",self.anime_ep_timestamp_file)
   print("self.ep_timestamp ->",self.ep_timestamp)
-  print("self.ep_duration_with_op_ed ->",self.ep_duration_with_op_ed)
-  print("self.ep_duration_without_op_ed ->",self.ep_duration_without_op_ed)
+  print("self.ep_duration_with_ed ->",self.ep_duration_with_ed)
+  print("self.ep_duration_without_ed ->",self.ep_duration_without_ed)
 end
 
 
@@ -57,7 +60,7 @@ function AnimeEpTimestamp:UpdateTimeStampVars()
     return
   end
 
-  while ((self.ep_timestamp <= self.ep_duration_with_op_ed) and
+  while ((self.ep_timestamp <= self.ep_duration_without_ed) and
          (mp.get_property_bool("pause") == false) and
          (mp.get_property("time-pos") ~= nil))
   do
@@ -76,81 +79,63 @@ end
 
 
 function AnimeEpTimestamp:ReadFromTimeStampFile()
-  local anime_ep_timestamp_file_obj = io.open(self.anime_ep_timestamp_file_path, "a+")
-  -- ep_timestamp = io.open("timestamp_file", "r")[-1]
-  -- ep = ep_timestamp[1]
-  -- if ep == curr_ep
-  --  start_pos = ep_timestamp[1]
-  --  self.start_pos = start_pos
-  if anime_ep_timestamp_file_obj ~= nil then anime_ep_timestamp_file_obj:close() end
-end
+  local anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "a+"))
+  local content_table = { }
 
-
-function ()
-end
-
-
-function AnimeEpTimestamp:edit_file_at_content_pos(f_path, line_pos, write_content)
-
-  local file_obj = assert(io.open(f_path, "a+"))
-  local curr_line_pos = 0 -- Start at the beginning of the file
-
-  for _ = 1, line_pos - 1 do
-      f_path:read("*line")
-      curr_line_pos = f_path:seek()
+  if anime_ep_timestamp_file_obj:read("l") == nil then
+    content_table = { self.anime_ep.." - "..self.ep_timestamp }
   end
 
-  f_path:seek("set", curr_line_pos)
-  f_path:write(write_content)
-  file_obj:close()
+  -- if anime_ep_timestamp_file_obj:read("l") ~= nil then
+  --   for i in io.lines(self.anime_ep_timestamp_file_path) do
+  --    print(i)
+  --    content_table.insert(i)
+  --   end
+  -- end
+  --
+  -- anime_ep_timestamp_file_obj:close()
 
+  return content_table
 end
+
 
 
 function AnimeEpTimestamp:WriteTimeStampOnQuit()
-  -- self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "a+"))
-  -- self.anime_ep_timestamp_file_obj:write(self.anime_ep.." - "..self.ep_timestamp)
-  -- -- self.anime_ep in timestamp_file.readlines()
-  -- -- string.replace("self.anime_ep - self.anime_ep_timestamp", "self.anime_ep - self.curr_pos")
-  -- self.anime_ep_timestamp_file_obj:close()
+  self.anime_ep_timestamp_file_obj = assert(io.open(self.anime_ep_timestamp_file_path, "a+"))
+  self.anime_ep_timestamp_file_obj:write(self.anime_ep.." - "..self.ep_timestamp.."\n")
+  -- self.anime_ep in timestamp_file.readlines()
+  -- string.replace("self.anime_ep - self.anime_ep_timestamp", "self.anime_ep - self.curr_pos")
+  self.anime_ep_timestamp_file_obj:close()
 end
 
 
 function AnimeEpTimestamp:EditEpHistoryOnQuit()
-  print("string =>", self.anime_ep_hist_file_path)
-  local watch_hist_f_obj = assert(io.open(self.anime_ep_hist_file_path, "r+"))
+  -- local watch_hist_f_obj = assert(io.open(self.anime_ep_hist_file_path, "r+"))
 
-  -- ani_hsts replace & match regex
-  local ep_num_regex = "^%d+%.?%d*"
-  local anime_hash_regex = "%w+%s"
-  local total_eps_in_bracket = "%([0-9]+ episodes%)"
-  -- end of regex def.s
+  -- -- ani_hsts replace & match regex
+  -- local ep_num_regex = "^%d+%.?%d*"
+  -- local anime_hash_regex = "%w+%s"
+  -- local total_eps_in_bracket = "%([0-9]+ episodes%)"
+  -- -- end of regex def.s
 
-  for i in watch_hist_f_obj:lines()
-  do
-    local anime_name = i:gsub(ep_num_regex.."%s", ""):gsub("^"..anime_hash_regex, ""):gsub(total_eps_in_bracket, "")
-    local anime_ep = i:match(ep_num_regex)
-    print(anime_name)
-  end
-  watch_hist_f_obj:close()
+  -- watch_hist_f_obj:close()
 end
 
 
--- AnimeEpTimestampObj = {}
 AnimeEpTimestampObj = AnimeEpTimestamp:new()
 function Onload()
   AnimeEpTimestampObj:GetProps()
-  AnimeEpTimestampObj:ShowDeets()
-  -- AnimeEpTimestampObj:ReadFromTimeStampFile()
-  -- AnimeEpTimestampObj:UpdateTimeStampVars()
+  -- AnimeEpTimestampObj:ShowDeets()
+  AnimeEpTimestampObj:ReadFromTimeStampFile()
+  AnimeEpTimestampObj:UpdateTimeStampVars()
   -- AnimeEpTimestampObj:EditEpHistoryOnQuit()
 
   -- write to file on shutdown
   mp.register_event("shutdown", AnimeEpTimestampObj:WriteTimeStampOnQuit())
 end
 
-mp.set_property("save-position-on-quit", "yes")
-mp.set_property("watch-later-directory", "/home/blank/.local/state/ani-cli/watch_later_tmp/")
+-- mp.set_property("save-position-on-quit", "yes")
+-- mp.set_property("watch-later-directory", "/home/blank/.local/state/ani-cli/watch_later_tmp/")
 -- mp.set_property("", "")
 
 mp.register_event("file-loaded", Onload)

--- a/scripts/continue_ep.lua
+++ b/scripts/continue_ep.lua
@@ -42,6 +42,11 @@ function AnimeEpTimestamp:GetProps()
     end
   end
 
+  local non_whole_ep_regex = "%.%d+$"
+  if self.media_title:match(non_whole_ep_regex) then
+    self.media_title = self.media_title:gsub(non_whole_ep_regex, "")
+  end
+
   self.anime_name = string.gsub(self.media_title, " [Ee]pisode [0-9]+", "")
   self.anime_ep = string.gsub(self.media_title, ".*[Ee]pisode ", "")
   self.ep_duration_with_ed = math.floor(mp.get_property("duration"))


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Feature
- [x] Documentation update

## Description
  * added instruction in the ani-cli script to check & create the "${HOME}/.local/state/ani-cli/ani-eps-hsts" & the "${HOME}/.config/ani-cli/scripts" directories
  * writes the timestamp in seconds format in a file named after the "media-title" property that will be created in the "${HOME}/.local/state/ani-cli/ani-eps-hsts/" directory on "shutdown" event if "time-pos" is less than "duration" property (subtract 90 seconds from duration cuz of outro and or next episode preview)
  * The tracker script looks for the the episode that's being played within the tracker file & if the episode exists, the "time-pos" property is set to the time that was written to the the tracker file
  * if "time-pos" property is greater than "duration" property (subtract 90 seconds) the following cases happen
     - if the tracker file is newly create, the tracker file will be deleted
     - the episode will be removed from the tracker file
     - if only one episode exists in the tracker file, the file will be deleted
  * added the instruction to copy the scripts file to "${HOME}/.config/ani-cli/" directory in the README.md file
## Checklist

- [x] any anime playing
