### PR TITLE
feat: allow -c to continue from dub

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -228,7 +228,7 @@ update_history() {
         sed -E "s|^[^\t]+\t${id}\t[^\t]+.*$|${ep_no}\t${id}\t${title}\t${mode}|" "$histfile" >"${histfile}.new"
     else
         cp "$histfile" "${histfile}.new"
-        printf "%s\t%s\t%s\t%s\n" "$ep_no" "$id" "$title" "$mode">>"${histfile}.new"
+        printf "%s\t%s\t%s\t%s\n" "$ep_no" "$id" "$title" "$mode" >>"${histfile}.new"
     fi
     mv "${histfile}.new" "$histfile"
 }
@@ -424,7 +424,7 @@ esac
 # searching
 case "$search" in
     history)
-        anime_list=$(while IFS=$'\t' read -r ep_no id title mode; do process_hist_entry & done <"$histfile")
+        anime_list=$(while IFS=$(printf '\t') read -r ep_no id title mode; do process_hist_entry & done <"$histfile")
         wait
         [ -z "$anime_list" ] && die "No unwatched series in history!"
         [ -z "${index##*[!0-9]*}" ] && id=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: " | cut -f1)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.10"
+version_number="4.8.11"
 
 # UI
 
@@ -22,7 +22,7 @@ nth() {
     prompt="$1"
     multi_flag=""
     [ $# -ne 1 ] && shift && multi_flag="$1"
-    line=$(printf "%s" "$stdin" | cut -f1,3 | tr '\t' ' ' | launcher "$multi_flag" "$prompt" | cut -d " " -f 1)
+    line=$(printf "%s" "$stdin" | cut -f1,3,4 | tr '\t' ' ' | launcher "$multi_flag" "$prompt" | cut -d " " -f 1)
     [ -n "$line" ] && printf "%s" "$stdin" | grep -E '^'"${line}"'($|[[:space:]])' | cut -f2,3 || exit 1
 }
 
@@ -220,15 +220,15 @@ process_hist_entry() {
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
     ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
-    [ -n "$ep_no" ] && printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
+    [ -n "$ep_no" ] && printf "%s\t%s - episode %s\t(%s)\n" "$id" "$title" "$ep_no" "$mode"
 }
 
 update_history() {
     if grep -q -- "$id" "$histfile"; then
-        sed -E "s|^[^\t]+\t${id}\t[^\t]+$|${ep_no}\t${id}\t${title}|" "$histfile" >"${histfile}.new"
+        sed -E "s|^[^\t]+\t${id}\t[^\t]+.*$|${ep_no}\t${id}\t${title}\t${mode}|" "$histfile" >"${histfile}.new"
     else
         cp "$histfile" "${histfile}.new"
-        printf "%s\t%s\t%s\n" "$ep_no" "$id" "$title" >>"${histfile}.new"
+        printf "%s\t%s\t%s\t%s\n" "$ep_no" "$id" "$title" "$mode">>"${histfile}.new"
     fi
     mv "${histfile}.new" "$histfile"
 }
@@ -424,7 +424,7 @@ esac
 # searching
 case "$search" in
     history)
-        anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
+        anime_list=$(while IFS=$'\t' read -r ep_no id title mode; do process_hist_entry & done <"$histfile")
         wait
         [ -z "$anime_list" ] && die "No unwatched series in history!"
         [ -z "${index##*[!0-9]*}" ] && id=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: " | cut -f1)
@@ -432,8 +432,10 @@ case "$search" in
         [ -z "$id" ] && exit 1
         title=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed 's/ - episode.*//')
         ep_list=$(episodes_list "$id")
-        ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)$/\1/p')
+        ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)/\1/p')
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        mode="$(printf "%s" "$anime_list" | grep "$id" | cut -f3 | sed 's/(\(.*\))/\1/')"
+        [ -z "$mode" ] && mode="${ANI_CLI_MODE:-sub}"
         ;;
     *)
         if [ "$use_external_menu" = "0" ]; then


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

This is a POC for #1371. It adds a sub/dub column in the history file so `-c` knows whether to continue subbed or dubbed.
It is not thoroughly tested.
It should work with old history files (without the sub/dub column).
The current behavior (in this PR) is so that if you switch between subbed and dubbed, the history file should reflect the latest switch.
If we want to track subbed and dubbed separately, a change can be added to allow for that.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
