### PR TITLE
docs: add fastanime to homies

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,3 +574,4 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 * [doccli](https://github.com/TowarzyszFatCat/doccli):  A cli to watch anime with POLISH subtitles (Python)
 * [GoAnime](https://github.com/alvarorichard/GoAnime): A CLI tool to browse, play, and download anime in Portuguese(Go)
 * [Curd](https://github.com/Wraient/curd): A CLI tool to watch anime with Anilist, Discord RPC, Skip Intro Outro (Python)
+- [FastAnime](https://github.com/Benex254/FastAnime): browser anime experience from the terminal (Python)


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description
Adds [FastAnime](https://github.com/Benex254/FastAnime) to homies which is just a tool that aims to replicate the anime browser site experience in the terminal.