### PR TITLE
fix:avoids reencoding the + while running time_until_next_ep

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -218,7 +218,8 @@ search_anime() {
 
 time_until_next_ep() {
     animeschedule="https://animeschedule.net"
-    curl -s -G "$animeschedule/api/v3/anime" --data-urlencode "q=$1" | sed 's|"id"|\n|g' | sed -nE 's|.*,"route":"([^"]*)","premier.*|\1|p' | while read -r anime; do
+    avoids_reencoding="$(printf "%s" "$1" |sed 's/+/ /g')"
+    curl -s -G "$animeschedule/api/v3/anime" --data-urlencode "q=$avoids_reencoding" | sed 's|"id"|\n|g' | sed -nE 's|.*,"route":"([^"]*)","premier.*|\1|p' | while read -r anime; do
         data=$(curl -s "$animeschedule/anime/$anime" | sed '1,/"anime-header-list-buttons-wrapper"/d' | sed -nE 's|.*countdown-time-raw" datetime="([^"]*)">.*|Next Raw Release: \1|p;s|.*countdown-time" datetime="([^"]*)">.*|Next Sub Release: \1|p;s|.*english-title">([^<]*)<.*|English Title: \1|p;s|.*main-title".*>([^<]*)<.*|Japanese Title: \1|p')
         status="Ongoing"
         color="33"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Hey, it's me again. ha. I hope this one is simpler and a bit more well tested.

I noticed that checking for the next episode countdown only works when you use `-N` or `--nextep-countdown` by itself and did not provide a search directly in the cli command.
I narrowed down the reasoning to two things:
This snippet automatically replaces spaces with `+`
https://github.com/pystardust/ani-cli/blob/f2e81120c076d5e56e2420a08e3310fc61b4c0f7/ani-cli#L435
and the `curl` in the function re-encodes the `+` to become `%2B` when I look the verbose curl output.
https://github.com/pystardust/ani-cli/blob/f2e81120c076d5e56e2420a08e3310fc61b4c0f7/ani-cli#L221
The only reason that it works at all when using the built-in query picker is because the function is called one line before that query gets its spaces converted to `+`'s. I suspect this was known about when the feature was added due to the function call placement, but the author didn't realize it didn't work for queries from the cli

https://github.com/pystardust/ani-cli/blob/f2e81120c076d5e56e2420a08e3310fc61b4c0f7/ani-cli#L479-L481

I do not know a lot about curl, so Idk if there's an easier way to avoid re-encoding the `+` during the call, I tried just removing the flag, but that broke harder, so I just decided to use sed to return the spaces.

Note, I didn't test any anime that have a literal + in the title, I don't know if that exists even, so there's that.

## Checklist

- [x] any anime playing
- [ ] bumped version
---
I don't really want to go through and click all of these, i only changed the -N function so it'll all work
- [ ] next, prev and replay work
- [x] `--nextep-countdown`works
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
