### PR TITLE
feat: exit after play

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.6"
+version_number="4.8.7"
 
 # UI
 
@@ -67,6 +67,8 @@ help_info() {
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach
         Don't detach the player (useful for in-terminal playback, mpv only)
+      --exit-after-play
+        Exit the player, and return the player exit code (useful for non interactive scenarios, works only if --no-detach is used, mpv only)
       --skip-title <title>
         Use given title as ani-skip query
       -N, --nextep-countdown
@@ -266,6 +268,10 @@ play_episode() {
                 nohup "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
             else
                 "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
+                mpv_exitcode=$?
+                if [ "$exit_after_play" = 1 ]; then
+                  exit "$mpv_exitcode"
+                fi
             fi
             ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
@@ -333,6 +339,7 @@ case "$(uname -a)" in
 esac
 
 no_detach="${ANI_CLI_NO_DETACH:-0}"
+exit_after_play="${ANI_CLI_EXIT_AFTER_PLAY:-0}"
 use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 skip_intro="${ANI_CLI_SKIP_INTRO:-0}"
 # shellcheck disable=SC2154
@@ -390,6 +397,7 @@ while [ $# -gt 0 ]; do
             ;;
         --dub) mode="dub" ;;
         --no-detach) no_detach=1 ;;
+        --exit-after-play) exit_after_play=1 ;;
         --rofi) use_external_menu=1 ;;
         --skip) skip_intro=1 ;;
         --skip-title)

--- a/ani-cli
+++ b/ani-cli
@@ -270,7 +270,7 @@ play_episode() {
                 "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
                 if [ "$exit_after_play" = 1 ]; then
-                  exit "$mpv_exitcode"
+                    exit "$mpv_exitcode"
                 fi
             fi
             ;;

--- a/ani-cli
+++ b/ani-cli
@@ -269,9 +269,7 @@ play_episode() {
             else
                 "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
-                if [ "$exit_after_play" = 1 ]; then
-                    exit "$mpv_exitcode"
-                fi
+                [ "$exit_after_play" = 1 ] && exit "$mpv_exitcode"
             fi
             ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -53,13 +53,15 @@ Prints a countdown to the next episode as the last episode in the list. If in hi
 Play the dubbed version. Without this flag, it'll always play the subbed version.
 .TP
 \fB\--rofi\fR
-Use rofi instead of fzf for the interactive menu 
+Use rofi instead of fzf for the interactive menu
 .TP
 \fB\--skip\fR
 Use ani-skip to skip the intro of the episode (mpv only)
 .TP
 \fB\--no-detach\fR
 Don't detach the player (useful for in-terminal playback, mpv only)
+\fB\--exit-after-play\fR
+Exit the player, and return the player exit code (useful for non interactive scenarios, works only if --no-detach is used, mpv only)
 .TP
 \fB\--skip-title\fR \fI\,<title>\/\fR
 Specify the title to use for ani-skip


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description



## Checklist

- [ ] any anime playing
- [x] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
