### PR TITLE
feat: added flag for mpv as flatpak

### DIFF
--- a/.github/workflows/ani-cli.yml
+++ b/.github/workflows/ani-cli.yml
@@ -12,7 +12,7 @@ jobs:
     name: Shellcheck + Shfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run the sh-checker
       uses: luizm/action-sh-checker@master
       env:
@@ -23,7 +23,7 @@ jobs:
     name: Executable Bit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: test exec bit
       run: test -x "./ani-cli"
 
@@ -31,6 +31,6 @@ jobs:
     name: No Awk Allowed
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: verify that noone added awk
       run: '! grep awk "./ani-cli"'

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -22,5 +22,5 @@ jobs:
     name: Find Trailing Whitespace
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ocular-d/trailing-spaces@0.0.2

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,7 +9,7 @@ jobs:
     name: Version Bump
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: check version bump

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.0"
+version_number="4.9.1"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -45,6 +45,8 @@ help_info() {
         Download the video instead of playing it
       -D, --delete
         Delete history
+      -f, --flatpak-mpv
+        Use mpv (flatpak) to play the video
       -l, --logview
         Show logs
       -s, --syncplay
@@ -364,6 +366,8 @@ while [ $# -gt 0 ]; do
                 *) player_function="vlc" ;;
             esac
             ;;
+        -f | --flatpak-mpv)
+            player_function="flatpak_mpv" ;;
         -s | --syncplay)
             case "$(uname -s)" in
                 Darwin*) player_function="/Applications/Syncplay.app/Contents/MacOS/syncplay" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -45,8 +45,6 @@ help_info() {
         Download the video instead of playing it
       -D, --delete
         Delete history
-      -f, --flatpak-mpv
-        Use mpv (flatpak) to play the video
       -l, --logview
         Show logs
       -s, --syncplay
@@ -122,6 +120,12 @@ where_iina() {
     command -v iina >/dev/null && printf "iina" && return 0
     [ -e "/Applications/IINA.app/Contents/MacOS/iina-cli" ] && echo "/Applications/IINA.app/Contents/MacOS/iina-cli" && return 0
     dep_ch iina # exit with formating
+}
+
+where_mpv() {
+    command -v "$ANI_CLI_PLAYER" >/dev/null && printf "%s" "$ANI_CLI_PLAYER" && return 0
+    command -v "flatpak" >/dev/null && flatpak info io.mpv.Mpv >/dev/null 2>&1 && printf "%s" "flatpak_mpv" && return 0
+    dep_ch mpv # exit with formating
 }
 
 # SCRAPING
@@ -337,10 +341,12 @@ quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
     *Darwin*) player_function="$(where_iina)" ;;                      # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
-    *neptune*) player_function="${ANI_CLI_PLAYER:-flatpak_mpv}" ;;    # steamdeck OS
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
-    *) player_function="${ANI_CLI_PLAYER:-mpv}" ;;                    # Linux OS
+    *) 
+      player_function="${ANI_CLI_PLAYER:-$(where_mpv)}"               # Linux OS
+      [ $? -eq 0 ] || exit $?
+      ;;
 esac
 
 no_detach="${ANI_CLI_NO_DETACH:-0}"
@@ -365,9 +371,6 @@ while [ $# -gt 0 ]; do
                 *ish*) player_function="iSH" ;;
                 *) player_function="vlc" ;;
             esac
-            ;;
-        -f | --flatpak-mpv)
-            player_function="flatpak_mpv"
             ;;
         -s | --syncplay)
             case "$(uname -s)" in
@@ -436,13 +439,10 @@ if [ -z "$ANI_CLI_NON_INTERACTIVE" ]; then dep_ch fzf || true; fi
 case "$player_function" in
     debug) ;;
     download) dep_ch "ffmpeg" "aria2c" ;;
-    flatpak*)
-        dep_ch "flatpak"
-        flatpak info io.mpv.Mpv >/dev/null 2>&1 || die "Program \"mpv (flatpak)\" not found. Please install it."
-        ;;
     android*) printf "\33[2K\rChecking of players on Android is disabled\n" ;;
     *iSH*) printf "\33[2K\rChecking of players on iOS is disabled\n" ;;
     *iina*) true ;; # handled out of band in where_iina
+    *mpv*) true ;; # handled out of band in where_mpv
     *) dep_ch "$player_function" ;;
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -367,7 +367,8 @@ while [ $# -gt 0 ]; do
             esac
             ;;
         -f | --flatpak-mpv)
-            player_function="flatpak_mpv" ;;
+            player_function="flatpak_mpv"
+            ;;
         -s | --syncplay)
             case "$(uname -s)" in
                 Darwin*) player_function="/Applications/Syncplay.app/Contents/MacOS/syncplay" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -339,14 +339,17 @@ download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"
 quality="${ANI_CLI_QUALITY:-best}"
 case "$(uname -a)" in
-    *Darwin*) player_function="$(where_iina)" ;;                      # mac OS
+    *Darwin*)                                                         # mac OS
+        player_function="$(where_iina)"
+        [ $? -eq 0 ] || exit $?
+        ;;
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
     *ish*) player_function="${ANI_CLI_PLAYER:-iSH}" ;;                # iOS (iSH)
-    *) 
-      player_function="${ANI_CLI_PLAYER:-$(where_mpv)}"               # Linux OS
-      [ $? -eq 0 ] || exit $?
-      ;;
+    *)                                                                # Linux OS
+        player_function="${ANI_CLI_PLAYER:-$(where_mpv)}"
+        [ $? -eq 0 ] || exit $?
+        ;;
 esac
 
 no_detach="${ANI_CLI_NO_DETACH:-0}"

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -25,9 +25,6 @@ Continue watching anime from history.
 \fB\-d | --download\fR
 Download episode.
 .TP
-\fB\-f | --flatpak-mpv\fR
-Wathc anime via mpv packaged as flatpak.
-.TP
 \fB\-D | --delete\fR
 Delete history.
 .TP

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -25,6 +25,9 @@ Continue watching anime from history.
 \fB\-d | --download\fR
 Download episode.
 .TP
+\fB\-f | --flatpak-mpv\fR
+Wathc anime via mpv packaged as flatpak.
+.TP
 \fB\-D | --delete\fR
 Delete history.
 .TP


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Comply with request #1408

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [ ] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
