### PR TITLE
docs: add more community health files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Contributor Code of Conduct
+
+This project adheres to No Code of Conduct.  We are all adults.  We accept anyone's contributions.  Nothing else matters.
+
+For more information please visit the [No Code of Conduct](https://github.com/domgetter/NCoC) homepage.

--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -1,0 +1,9 @@
+This file aims to document the roles/responsibilities of the core maintainers.
+See [Contributing.md](https://github.com/pystardust/ani-cli/blob/master/CONTRIBUTING.md) for details on how to contribute.
+
+@CoolnsX primarily contributes code, with a strong focus on scraping logic.
+@71zenith adds small but frequent code contributions to most areas of the codebase and helps with large PRs.
+@Derisis13 primarily does code review and focuses on quality improvements in code contributions.
+@justchokingaround contributes code with a strong focus on the terminal UI/UX.
+@justchokingaround is also responsible for the readme and discord server.
+@port19x leads the project and does governance, reviewing almost all PRs and ensuring long-term project sustainability.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,6 @@
+This is an application that talks to a designated set of websites.
+Please refer to [disclaimer.md](https://github.com/pystardust/ani-cli/blob/master/disclaimer.md) for legal information.
+
+Disclose any security bugs, should there ever be any, to [port19](mailto:port19@port19.xyz) directly.
+
+Alternatively, [report a vulnerability](https://github.com/pystardust/ani-cli/security/advisories/new) via GitHub's [private reporting feature](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Documentation update

## Description

See [official docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types
)

Please verify that my description of your involvement in the project in `GOVERNANCE.md` aligns with your experience and make adjustments if desired.

The `SECURITY.md` is a bit superfluous, we may remove it.

We may additionally add a `FUNDING.yml` if we can figure out a cause to endorse.
The [electronic frontier foundation](https://www.eff.org/) and [shellcheck](https://github.com/sponsors/koalaman) come to mind.