### PR TITLE
docs: added FreeBSD installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,34 +383,10 @@ rm -rf ani-cli
 
 #### Installation in steps:
 
-##### Install mpv:
+##### Install dependencies:
 
 ```sh
-sudo pkg install mpv
-```
-
-##### Install [fzf](https://github.com/junegunn/fzf):
-
-```sh
-sudo pkg install fzf
-```
-
-##### Install [aria2](https://github.com/aria2/aria2) (needed for download feature only):
-
-```sh
-sudo pkg install aria2
-```
-
-##### Install [yt-dlp](https://github.com/yt-dlp/yt-dlp) (needed for download feature only):
-
-```sh
-sudo pkg install yt-dlp
-```
-
-##### Install [patch](https://savannah.gnu.org/projects/patch/) (needed for self-update feature [ -U ] ):
-
-```sh
-sudo pkg install patch
+sudo pkg install mpv fzf aria2 yt-dlp patch
 ```
 
 ##### Install ani-cli:

--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ For install instructions visit [ani-skip](https://github.com/synacktraa/ani-skip
 
 Ani-skip uses the external lua script function of mpv and as such – for now – only works with mpv.
 
-**Warning:** For now, ani-skip does **not** seem to work under Windows or FreeBSD.
+**Warning:** For now, ani-skip does **not** seem to work under Windows.
 
 **Note:** It may be, that ani-skip won't know the anime you're trying to watch. Try using the `--skip-title <title>` command line argument. (It uses the [aniskip API](https://github.com/lexesjan/typescript-aniskip-extension/tree/main/src/api/aniskip-http-client) and you can contribute missing anime or ask for including it in the database on their [discord server](https://discord.com/invite/UqT55CbrbE)).
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ In Steam Desktop app:
 <details><summary><b>FreeBSD</b></summary>
 	
 #### Linux Binary Compatibility:
-important to note that ani-cli will not work if you don't have linuxemu installed.
+important to note that ani-cli will not work if you don't have linuxemu enabled.
 here are the minimum instructions to get it up and running, for more info refer to the official [docs](https://docs.freebsd.org/en/books/handbook/linuxemu/).
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -371,8 +371,21 @@ In Steam Desktop app:
 </details>
 
 <details><summary><b>FreeBSD</b></summary>
-	
-#### Linux Binary Compatibility:
+
+#### Copypaste script:
+
+```sh
+sudo sysrc linux_enable="YES"
+service linux start
+sudo pkg install mpv fzf aria2 yt-dlp patch git
+git clone "https://github.com/pystardust/ani-cli.git"
+sudo cp ani-cli/ani-cli /usr/local/bin
+rm -rf ani-cli
+```
+
+#### Installation in steps:
+
+##### Linux Binary Compatibility:
 important to note that ani-cli will not work if you don't have linuxemu enabled.
 here are the minimum instructions to get it up and running, for more info refer to the official [docs](https://docs.freebsd.org/en/books/handbook/linuxemu/).
 
@@ -381,13 +394,34 @@ sudo sysrc linux_enable="YES"
 service linux start
 ```
 
-#### Installation in steps:
-
-##### Install dependencies (including mpv): 
-important to note these are only the basic dependencies if you want more functionality its up to you to find and install them.
+##### Install mpv:
 
 ```sh
-sudo pkg install fzf curl mpv
+sudo pkg install mpv
+```
+
+##### Install [fzf](https://github.com/junegunn/fzf):
+
+```sh
+sudo pkg install fzf
+```
+
+##### Install [aria2](https://github.com/aria2/aria2) (needed for download feature only):
+
+```sh
+sudo pkg install aria2
+```
+
+##### Install [yt-dlp](https://github.com/yt-dlp/yt-dlp) (needed for download feature only):
+
+```sh
+sudo pkg install yt-dlp
+```
+
+##### Install [patch](https://savannah.gnu.org/projects/patch/) (needed for self-update feature [ -U ] ):
+
+```sh
+sudo pkg install patch
 ```
 
 ##### Install ani-cli:

--- a/README.md
+++ b/README.md
@@ -371,8 +371,39 @@ In Steam Desktop app:
 </details>
 
 <details><summary><b>FreeBSD</b></summary>
+	
+#### Linux Binary Compatibility:
+important to note that ani-cli will not work if you don't have linuxemu installed.
+here are the minimum instructions to get it up and running, for more info refer to the official [docs](https://docs.freebsd.org/en/books/handbook/linuxemu/).
+
 ```sh
-	echo test to see if i got structure of readme right
+sudo sysrc linux_enable="YES"
+service linux start
+```
+
+#### Installation in steps:
+
+##### Install dependencies (including mpv): 
+important to note these are only the basic dependencies if you want more functionality its up to you to find and install them.
+
+```sh
+sudo pkg install fzf curl mpv
+```
+
+##### Install ani-cli:
+
+install git if you haven't already
+
+```sh
+sudo pkg install git
+```
+
+install from source:
+
+```sh
+git clone "https://github.com/pystardust/ani-cli.git"
+sudo cp ani-cli/ani-cli /usr/local/bin
+rm -rf ani-cli
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Name=ani-cli' > $HOME/.local/share/applications/ani-cli.desktop
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"
 In Steam Desktop app:
 `Add game` > `Add a non-steam game` > tick a box for `ani-cli` > `Add selected programs`
+</details>
 
 <details><summary><b>FreeBSD</b></summary>
 ```sh

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A cli to browse and watch anime (alone AND with friends). This tool scrapes the 
 - [Fixing errors](#fixing-errors)
 - [Install](#install)
   - [Tier 1: Linux, Mac, Android](#tier-1-support-linux-mac-android)
-  - [Tier 2: Windows, WSL, iOS, Steam Deck](#tier-2-support-windows-wsl-ios-steam-deck)
+  - [Tier 2: Windows, WSL, iOS, Steam Deck, FreeBSD](#tier-2-support-windows-wsl-ios-steam-deck-FreeBSD)
   - [From Source](#installing-from-source)
 - [Uninstall](#uninstall)
 - [Dependencies](#dependencies-1)
@@ -160,9 +160,9 @@ For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note
 
 </details>
 
-### Tier 2 Support: Windows, WSL, iOS, Steam Deck
+### Tier 2 Support: Windows, WSL, iOS, Steam Deck, FreeBSD
 
-*While officially supported, installation is more involved on these platforms and sometimes issues arise. \
+*While officially supported (except FreeBSD), installation is more involved on these platforms and sometimes issues arise. \
 Reach out if you need help.*
 
 <details><summary><b>Windows</b></summary>
@@ -368,6 +368,12 @@ Name=ani-cli' > $HOME/.local/share/applications/ani-cli.desktop
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"
 In Steam Desktop app:
 `Add game` > `Add a non-steam game` > tick a box for `ani-cli` > `Add selected programs`
+
+<details><summary><b>FreeBSD</b></summary>
+```sh
+	echo test to see if i got structure of readme right
+```
+
 </details>
 
 ### Installing from source

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ For install instructions visit [ani-skip](https://github.com/synacktraa/ani-skip
 
 Ani-skip uses the external lua script function of mpv and as such – for now – only works with mpv.
 
-**Warning:** For now, ani-skip does **not** seem to work under Windows.
+**Warning:** For now, ani-skip does **not** seem to work under Windows or FreeBSD.
 
 **Note:** It may be, that ani-skip won't know the anime you're trying to watch. Try using the `--skip-title <title>` command line argument. (It uses the [aniskip API](https://github.com/lexesjan/typescript-aniskip-extension/tree/main/src/api/aniskip-http-client) and you can contribute missing anime or ask for including it in the database on their [discord server](https://discord.com/invite/UqT55CbrbE)).
 

--- a/README.md
+++ b/README.md
@@ -375,8 +375,6 @@ In Steam Desktop app:
 #### Copypaste script:
 
 ```sh
-sudo sysrc linux_enable="YES"
-service linux start
 sudo pkg install mpv fzf aria2 yt-dlp patch git
 git clone "https://github.com/pystardust/ani-cli.git"
 sudo cp ani-cli/ani-cli /usr/local/bin
@@ -384,15 +382,6 @@ rm -rf ani-cli
 ```
 
 #### Installation in steps:
-
-##### Linux Binary Compatibility:
-important to note that ani-cli will not work if you don't have linuxemu enabled.
-here are the minimum instructions to get it up and running, for more info refer to the official [docs](https://docs.freebsd.org/en/books/handbook/linuxemu/).
-
-```sh
-sudo sysrc linux_enable="YES"
-service linux start
-```
 
 ##### Install mpv:
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

I added Tier 2 FreeBSD support using the linuxemu (aka Linux ABI)
which is very simple to setup.

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
