### PR TITLE
feat: add mpvnet support

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -302,7 +302,16 @@ case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
     *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;  # steamdeck OS
-    *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
+    *MINGW* | *WSL2*)                                                 # Windows OS
+        # check for mpvnet, fallback to mpv if not found
+        if command -v "mpvnet.exe" >/dev/null; then
+            player_function="${ANI_CLI_PLAYER:-mpvnet.exe}"
+        elif command -v "mpv.exe" >/dev/null; then
+            player_function="${ANI_CLI_PLAYER:-mpv.exe}"
+        else
+            die "Neither mpv.exe nor mpvnet.exe found. Please install one of them."
+        fi
+        ;;
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                    # Linux OS
 esac


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Added support for [mpvnet](https://github.com/mpvnet-player/mpv.net) as an alternative to mpv for Windows users.

#322 mentioned adding mpvnet as a player option, the issue was closed as completed but mpvnet support has never been added. Since mpvnet is just a fork of mpv it should work exactly the same, I ran a few tests and it all worked for me. Open to suggestions for improvements.

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
