### PR TITLE
Add copy url to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 - fzf - User interface
 - ani-skip (optional)
 - patch - Self updating
+- [clipboard](https://github.com/Slackadays/Clipboard)
 
 ### Ani-Skip
 

--- a/ani-cli
+++ b/ani-cli
@@ -278,6 +278,7 @@ play_episode() {
             printf "\e]8;;vlc://%s\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode"
             sleep 5
             ;;
+        cb*) nohup "$player_function" copy "$episode" >/dev/null 2>&1 & ;;
         *) nohup "$player_function" "$episode" >/dev/null 2>&1 & ;;
     esac
     replay="$episode"
@@ -361,6 +362,15 @@ while [ $# -gt 0 ]; do
                     player_function="syncplay.exe"
                     ;;
                 *) player_function="syncplay" ;;
+            esac
+            ;;
+        -C | --copyurl) # Sorry for bad SH :3 <3
+            case "$(uname -s)" in
+                MINGW* | *Msys)
+                    export PATH="$PATH":"/c/Users/$(whoami)/scoop/shims" # i hope you have "clipboard" installed using scoop (https://github.com/Slackadays/Clipboard)
+                    player_function="cb.exe"
+                    ;;
+                *) player_function="cb" ;;
             esac
             ;;
         -q | --quality)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.11"
+version_number="4.8.12"
 
 # UI
 
@@ -41,6 +41,8 @@ help_info() {
     Options:
       -c, --continue
         Continue watching from history
+      -C, --copyurl
+        Copy the currently playing anime URL to clipboard
       -d, --download
         Download the video instead of playing it
       -D, --delete

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -22,6 +22,9 @@ Specify the episode numbers to watch. If range is specified it should be quoted 
 \fB\-c | --continue\fR
 Continue watching anime from history.
 .TP
+\fB\-C | --copyurl\fR
+Copy the currently playing anime URL to clipboard.
+.TP
 \fB\-d | --download\fR
 Download episode.
 .TP


### PR DESCRIPTION
Add a thing to copy the episode url to clipboard

# Pull Request Template

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Documentation update

## Description

Syncplay was a little odd so I just thought it'd be easier to have the episode URL copied to the clipboard and then pasted to syncplay instead of rejoining the instance 200 times just while watching one piece for example.
I've just checked the applicable below.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [x] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
