### PR TITLE
fix: fix issue where a non-working Alt link gets used when on iSH

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -178,7 +178,7 @@ get_episode_url() {
     done
     wait
     # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d;\Alt\d' | sort -g -r -s)
+    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d;/Alt/d' | sort -g -r -s)
     rm -r "$cache_dir"
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"

--- a/ani-cli
+++ b/ani-cli
@@ -178,7 +178,7 @@ get_episode_url() {
     done
     wait
     # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d' | sort -g -r -s)
+    links=$(cat "$cache_dir"/* | sed '\Alt\d;s|^Mp4-||g;/http/!d' | sort -g -r -s)
     rm -r "$cache_dir"
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"

--- a/ani-cli
+++ b/ani-cli
@@ -178,7 +178,7 @@ get_episode_url() {
     done
     wait
     # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d;\Alt\d;' | sort -g -r -s)
+    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d;\Alt\d' | sort -g -r -s)
     rm -r "$cache_dir"
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.8.11"
+version_number="4.8.12"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -178,7 +178,7 @@ get_episode_url() {
     done
     wait
     # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sed '\Alt\d;s|^Mp4-||g;/http/!d' | sort -g -r -s)
+    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d;\Alt\d;' | sort -g -r -s)
     rm -r "$cache_dir"
     episode=$(select_quality "$quality")
     [ -z "$episode" ] && die "Episode not released!"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

How the hell did this happen?
I couldn’t test sync play as I don’t have an actual PC on me atm.
Quality doesn’t work on the current version so it won’t work here either. This isn’t to fix that problem.
I don’t have ani-skip so I can’t test that but it should work.

couldn’t test no-detach cause I don’t have a PC on me rn. Again it should work

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [X] `-S` select index works
- [X] `-r` range selection works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
