### PR TITLE
Add flag to allow adding an new anime to the histfile

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.6"
+version_number="4.9.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -39,6 +39,8 @@ help_info() {
     %s [options] [query] [options]
 
     Options:
+      -a, --add
+        Add an anime to the history (to watch later)
       -c, --continue
         Continue watching from history
       -d, --download
@@ -237,6 +239,16 @@ update_history() {
     mv "${histfile}.new" "$histfile"
 }
 
+add_unwatched_to_history() {
+    if grep -q -- "$id" "$histfile"; then
+        return
+    fi
+
+    cp "$histfile" "${histfile}.new"
+    printf "unwatched\t%s\t%s\n" "$id" "$title" >>"${histfile}.new"
+    mv "${histfile}.new" "$histfile"
+}
+
 download() {
     case $1 in
         *m3u8*)
@@ -343,6 +355,7 @@ hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 histfile="$hist_dir/ani-hsts"
 [ ! -f "$histfile" ] && : >"$histfile"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
+only_add_to_hist=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -374,6 +387,7 @@ while [ $# -gt 0 ]; do
             index="$2"
             shift
             ;;
+        -a | --add) only_add_to_hist=true ;;
         -c | --continue) search=history ;;
         -d | --download) player_function=download ;;
         -D | --delete)
@@ -457,6 +471,9 @@ case "$search" in
         title=$(printf "%s" "$result" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
+
+        $only_add_to_hist && add_unwatched_to_history && exit 0
+
         ep_list=$(episodes_list "$id")
         [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1

--- a/ani-cli
+++ b/ani-cli
@@ -225,7 +225,13 @@ episodes_list() {
 
 process_hist_entry() {
     ep_list=$(episodes_list "$id")
-    ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
+
+    if [ "$ep_no" = "unwatched" ]; then
+        ep_no=$(printf "%s" "$ep_list" | head -n 1)
+    else
+        ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
+    fi
+
     [ -n "$ep_no" ] && printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
 }
 
@@ -446,8 +452,7 @@ case "$search" in
         resfile="$(mktemp)"
         grep "$result" "$histfile" >"$resfile"
         read -r ep_no id title <"$resfile"
-        ep_list=$(episodes_list "$id")
-        ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
+        process_hist_entry
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ;;
     *)

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -19,6 +19,9 @@ This tool scrapes the site allanime.
 \fB\-e | --episode | -r | --range\fR \fI\,<episode>\/\fR
 Specify the episode numbers to watch. If range is specified it should be quoted or separated by a non-numeric character (eg. -).
 .TP
+\fB\-a | --add\fR
+Add an anime to the history (to watch later)
+.TP
 \fB\-c | --continue\fR
 Continue watching anime from history.
 .TP


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

A use case that I frequently have is that I want to add an anime to my histfile so that I can watch it later.
This PR adds a flag `-a/--add` which allows us to simply add the anime without playing the episode.

For these animes, we use `unwatched` to signify the "ep_no" field in the histfile.

This flag only significant in the case of using `-c` later. 
Standard operations of `ani-cli` have no interaction with this flag.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [ ] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [x] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
