### PR TITLE
Add mpv option to use for MAC

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -359,7 +359,7 @@ while [ $# -gt 0 ]; do
             case "$(uname -a)" in
                 *ndroid*) player_function="android_mpv" ;;
                 MINGW* | *WSL2*) player_function="mpv.exe" ;;
-                *steamdeck* player_function="flatpak_mpv" ;;
+                *steamdeck*) player_function="flatpak_mpv" ;;
                 *) player_function="mpv" ;;
             esac
             ;;

--- a/ani-cli
+++ b/ani-cli
@@ -53,6 +53,8 @@ help_info() {
         Specify the video quality
       -v, --vlc
         Use VLC to play the video
+      -m, --mpv
+        Use MPV to play the video
       -V, --version
         Show the version of the script
       -h, --help
@@ -351,6 +353,14 @@ while [ $# -gt 0 ]; do
                 MINGW* | *WSL2*) player_function="vlc.exe" ;;
                 *ish*) player_function="iSH" ;;
                 *) player_function="vlc" ;;
+            esac
+            ;;
+        -m | --mpv)
+            case "$(uname -a)" in
+                *ndroid*) player_function="android_mpv" ;;
+                MINGW* | *WSL2*) player_function="mpv.exe" ;;
+                *steamdeck* player_function="flatpak_mpv" ;;
+                *) player_function="mpv" ;;
             esac
             ;;
         -s | --syncplay)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.9"
+version_number="4.8.10"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Documentation update

## Description
An option to force using mpv on devices where mpv is not default. I want to use it on mac specifically.

## Checklist

- [ x] any anime playing
- [ x] bumped version
---
- [ x] next, prev and replay work
- [ x] `-c` history and continue work
- [ x] `-d` downloads work
- [ ] `-s` syncplay works
- [ x] `-q` quality works
- [ x] `-v` vlc works
- [ x] `-e` select episode works
- [ x] `-S` select index works
- [ x] `-r` range selection works
- [ x] `--skip` ani-skip works
- [ x] `--skip-title` ani-skip title argument works
- [ x] `--no-detach` no detach works
- [ x] `--dub` and regular (sub) mode both work
- [ x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ x] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
