### PR TITLE
fix: Steam deck installation and .desktop fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ echo '[Desktop Entry]
 Encoding=UTF-8
 Type=Application
 Exec=bash -c "source $HOME/.'$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")'rc && konsole --fullscreen -e ani-cli
-Name=ani-cli' > $HOME/local/share/applications/ani-cli.desktop
+Name=ani-cli' > $HOME/.local/share/applications/ani-cli.desktop
 ```
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"
 In Steam Desktop app:

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ cp ~/.ani-cli/ani-cli ~/.local/bin/
 echo '[Desktop Entry]
 Encoding=UTF-8
 Type=Application
-Exec=bash -c "source $HOME/.'$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")'rc && konsole --fullscreen -e ani-cli
+Exec=bash -c "source $HOME/.'$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")'rc && konsole --fullscreen -e ani-cli"
 Name=ani-cli' > $HOME/.local/share/applications/ani-cli.desktop
 ```
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ note that downloading is going to be very slow. This is an iSH issue, not an ani
 * Copy the script, paste it in the CLI and press Enter("A" button on Steam Deck)
 
 ```sh
-[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export $PATH=$HOME/.local/bin:$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
+[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
 
 git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install
@@ -258,7 +258,7 @@ press enter("A" button on Steam Deck) on questions
 ##### Make a ~/.local/bin folder if doesn't exist and add it to $PATH
 
 ```sh
-[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export $PATH=$HOME/.local/bin:$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
+[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
 ```
 
 ##### Install [aria2](https://github.com/aria2/aria2) (needed for download feature only):

--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ Name=ani-cli' > $HOME/.local/share/applications/ani-cli.desktop
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"
 In Steam Desktop app:
 `Add game` > `Add a non-steam game` > tick a box for `ani-cli` > `Add selected programs`
-*Note: this is not working the way it should yet.*
 </details>
 
 ### Installing from source

--- a/README.md
+++ b/README.md
@@ -290,9 +290,8 @@ cp ~/.ani-cli/ani-cli ~/.local/bin/
 ```
 echo '[Desktop Entry]
 Encoding=UTF-8
-Version=4.0
 Type=Application
-Exec=konsole -e ani-cli
+Exec=konsole -e $HOME/.local/bin/ani-cli
 Name=ani-cli' > ~/.local/share/applications/ani-cli.desktop
 ```
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"

--- a/README.md
+++ b/README.md
@@ -291,13 +291,12 @@ cp ~/.ani-cli/ani-cli ~/.local/bin/
 echo '[Desktop Entry]
 Encoding=UTF-8
 Type=Application
-Exec=konsole -e $HOME/.local/bin/ani-cli
-Name=ani-cli' > ~/.local/share/applications/ani-cli.desktop
+Exec=bash -c "source $HOME/.'$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")'rc && konsole --fullscreen -e ani-cli
+Name=ani-cli' > $HOME/local/share/applications/ani-cli.desktop
 ```
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"
 In Steam Desktop app:
 `Add game` > `Add a non-steam game` > tick a box for `ani-cli` > `Add selected programs`
-*Note: Konsole window size bugs out if launched from "Gaming Mode".*
 *Note: this is not working the way it should yet.*
 </details>
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ note that downloading is going to be very slow. This is an iSH issue, not an ani
 * Copy the script, paste it in the CLI and press Enter("A" button on Steam Deck)
 
 ```sh
-[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
+[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:\$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
 
 git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install
@@ -258,7 +258,7 @@ press enter("A" button on Steam Deck) on questions
 ##### Make a ~/.local/bin folder if doesn't exist and add it to $PATH
 
 ```sh
-[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
+[ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:\$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
 ```
 
 ##### Install [aria2](https://github.com/aria2/aria2) (needed for download feature only):


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Documentation update

## Description
Makes ani-cli installation instructions for steamdeck work.
Also enables easy launch from Steam "game mode" 
Fix for this https://github.com/pystardust/ani-cli/issues/1268

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [x] Readme is up to date
- [ ] Man page is up to date| i guess?