### PR TITLE
test: add nix dev shell env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,25 @@
 - Take part in troubleshooting and testing
 - Star the repo
 - Follow the maintainers
+
+## Development with nix
+
+When you develop with nix you can use the [dev shell](https://github.com/pystardust/ani-cli#nix-shell).
+To run the dev shell you can run the following command in the repository root: `nix-shell`
+The dev shell includes the following packages:
+- runtime dependencies of ani-cli
+- shfmt
+- shellcheck
+Its also possible to use alternative packages for the video player or add features with this command:
+```shell
+nix-shell --arg <feature> true
+```
+These are the packages available in the dev shell:
+- `withVlc`
+- `withIina`
+- `chromecastSupport`
+- `syncSupport`
+Just chain these commands together when you wanna multiple features for example:
+```shell
+nix-shell --arg withVlc true --arg chromecastSupport true
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,17 @@
 ## Development with nix
 
 When you develop with nix you can use the [dev shell](https://github.com/pystardust/ani-cli#nix-shell).
-To run the dev shell you can run the following command in the repository root: `nix-shell`
+
+To run the dev shell you can run the following command in the repository root: 
+```shell
+nix-shell
+```
+
 The dev shell includes the following packages:
 - runtime dependencies of ani-cli
 - shfmt
 - shellcheck
+
 Its also possible to use alternative packages for the video player or add features with this command:
 ```shell
 nix-shell --arg <feature> true
@@ -38,6 +44,7 @@ These are the packages available in the dev shell:
 - `withIina`
 - `chromecastSupport`
 - `syncSupport`
+  
 Just chain these commands together when you wanna multiple features for example:
 ```shell
 nix-shell --arg withVlc true --arg chromecastSupport true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@
 
 When you develop with nix you can use the [dev shell](https://github.com/pystardust/ani-cli#nix-shell).
 
-To run the dev shell you can run the following command in the repository root: 
+To run the dev shell you can run the following command in the repository root:
 ```shell
 nix-shell
 ```
@@ -44,7 +44,7 @@ These are the packages available in the dev shell:
 - `withIina`
 - `chromecastSupport`
 - `syncSupport`
-  
+
 Just chain these commands together when you wanna multiple features for example:
 ```shell
 nix-shell --arg withVlc true --arg chromecastSupport true

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+{ 
+  pkgs ? import <nixpkgs> {}, 
+  withMpv ? true,
+  withVlc ? false,
+  withIina ? false,
+  chromecastSupport ? false,
+  syncSupport ? false
+}:
+
+# To start the dev shell use the comment nix-shell
+# use --arg withVlc true to use VLC
+# use --arg withIina true to use Iina
+# use --arg chromecastSupport true to use chromecastSupport
+# use --arg syncSupport true to use syncSupport
+
+assert withMpv || withVlc || withIina;
+
+with pkgs;
+mkShell {
+  name = "ani-cli dev shell";
+  buildInputs = [ (ani-cli.override ({ withMpv = withMpv; withVlc = withVlc; withIina = withIina; chromecastSupport = chromecastSupport; syncSupport = syncSupport; })).runtimeDependencies ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -18,5 +18,5 @@ assert withMpv || withVlc || withIina;
 with pkgs;
 mkShell {
   name = "ani-cli dev shell";
-  buildInputs = [ (ani-cli.override ({ withMpv = withMpv; withVlc = withVlc; withIina = withIina; chromecastSupport = chromecastSupport; syncSupport = syncSupport; })).runtimeDependencies ];
+  buildInputs = [ shfmt shellcheck (ani-cli.override ({ withMpv = withMpv; withVlc = withVlc; withIina = withIina; chromecastSupport = chromecastSupport; syncSupport = syncSupport; })).runtimeDependencies ];
 }


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Added nix dev shell env.
To use it go in the repo and use `nix-shell` in the dev shell you have all bin that ani-cli uses.
With arguments you can also add vlc, chromecast support and so on is commented in the `shell.nix` file

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
