### PR TITLE
fix: multi-selection support

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.6.1"
+version_number="4.6.2"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -309,8 +309,6 @@ esac
 
 use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 [ -t 0 ] || use_external_menu=1
-[ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
-[ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
@@ -368,6 +366,8 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+[ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
+[ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033\n[0m"
 dep_ch "curl" "sed" "grep" || true
 if [ -z "$ANI_CLI_NON_INTERACTIVE" ]; then dep_ch fzf || true; fi


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] Bug fix for [issue 1225](https://github.com/pystardust/ani-cli/issues/1225)
- [ ] Feature
- [ ] Documentation update

## Description

The check for [ $use_external_menu = 0 | 1 ] was made before the variable even gets a chance to be changed and use_external_menu was set to 0 just before that if ani-cli was started from a terminal.

BEFORE multi-selection (from the terminal with --rofi set) only worked if the env variable $ANI_CLI_EXTERNAL_MENU was set or ani-cli was not started from a terminal.

NOW multi-selection also works if the --rofi flag is set in via terminal, because the check takes place AFTER parcing command-line-arguments.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
