### PR TITLE
feat:Add carapace, multi shell autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ rm -rf "~/.fzf"
 flatpak uninstall io.mpv.Mpv
 ```
 * iOS
-```
+```sh
 rm -rf /usr/local/bin/ani-cli
 ```
 To uninstall other dependencies:
@@ -504,7 +504,7 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 ### bash
 
 To add tab completions using bash run the following command inside the ani-cli directory
-```
+```sh
 cp _ani-cli-bash /path/to/your/completions
 echo "source /path/to/your/completions/_ani-cli-bash" >> ~/.bashrc
 ```
@@ -512,11 +512,19 @@ echo "source /path/to/your/completions/_ani-cli-bash" >> ~/.bashrc
 ### zsh
 
 To add tab completions using zsh run the following command inside the ani-cli directory
-```
+```sh
 cp _ani-cli-zsh /path/to/your/completions
 echo "source /path/to/your/completions/_ani-cli-zsh" >> ~/.zshrc
 ```
 
+### Cross-Shell (with [Carapace](https://github.com/carapace-sh/carapace))
+
+See the [setup](https://carapace-sh.github.io/carapace-bin/setup.html) guide on Carapace for your specific shell. 
+To add tab completions using zsh run the following command inside the ani-cli directory
+```sh
+cp ani-cli.toml $HOME/.config/carapace/specs/ani-cli.yaml
+# Restart your shell for good measure
+``````
 ## Dependencies
 
 - grep

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.2"
+version_number="4.9.3"
 
 # UI
 

--- a/ani-cli.yaml
+++ b/ani-cli.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://carapace.sh/schemas/command.json
+name: ani-cli
+flags:
+  -c:  Continue watching from history
+  -d, --download:  Download the video instead of playing it
+  -D, --delete:  Delete history
+  -l, --logview:  Show logs
+  -s, --syncplay:  Use Syncplay to watch with friends
+  -S, --select-nth: Select nth entry
+  -q, --quality=: Specify the video quality
+  -v, --vlc:  Use VLC to play the video
+  -V, --version:  Show the version of the script
+  -e, --episode=:                      Specify the episode to watch
+  -r, --range=:                        Specify the range of episodes to watch
+  --dub:  Play dubbed version
+  --rofi:  Use rofi instead of fzf for the interactive menu
+  --skip:  Use ani-skip to skip the intro of the episode (mpv only)
+  --no-detach:  Don't detach the player (mpv only)
+  --exit-after-play:  Exit the player, and return the player exit code (mpv only)
+  --skip-title=:                       Use given title as ani-skip query
+  -N, --nextep-countdown:             Display a countdown to the next episode
+  -U, --update:  Update the script
+persistentflags:
+  -h, --help:  Show this help message and exit
+completion:
+  flag:
+    quality: ["480p", "720p", "1080p", "4K"] # Add supported qualities
+    episode: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"] # Example episode numbers or ranges
+    range: [ "1-13","1-26","1-3", "2-4", "3-4", "5-6"] # Example ranges


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [x] Feature
- [x] Documentation update

## Description

I saw that there was bash and zsh completion available (which seems to be non-exhaustive of flags, I noticed that while comparing to --help) and as I am a NuShell user primarily, I wanted to have that too. Carapace is a cross-shell (and even windows) auto-completion engine, so I figured it would be nice for everyone to have.

I am not sure if [Carapace-spec](https://carapace-sh.github.io/carapace-spec/carapace-spec/usage.html) is required for this as I used documentation from that version, but I could not test as I am on NixOS and the only Carapace available just works. If others could test and confirm, I can make note of that in the READMe. General testing would be handy of course. :)

## Checklist

- [x] any anime playing
- [x] bumped version
---
### I didn't change the actual code so this all should be identical
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [x] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
