### PR TITLE
Countdown to next episode

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# Using /usr/bin/env so that the script is portable across all distributions
 
 version_number="4.8.1"
 
@@ -196,15 +197,15 @@ search_anime() {
 |g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p"
 }
 
+# searches the query on animeschedule and gives results
 search_next_episode() {
 
-    search_gql="query(        \$search: SearchInput        \$limit: Int        \$page: Int        \$translationType: VaildTranslationTypeEnumType        \$countryOrigin: VaildCountryOriginEnumType    ) {    shows(        search: \$search        limit: \$limit        page: \$page        translationType: \$translationType        countryOrigin: \$countryOrigin    ) {        edges {            _id name availableEpisodes __typename       }    }}"
-    
-    curl -e "$animeschedule" -s "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
-|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\"|p"
+    nep_query="$(printf "%s" "$1" | sed "s|-|%20|g")"
+    curl -s "$animeschedule_base/shows?q=$nep_query" | awk -F '"' '{print $2}' | sed "s|/shows/||g"
 
 }
 
+# gets countdown timer from animeschedule
 time_until_next_ep() {
 
     fetched="$(curl -s "$animeschedule/$1")"
@@ -319,6 +320,7 @@ allanime_refr="https://allanime.to"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
 animeschedule="https://animeschedule.net/anime"
+animeschedule_base="https://animeschedule.net"
 time_to_next_ep=""
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
@@ -451,12 +453,15 @@ case "$search" in
         [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
         [ -z "$result" ] && exit 1
         title=$(printf "%s" "$result" | cut -f2)
-        schedule_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | sed "s| |-|g" | sed 's/.$//' | sed "s|-Season-|-|g")"
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
         ep_list=$(episodes_list "$id")
+        
+        schedule_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | sed "s| |-|g" | sed 's/.$//' | sed "s|-Season-|-|g")"
+        schedule_title=$(search_next_episode "$schedule_title")
         ttne=$(time_until_next_ep "$schedule_title")
-        [ -z "$ep_no" ] && ep_no=$(printf "%s\n%s\n%s" "$ep_list" "$ttne" "$schedule_title" | nth "Select episode: " "$multi_selection_flag")
+       
+        [ -z "$ep_no" ] && ep_no=$(printf "%s\n%s" "$ep_list" "$ttne" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1
         ;;
 esac

--- a/ani-cli
+++ b/ani-cli
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Using /usr/bin/env so that the script is portable across all distributions
 
-version_number="4.8.1"
+version_number="4.8.2"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 version_number="4.8.1"
 
@@ -111,7 +111,7 @@ dep_ch() {
 
 # SCRAPING
 
-# extract the video links from reponse of embed urls, extract mp4 links form m3u8 lists
+# extract the video links from response of embed urls, extract mp4 links form m3u8 lists
 get_links() {
     episode_link="$(curl -e "$allanime_refr" -s "https://${allanime_base}$*" -A "$agent" | sed 's|},{|\
 |g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
@@ -194,6 +194,24 @@ search_anime() {
 
     curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
 |g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p"
+}
+
+search_next_episode() {
+
+    search_gql="query(        \$search: SearchInput        \$limit: Int        \$page: Int        \$translationType: VaildTranslationTypeEnumType        \$countryOrigin: VaildCountryOriginEnumType    ) {    shows(        search: \$search        limit: \$limit        page: \$page        translationType: \$translationType        countryOrigin: \$countryOrigin    ) {        edges {            _id name availableEpisodes __typename       }    }}"
+    
+    curl -e "$animeschedule" -s "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
+|g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\".*${mode}\"|p"
+
+}
+
+time_until_next_ep() {
+
+    fetched="$(curl -s "$animeschedule/$1")"
+
+    ttne="$(printf "%s" "$fetched" | grep 'countdown-time countdown-time-raw' | uniq | awk -F '"' '{print $4}')"
+    printf "%s" "$ttne"
+
 }
 
 # get the episodes list of the selected anime
@@ -300,6 +318,8 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefo
 allanime_refr="https://allanime.to"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
+animeschedule="https://animeschedule.net/anime"
+time_to_next_ep=""
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
@@ -412,7 +432,7 @@ case "$search" in
         grep "$result" "$histfile" >"$resfile"
         read -r ep_no id title <"$resfile"
         ep_list=$(episodes_list "$id")
-        ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
+        ep_no=$(printf "%s\n%s" "$ep_list" "$ttne" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ;;
     *)
@@ -431,10 +451,12 @@ case "$search" in
         [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
         [ -z "$result" ] && exit 1
         title=$(printf "%s" "$result" | cut -f2)
+        schedule_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]' | sed "s| |-|g" | sed 's/.$//' | sed "s|-Season-|-|g")"
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
         ep_list=$(episodes_list "$id")
-        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        ttne=$(time_until_next_ep "$schedule_title")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s\n%s\n%s" "$ep_list" "$ttne" "$schedule_title" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1
         ;;
 esac

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,3 @@
+Youkoso-Jitsuryoku-Shijou-Shugi-no-Kyoushitsu-e-3Youkoso%20Jitsuryoku%20Shijou%20Shugi%20no%20Kyoushitsu%20e%203
+https://animeschedule.net/anime/shows?q=Youkoso%20Jitsuryoku%20Shijou%20Shugi%20no%20Kyoushitsu%20e%203
+https://animeschedule.net/anime/shows?q=Youkoso%20Jitsuryoku%20Shijou%20Shugi%20no%20Kyoushitsu%20e%203

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,0 @@
-Youkoso-Jitsuryoku-Shijou-Shugi-no-Kyoushitsu-e-3Youkoso%20Jitsuryoku%20Shijou%20Shugi%20no%20Kyoushitsu%20e%203
-https://animeschedule.net/anime/shows?q=Youkoso%20Jitsuryoku%20Shijou%20Shugi%20no%20Kyoushitsu%20e%203
-https://animeschedule.net/anime/shows?q=Youkoso%20Jitsuryoku%20Shijou%20Shugi%20no%20Kyoushitsu%20e%203


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [] Bug fix
- [x] Feature
- [] Documentation update

## Description

Implementation of a function to get the countdown to the next episode
Also changed ``#!/bin/sh`` to ``#!/usr/bin/env sh`` to make it more portable (sorry if I wasn't supposed to)

** I had originally opened a PR, but then noticed unwanted behavior for some japanese titles **

Now it works with the vast majority of the titles, though some have really different names
across websites, therefore the countdown is not found (an example is One Piece, 1P on allanime, one-piece on animeschedule
Pretty sure this can be corrected with some thinkering but I haven't been able to 

It uses https://animeschedule.net/ to find titles and their release date

> The countdown is shown as the last episode in the episode list

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)