### PR TITLE
docs: Added android 14 fix in readme prior to #1206

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Install termux [(Guide)](https://termux.com/)
 pkg up -y
 pkg install ani-cli
 ```
+If you're using Android 14 make sure to run this due to [#1206](https://github.com/pystardust/ani-cli/issues/1206):
+```sh
+pkg install termux-am
+```
 
 For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note that these cannot be checked from termux so a warning is generated when checking dependencies.
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description
For the newly released Android 14 update Termux's MPV intent seems to fail to execute unless you install the ``termux-am`` package as confirmed by me and these issues: 

- https://github.com/pystardust/ani-cli/issues/1206
- https://github.com/termux/termux-app/issues/3647#issuecomment-1763563028

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
