### PR TITLE
docs: Update README.md to include instructions for NixOS and Nix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ Consider using the 9999 ebuild.
 sudo emerge -a =app-misc/ani-cli-9999
 ```
 
+</details><details><summary>NixOS and Nix</summary>
+
+Nixpkgs provides the `pkgs.ani-cli` attribute which can be overrided to support multiple options as demonstrated below. By default, `pkgs.ani-cli` only provides mpv support.
+
+```nix
+packages =
+    let
+        custom-ani-cli = pkgs.ani-cli.override {
+            withMpv = true;
+            withVlc = true;
+            withIina = true; # for macOS nix users
+            chromecastSupport = true;
+            syncSupport = true;
+        };
+    in
+    with pkgs; [
+        custom-ani-cli
+        ani-skip # ani-skip can also be installed (mpv only)
+    ];
+```
+
 </details><details><summary>OpenSuse</summary>
 
 On Suse the provided MPV and VLC packages are missing features that are used by ani-cli. The only required is the "Only Essentials" repository which has versions for each Suse release.
@@ -545,7 +566,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 
 ## FAQ
 <details>
-	
+
 * Can I change subtitle language or turn them off? - No, the subtitles are baked into the video.
 * Can I watch dub? - Yes, use `--dub`.
 * Can I change dub language? - No.


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Documentation update

## Description

Added NixOS and Nix entry to Install section as well as showcase the argument overrides one can use to enable support for other features. The instructions also work with Nix on MacOS but I decided to place NixOS under the Linux section. 

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` select episode works
- [ ] `-S` select index works
- [ ] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
