### PR TITLE
ci: fix conflicting path and path ignore

### DIFF
--- a/.github/workflows/ani-cli.yml
+++ b/.github/workflows/ani-cli.yml
@@ -5,10 +5,7 @@ on:
       - master
   pull_request:
     paths:
-      - "**ani-cli"
-    paths-ignore:
-      - "_ani-cli-bash"
-      - "_ani-cli-zsh"
+      - "/ani-cli"
 
 jobs:
   sh-checker:

--- a/.github/workflows/inverse-ani.yml
+++ b/.github/workflows/inverse-ani.yml
@@ -5,7 +5,7 @@ name: 'ani-cli checks'
 on:
   pull_request:
     paths-ignore:
-      - "**ani-cli"
+      - "/ani-cli"
 jobs:
   sh-checker:
     name: Shellcheck + Shfmt

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,7 +2,7 @@ name: 'ani-cli checks'
 on:
   pull_request:
     paths: 
-      - "**ani-cli"
+      - "/ani-cli"
       
 jobs:
   version-bump:


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
