### PR TITLE
feat: initial logger support

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -385,7 +385,7 @@ while [ $# -gt 0 ]; do
             ;;
         -l | --logview)
             case "$(uname -s)" in
-                Darwin*) log show --predicate 'eventMessage contains "ani-cli"' --info ;;
+                Darwin*) log show --predicate 'process == "logger"' ;;
                 Linux*) journalctl -t ani-cli ;;
                 *) die "Logger not implemented for your platform" ;;
             esac

--- a/ani-cli
+++ b/ani-cli
@@ -2,7 +2,6 @@
 
 version_number="4.9.0"
 
-
 # UI
 
 external_menu() {

--- a/ani-cli
+++ b/ani-cli
@@ -45,6 +45,8 @@ help_info() {
         Download the video instead of playing it
       -D, --delete
         Delete history
+      -l, --logview
+        Show logs
       -s, --syncplay
         Use Syncplay to watch with friends
       -S, --select-nth
@@ -249,6 +251,7 @@ download() {
 }
 
 play_episode() {
+    [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
     [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
@@ -320,6 +323,7 @@ allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
+log_episode="${ANI_CLI_LOG:-1}"
 quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
@@ -377,6 +381,13 @@ while [ $# -gt 0 ]; do
         -d | --download) player_function=download ;;
         -D | --delete)
             : >"$histfile"
+            exit 0
+            ;;
+        -l | --logview)
+            case "$(uname -s)" in
+                Darwin*) log show --predicate 'eventMessage contains "ani-cli"' --info ;;
+                Linux*) journalctl -t ani-cli ;;
+            esac
             exit 0
             ;;
         -V | --version) version_info ;;

--- a/ani-cli
+++ b/ani-cli
@@ -387,6 +387,7 @@ while [ $# -gt 0 ]; do
             case "$(uname -s)" in
                 Darwin*) log show --predicate 'eventMessage contains "ani-cli"' --info ;;
                 Linux*) journalctl -t ani-cli ;;
+                *) die "Logger not implemented for your platform" ;;
             esac
             exit 0
             ;;

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.10"
+version_number="4.9.0"
 
 # UI
 

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -28,6 +28,9 @@ Download episode.
 \fB\-D | --delete\fR
 Delete history.
 .TP
+\fB\-l | --logview\fR
+Show logs.
+.TP
 \fB\-h | --help\fR
 Show summary of options.
 .TP
@@ -85,6 +88,9 @@ Sets the player ani-cli uses. Can be debug (print links), download (equivalent t
 .TP
 \fBANI_CLI_EXTERNAL_MENU\fR
 Controls the frontend of ani-cli. Can be 0 (uses fzf) or 1 (uses rofi dmenu). Default is 0.
+.TP
+\fBANI_CLI_LOG_EPISODE\fR
+Controls the logging feature for playback. Can be 1(logs) or 0(doesn't log). Default is 1.
 .TP
 \fBANI_CLI_MULTI_SELECTION\fR
 Controls the multi flag for the chosen frontend. Default is -m for fzf and --multi-select for rofi dmenu.


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
