### PR TITLE
fix: remove hostname from uname output in OS detection

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -335,7 +335,7 @@ mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"
 quality="${ANI_CLI_QUALITY:-best}"
-case "$(uname -a)" in
+case "$(uname -a | cut -d " " -f 1,3-)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-$(where_iina)}" ;;   # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
     *MINGW* | *WSL2*) player_function="${ANI_CLI_PLAYER:-mpv.exe}" ;; # Windows OS
@@ -359,7 +359,7 @@ search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
 while [ $# -gt 0 ]; do
     case "$1" in
         -v | --vlc)
-            case "$(uname -a)" in
+            case "$(uname -a | cut -d " " -f 1,3-)" in
                 *ndroid*) player_function="android_vlc" ;;
                 MINGW* | *WSL2*) player_function="vlc.exe" ;;
                 *ish*) player_function="iSH" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.2"
+version_number="4.9.5"
 
 # UI
 


### PR DESCRIPTION
# fix: remove hostname from uname output in OS detection

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Using $(uname -a | awk '{$2=""; print $0}') instead of just uname -a helps remove the hostname from the output. since hostname can vary between systems it may lead to incorrect OS detection. By stripping out the hostname case statement accurately matches the relevant OS identifiers.

In my system script not work properly because my hostname is "vaishakh" , because it contains "ish" the case identify my linux device as ios device and ani-cli failed to play the video.

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-S` select index works
- [X] `-r` range selection works
- [X] `--skip` ani-skip works
- [X] `--skip-title` ani-skip title argument works
- [X] `--no-detach` no detach works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
