### PR TITLE
docs: Add gnu patch install script for Steam Deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,9 @@ curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.l
 chmod +x ~/.local/bin/yt-dlp
 
 mkdir ~/.patch
-curl -o ~/.patch/patch.tar.gz ftp://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.gz
-tar xvf ~/.patch/patch.tar.gz -C ~/.patch/
- cd ~/.patch/patch-2.7.6 && ./configure && make && cp ~/.patch/patch-2.7.6/src/patch ~/.local/bin/
-cd ~
+curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
+tar xvf .patch/patch.tar.zst -C ~/.patch 
+cp ~/.patch/usr/bin/patch ~/.local/bin 
 
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli
 cp ~/.ani-cli/ani-cli ~/.local/bin/

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ chmod +x ~/.local/bin/yt-dlp
 
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
-tar xvf .patch/patch.tar.zst -C ~/.patch 
+tar xvf .patch/patch.tar.zst -C ~/.patch/
 cp ~/.patch/usr/bin/patch ~/.local/bin 
 
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli
@@ -281,10 +281,9 @@ chmod +x ~/.local/bin/yt-dlp
 
 ```
 mkdir ~/.patch
-curl -o ~/.patch/patch.tar.gz ftp://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.gz
-tar xvf ~/.patch/patch.tar.gz -C ~/.patch/
- cd ~/.patch/patch-2.7.6 && ./configure && make && cp ~/.patch/patch-2.7.6/src/patch ~/.local/bin/
-cd ~
+curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
+tar xvf .patch/patch.tar.zst -C ~/.patch/ 
+cp ~/.patch/usr/bin/patch ~/.local/bin
 ```
 
 ##### Install ani-cli:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ chmod +x ~/.local/bin/aria2c
 curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
 chmod +x ~/.local/bin/yt-dlp
 
+mkdir ~/.patch
+curl -o ~/.patch/patch.tar.gz ftp://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.gz
+tar xvf ~/.patch/patch.tar.gz -C ~/.patch/
+ cd ~/.patch/patch-2.7.6 && ./configure && make && cp ~/.patch/patch-2.7.6/src/patch ~/.local/bin/
+cd ~
+
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli
 cp ~/.ani-cli/ani-cli ~/.local/bin/
 
@@ -270,6 +276,16 @@ chmod +x ~/.local/bin/aria2c
 ```sh
 curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
 chmod +x ~/.local/bin/yt-dlp
+```
+
+##### Install [patch](https://savannah.gnu.org/projects/patch/)
+
+```
+mkdir ~/.patch
+curl -o ~/.patch/patch.tar.gz ftp://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.gz
+tar xvf ~/.patch/patch.tar.gz -C ~/.patch/
+ cd ~/.patch/patch-2.7.6 && ./configure && make && cp ~/.patch/patch-2.7.6/src/patch ~/.local/bin/
+cd ~
 ```
 
 ##### Install ani-cli:
@@ -393,6 +409,7 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 - ffmpeg - m3u8 Downloader (fallback)
 - fzf - User interface
 - ani-skip (optional)
+- patch - Self updating
 
 ### Ani-Skip
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ chmod +x ~/.local/bin/yt-dlp
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
 tar xvf .patch/patch.tar.zst -C ~/.patch/
-cp ~/.patch/usr/bin/patch ~/.local/bin 
+cp ~/.patch/usr/bin/patch ~/.local/bin/
 
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli
 cp ~/.ani-cli/ani-cli ~/.local/bin/
@@ -283,7 +283,7 @@ chmod +x ~/.local/bin/yt-dlp
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
 tar xvf .patch/patch.tar.zst -C ~/.patch/
-cp ~/.patch/usr/bin/patch ~/.local/bin
+cp ~/.patch/usr/bin/patch ~/.local/bin/
 ```
 
 ##### Install ani-cli:

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ chmod +x ~/.local/bin/yt-dlp
 
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
-tar xvf .patch/patch.tar.zst -C ~/.patch/
+tar xvf ~/.patch/patch.tar.zst -C ~/.patch/
 cp ~/.patch/usr/bin/patch ~/.local/bin/
 
 git clone https://github.com/pystardust/ani-cli.git ~/.ani-cli
@@ -282,7 +282,7 @@ chmod +x ~/.local/bin/yt-dlp
 ```sh
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
-tar xvf .patch/patch.tar.zst -C ~/.patch/
+tar xvf ~/.patch/patch.tar.zst -C ~/.patch/
 cp ~/.patch/usr/bin/patch ~/.local/bin/
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.l
 chmod +x ~/.local/bin/yt-dlp
 ```
 
-##### Install [patch](https://savannah.gnu.org/projects/patch/)
+##### Install [patch](https://savannah.gnu.org/projects/patch/) (needed for self-update feature [ -U ] ):
 
-```
+```sh
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
 tar xvf .patch/patch.tar.zst -C ~/.patch/

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ chmod +x ~/.local/bin/yt-dlp
 ```
 mkdir ~/.patch
 curl -o ~/.patch/patch.tar.zst https://mirror.sunred.org/archlinux/core/os/x86_64/patch-2.7.6-10-x86_64.pkg.tar.zst
-tar xvf .patch/patch.tar.zst -C ~/.patch/ 
+tar xvf .patch/patch.tar.zst -C ~/.patch/
 cp ~/.patch/usr/bin/patch ~/.local/bin
 ```
 


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] Feature
- [X] Documentation update

## Description

Steam Deck has no gnu patch preinstalled.
pacman -S patch wont work in a long term because the root partition is:
1. immutable (but can be set to be mutable)
2. reset with each steamOS update (at least from what i have heared)

Because we already add .local/bin to PATH, it make sense to install gnu patch in .local/bin.