### PR TITLE
Added a function to get time until a next episode

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 ## Type of change
 
-- [x] Bug fix
-- [x] Feature
-- [x] Documentation update
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation update
 
 ## Description
 
@@ -12,27 +12,27 @@
 
 ## Checklist
 
-- [x] any anime playing
-- [x] bumped version
+- [ ] any anime playing
+- [ ] bumped version
 ---
-- [x] next, prev and replay work
-- [x] `-c` history and continue work
-- [x] `-d` downloads work
-- [x] `-s` syncplay works
-- [x] `-q` quality works
-- [x] `-v` vlc works
-- [x] `-e` select episode works
-- [x] `-S` select index works
-- [x] `-r` range selection works
-- [x] `--skip` ani-skip works
-- [x] `--skip-title` ani-skip title argument works
-- [x] `--no-detach` no detach works
-- [x] `--dub` and regular (sub) mode both work
-- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
+- [ ] next, prev and replay work
+- [ ] `-c` history and continue work
+- [ ] `-d` downloads work
+- [ ] `-s` syncplay works
+- [ ] `-q` quality works
+- [ ] `-v` vlc works
+- [ ] `-e` select episode works
+- [ ] `-S` select index works
+- [ ] `-r` range selection works
+- [ ] `--skip` ani-skip works
+- [ ] `--skip-title` ani-skip title argument works
+- [ ] `--no-detach` no detach works
+- [ ] `--dub` and regular (sub) mode both work
+- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
 ---
-- [x] `-h` help info is up to date
-- [x] Readme is up to date
-- [x] Man page is up to date
+- [ ] `-h` help info is up to date
+- [ ] Readme is up to date
+- [ ] Man page is up to date
 
 ## Additional Testcases
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 
 ## Type of change
 
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Documentation update
+- [x] Bug fix
+- [x] Feature
+- [x] Documentation update
 
 ## Description
 
@@ -12,27 +12,27 @@
 
 ## Checklist
 
-- [ ] any anime playing
-- [ ] bumped version
+- [x] any anime playing
+- [x] bumped version
 ---
-- [ ] next, prev and replay work
-- [ ] `-c` history and continue work
-- [ ] `-d` downloads work
-- [ ] `-s` syncplay works
-- [ ] `-q` quality works
-- [ ] `-v` vlc works
-- [ ] `-e` select episode works
-- [ ] `-S` select index works
-- [ ] `-r` range selection works
-- [ ] `--skip` ani-skip works
-- [ ] `--skip-title` ani-skip title argument works
-- [ ] `--no-detach` no detach works
-- [ ] `--dub` and regular (sub) mode both work
-- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
+- [x] next, prev and replay work
+- [x] `-c` history and continue work
+- [x] `-d` downloads work
+- [x] `-s` syncplay works
+- [x] `-q` quality works
+- [x] `-v` vlc works
+- [x] `-e` select episode works
+- [x] `-S` select index works
+- [x] `-r` range selection works
+- [x] `--skip` ani-skip works
+- [x] `--skip-title` ani-skip title argument works
+- [x] `--no-detach` no detach works
+- [x] `--dub` and regular (sub) mode both work
+- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
 ---
-- [ ] `-h` help info is up to date
-- [ ] Readme is up to date
-- [ ] Man page is up to date
+- [x] `-h` help info is up to date
+- [x] Readme is up to date
+- [x] Man page is up to date
 
 ## Additional Testcases
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 version_number="4.8.1"
 
@@ -111,7 +111,7 @@ dep_ch() {
 
 # SCRAPING
 
-# extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
+# extract the video links from response of embed urls, extract mp4 links form m3u8 lists
 get_links() {
     episode_link="$(curl -e "$allanime_refr" -s "https://${allanime_base}$*" -A "$agent" | sed 's|},{|\
 |g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
@@ -194,6 +194,15 @@ search_anime() {
 
     curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
 |g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p"
+}
+
+time_until_next_ep() {
+
+    fetched="$(curl -s "$animeschedule/$1")"
+
+    ttne="$(printf "%s" "$fetched" | grep 'countdown-time countdown-time-raw' | uniq | awk -F '"' '{print $4}')"
+    printf "%s" "$ttne"
+
 }
 
 # get the episodes list of the selected anime
@@ -300,6 +309,8 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefo
 allanime_refr="https://allanime.to"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
+animeschedule="https://animeschedule.net/anime"
+time_to_next_ep=""
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
@@ -412,7 +423,7 @@ case "$search" in
         grep "$result" "$histfile" >"$resfile"
         read -r ep_no id title <"$resfile"
         ep_list=$(episodes_list "$id")
-        ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
+        ep_no=$(printf "%s%s" "$ep_list" "$ttne" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ;;
     *)
@@ -424,6 +435,8 @@ case "$search" in
             [ -z "$query" ] && query=$(printf "" | external_menu "" "Search anime: ")
             [ -z "$query" ] && exit 1
         fi
+        schedule_query=$(printf "%s" "$query" | sed "s| |-|g")
+        ttne=$(time_until_next_ep "$schedule_query")
         query=$(printf "%s" "$query" | sed "s| |+|g")
         anime_list=$(search_anime "$query")
         [ -z "$anime_list" ] && die "No results found!"
@@ -434,7 +447,7 @@ case "$search" in
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
         ep_list=$(episodes_list "$id")
-        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s\n%s" "$ep_list" "$ttne" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1
         ;;
 esac


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [] Bug fix
- [x] Feature
- [] Documentation update

## Description

When an anime is selected, if there will be a next episode it will display
as last in the episode list the time until it releases

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
