### PR TITLE
fix: correctly closes escape sequence in message 'Checking dependencies…'

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -373,7 +373,7 @@ while [ $# -gt 0 ]; do
 done
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
-printf "\33[2K\r\033[1;34mChecking dependencies...\033\n[0m"
+printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 if [ -z "$ANI_CLI_NON_INTERACTIVE" ]; then dep_ch fzf || true; fi


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [X] Bug fix

## Description

Hi, there! I've caught annoying UI bug on zsh when line "Checking dependencies..." is printed to stdout.

Before this patch it looks like this:

```
❯ ani-cli 'FLCL'
Checking dependencies...
                        [0m%
```

Symbol "\n" must be printed after resetting styles (or before them). And this patch is only about that:
```
❯ ./ani-cli 'FLCL'
Checking dependencies...
```

## For maintaners

I am able to check basic functionality only on macos zsh and bash, I don't think that this patch somehow disturbes core functionality of the `ani-cli`.

If needed, I might bump patch version too, but I would better leave it for maintainers.

## Checklist

- [X] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
