### PR TITLE
fix: yt-dlp reports SSL: CERTIFICATE_VERIFY_FAILED when using ani-cli

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -261,7 +261,7 @@ download() {
     case $1 in
         *m3u8*)
             if command -v "yt-dlp" >/dev/null; then
-                yt-dlp "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
+                yt-dlp "$1" --no-check-certificate --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
             else
                 ffmpeg -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.5"
+version_number="4.9.6"
 
 # UI
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

```
[generic] Extracting URL: https://www083.anicdnstream.info/videos/hls/frDyoc9zWBkHzNV7K6Rqeg/1729950029/49323/f5db347daf6fb...p.14.1703900366.m3u8
[generic] ep.14.1703900366: Downloading webpage
ERROR: [generic] Unable to download webpage: Failed to perform, ErrCode: 60, Reason: 'SSL certificate problem: certificate has expired'. This may be a libcurl error, See https://curl.se/libcurl/c/libcurl-errors.html first for more details. (caused by CertificateVerifyError("Failed to perform, ErrCode: 60, Reason: 'SSL certificate problem: certificate has expired'. This may be a libcurl error, See https://curl.se/libcurl/c/libcurl-errors.html first for more details.")); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U
```

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
