### PR TITLE
fix: steamdeck kernel detection

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.10"
+version_number="4.8.11"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -324,7 +324,7 @@ quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
-    *steamdeck*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;  # steamdeck OS
+    *neptune*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;  # steamdeck OS - Fixed checking for default hostname, now checks for kernel codename.
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                    # Linux OS

--- a/ani-cli
+++ b/ani-cli
@@ -324,7 +324,7 @@ quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
-    *neptune*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;  # steamdeck OS - Fixed checking for default hostname, now checks for kernel codename.
+    *neptune*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;    # steamdeck OS
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
     *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                    # Linux OS


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [X ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Ani-Cli originally checks for Steam Deck / SteamOS by checking for the default host name, which breaks the script if the host name is changed by the user. This fix checks for the kernel codename instead.


