### PR TITLE
fix: support using non brew iina as a player on macos

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -115,7 +115,7 @@ dep_ch() {
 
 where_iina() {
     [ -n "$ANI_CLI_PLAYER" ] && echo "$ANI_CLI_PLAYER" && return 0
-    [ -n "$(command -v iina)" ] && echo "iina" && return 0
+    command -v iina >/dev/null && echo "iina" && return 0
     [ -e "/Applications/IINA.app/Contents/MacOS/iina-cli" ] && echo "/Applications/IINA.app/Contents/MacOS/iina-cli" && return 0
     dep_ch iina # exit with formating
 }

--- a/ani-cli
+++ b/ani-cli
@@ -275,7 +275,7 @@ play_episode() {
             ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
-        iina) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        *iina*) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -114,8 +114,8 @@ dep_ch() {
 }
 
 where_iina() {
-    [ -n "$ANI_CLI_PLAYER" ] && echo "$ANI_CLI_PLAYER" && return 0
-    command -v iina >/dev/null && echo "iina" && return 0
+    [ -n "$ANI_CLI_PLAYER" ] && printf "$ANI_CLI_PLAYER" && return 0
+    command -v iina >/dev/null && printf "iina" && return 0
     [ -e "/Applications/IINA.app/Contents/MacOS/iina-cli" ] && echo "/Applications/IINA.app/Contents/MacOS/iina-cli" && return 0
     dep_ch iina # exit with formating
 }
@@ -329,7 +329,7 @@ mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
-    *Darwin*) player_function=$(where_iina) ;;                        # mac OS
+    *Darwin*) player_function="$(where_iina)" ;;                      # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
     *neptune*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;    # steamdeck OS
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS

--- a/ani-cli
+++ b/ani-cli
@@ -114,7 +114,7 @@ dep_ch() {
 }
 
 where_iina() {
-    [ -n "$ANI_CLI_PLAYER" ] && printf "$ANI_CLI_PLAYER" && return 0
+    [ -n "$ANI_CLI_PLAYER" ] && printf "%s" "$ANI_CLI_PLAYER" && return 0
     command -v iina >/dev/null && printf "iina" && return 0
     [ -e "/Applications/IINA.app/Contents/MacOS/iina-cli" ] && echo "/Applications/IINA.app/Contents/MacOS/iina-cli" && return 0
     dep_ch iina # exit with formating

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.11"
+version_number="4.8.12"
 
 # UI
 
@@ -111,6 +111,13 @@ dep_ch() {
     for dep; do
         command -v "$dep" >/dev/null || die "Program \"$dep\" not found. Please install it."
     done
+}
+
+where_iina() {
+    [ -n "$ANI_CLI_PLAYER" ] && echo "$ANI_CLI_PLAYER" && return 0
+    [ -n "$(command -v iina)" ] && echo "iina" && return 0
+    [ -e "/Applications/IINA.app/Contents/MacOS/iina-cli" ] && echo "/Applications/IINA.app/Contents/MacOS/iina-cli" && return 0
+    dep_ch iina # exit with formating
 }
 
 # SCRAPING
@@ -322,7 +329,7 @@ mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
-    *Darwin*) player_function="${ANI_CLI_PLAYER:-iina}" ;;            # mac OS
+    *Darwin*) player_function=$(where_iina) ;;                        # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
     *neptune*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;    # steamdeck OS
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
@@ -418,6 +425,7 @@ case "$player_function" in
         ;;
     android*) printf "\33[2K\rChecking of players on Android is disabled\n" ;;
     *iSH*) printf "\33[2K\rChecking of players on iOS is disabled\n" ;;
+    *iina*) true ;; # handled out of band in where_iina
     *) dep_ch "$player_function" ;;
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.12"
+version_number="4.8.13"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix

## Description

supersedes #1386 

## To test

- [x] the `-e` test works on mac os (could fail due to permissions)
- [x] both iinas work
- [x] failing dep check works as expected
- [x] test playing the next episode
- [x] test `-c`