### PR TITLE
feat: Fullscreen start option

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -63,6 +63,8 @@ help_info() {
         Play dubbed version
       --rofi
         Use rofi instead of fzf for the interactive menu
+       -f, --fs, --fullscreen
+        Open player in Fullscreen (mpv and vlc)
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach
@@ -264,7 +266,7 @@ play_episode() {
             ;;
         mpv*)
             if [ "$no_detach" = 0 ]; then
-                nohup "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
+                nohup "$player_function" "${fullscreen_flag[0]}" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
             else
                 "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
             fi
@@ -273,7 +275,7 @@ play_episode() {
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
-        vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        vlc*) nohup "$player_function" "${fullscreen_flag[1]}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
@@ -399,6 +401,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -N | --nextep-countdown) search=nextep ;;
+        -f | --fs | --fullscreen) fullscreen_flag=("--fullscreen" "-f" "--mpv-fs") ;; #options 0)mpv 1)vlc
         -U | --update) update_script ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
     esac

--- a/ani-cli
+++ b/ani-cli
@@ -64,7 +64,7 @@ help_info() {
       --rofi
         Use rofi instead of fzf for the interactive menu
        -f, --fs, --fullscreen
-        Open player in Fullscreen (mpv and vlc)
+        Open player in fullscreen (mpv and vlc)
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach

--- a/ani-cli
+++ b/ani-cli
@@ -400,7 +400,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -N | --nextep-countdown) search=nextep ;;
-        -f | --fs | --fullscreen) 
+        -f | --fs | --fullscreen)
             fullscreen_flag_mpv="--fullscreen"
             fullscreen_flag_vlc="-f"
             ;;

--- a/ani-cli
+++ b/ani-cli
@@ -265,7 +265,7 @@ play_episode() {
             ;;
         mpv*)
             if [ "$no_detach" = 0 ]; then
-                nohup "$player_function" "${fullscreen_flag[0]}" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
+                nohup "$player_function" "${fullscreen_flag_mpv}" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
             else
                 "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
             fi
@@ -274,7 +274,7 @@ play_episode() {
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
-        vlc*) nohup "$player_function" "${fullscreen_flag[1]}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        vlc*) nohup "$player_function" "${fullscreen_flag_vlc}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" ;;
         catt) nohup catt cast "$episode" >/dev/null 2>&1 & ;;
@@ -400,7 +400,10 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -N | --nextep-countdown) search=nextep ;;
-        -f | --fs | --fullscreen) fullscreen_flag=("--fullscreen" "-f" "--mpv-fs") ;; #options 0)mpv 1)vlc
+        -f | --fs | --fullscreen) 
+            fullscreen_flag_mpv="--fullscreen"
+            fullscreen_flag_vlc="-f"
+            ;;
         -U | --update) update_script ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
     esac

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.5"
+version_number="4.8.6"
 
 # UI
 

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -63,6 +63,9 @@ Don't detach the player (useful for in-terminal playback, mpv only)
 .TP
 \fB\--skip-title\fR \fI\,<title>\/\fR
 Specify the title to use for ani-skip
+.TP
+\fB\-f | --fs | --fullscreen\fR
+Opens player in fullscreen (mpv and vlc only)
 .PP
 .SH
 ENVIRONMENT VARIABLES


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Adds -f,--fs,--fullscreen start arg that will open MPV and VLC in fullscreen automatically. 
Great for Binge watching a series i find.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [ ] `-S` select index works
- [x] `-r` range selection works
- [x] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [ ] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
