### PR TITLE
feat: folder support

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -43,6 +43,8 @@ help_info() {
         Continue watching from history
       -d, --download
         Download the video instead of playing it
+      -f, --folder
+        Changes root to a new folder
       -D, --delete
         Delete history
       -s, --syncplay
@@ -216,6 +218,12 @@ update_history() {
 }
 
 download() {
+    if [[ $folder_path = true ]]; then
+      mkdir -p "$download_dir/$title"
+	    download_dir="$download_dir/$title"
+      folder_path=false
+    fi
+
     case $1 in
         *m3u8*)
             if command -v "yt-dlp" >/dev/null; then
@@ -316,6 +324,7 @@ hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 histfile="$hist_dir/ani-hsts"
 [ ! -f "$histfile" ] && : >"$histfile"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
+folder_path=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -349,6 +358,7 @@ while [ $# -gt 0 ]; do
             ;;
         -c | --continue) search=history ;;
         -d | --download) player_function=download ;;
+        -f | --folder) folder_path=true ;;
         -D | --delete)
             : >"$histfile"
             exit 0

--- a/ani-cli
+++ b/ani-cli
@@ -218,7 +218,7 @@ update_history() {
 }
 
 download() {
-    if [ $folder_path = true ]; then
+    if [ "$folder_path" = true ]; then
       mkdir -p "$download_dir/$title"
 	    download_dir="$download_dir/$title"
       folder_path=false

--- a/ani-cli
+++ b/ani-cli
@@ -218,7 +218,7 @@ update_history() {
 }
 
 download() {
-    if [[ $folder_path = true ]]; then
+    if [ $folder_path = true ]; then
       mkdir -p "$download_dir/$title"
 	    download_dir="$download_dir/$title"
       folder_path=false


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Instead of downloading at the base root, make it create a new folder and store the videos from that new folder. Needs to have the -f flag to activate it.

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
