### PR TITLE
docs: removed duplicate entries from manpage

### DIFF
--- a/ani-cli.1
+++ b/ani-cli.1
@@ -28,9 +28,6 @@ Download episode.
 \fB\-D | --delete\fR
 Delete history.
 .TP
-\fB\-S | --select-nth\fR \fI\,<index>\/\fR
-Selects nth entry.
-.TP
 \fB\-h | --help\fR
 Show summary of options.
 .TP
@@ -45,9 +42,6 @@ Fetch update from github.
 .TP
 \fB\-v | --vlc\fR
 Use VLC as the media player.
-.TP
-\fB\-N | --non-interactive\fR
-Disable the interactive menu.
 .TP
 \fB\-S | --select-nth\fR \fI\,<index>\/\fR
 Selects nth entry.


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

I suppose this is just a little oversight. Should not require a version bump as only the manpage is affected.

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
