### PR TITLE
docs: Update README.md to use now fixed FFmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,15 +197,7 @@ Make sure apk is updated using
 ```apk update; apk upgrade```
 then run this:
 ```sh
-apk add grep sed curl fzf git aria2 alpine-sdk ncurses
-git clone https://github.com/Lockl00p/ffmpeglibs-iSH.git ~/ffmpeg
-cd ~/ffmpeg
-cat fmp.?? > ffmpeg.tar.gz
-tar -xvf ffmpeg.tar.gz
-cd FFmpeg
-make install
-cd
-rm -rf ffmpeg
+apk add grep sed curl fzf git aria2 ncurses
 apk add ffmpeg
 git clone https://github.com/pystardust/ani-cli ~/.ani-cli
 cp ~/.ani-cli/ani-cli /usr/local/bin/ani-cli
@@ -390,14 +382,9 @@ flatpak uninstall io.mpv.Mpv
 ```
 rm -rf /usr/local/bin/ani-cli
 ```
-To uninstall FFmpeg:
-```
-rm -rf /usr/local/lib/libavutil.a /usr/local/lib/libavcodec.a /usr/local/lib/libavformat.a /usr/local/lib/pkgconfig/libavutil.a /usr/local/lib/pkgconfig/libavcodec.a /usr/local/lib/pkgconfig/libavformat.a
-apk del ffmpeg
-```
 To uninstall other dependencies:
 ```
-apk del grep sed curl fzf git aria2 alpine-sdk ncurses
+apk del grep sed curl fzf git aria2 ffmpeg ncurses
 ```
 
 </details>


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Documentation update

## Description

*ramble here*

## Checklist

- [X] any anime playing
- [ ] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-S` select index works
- [X] `-r` range selection works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
