### PR TITLE
Feature to play all episodes

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -83,6 +83,7 @@ help_info() {
       %s -d -e 2 cyberpunk edgerunners
       %s --vlc cyberpunk edgerunners -q 1080p -e 4
       %s blue lock -e 5-6
+      %s blue lock -e all
       %s -e \"5 6\" blue lock
     \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
     exit 0

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.6"
+version_number="4.9.7"
 
 # UI
 
@@ -318,6 +318,10 @@ play() {
     [ -z "$end" ] || [ "$end" = "$start" ] && unset start end
     [ "$end" = "-1" ] && end=$(printf "%s" "$ep_list" | tail -n1)
     line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")
+    if [ "$ep_no" = "all" ]; then
+        start=1
+        end=$(printf "%s" "$ep_list" | tail -n1)
+    fi
     if [ "$line_count" != 1 ] || [ -n "$start" ]; then
         [ -z "$start" ] && start=$(printf "%s\n" "$ep_no" | head -n1)
         [ -z "$end" ] && end=$(printf "%s\n" "$ep_no" | tail -n1)


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

So I wanted to make a shell script for my phone to download multiple anime shows, but I needed a feature that lets me download a full series without specifying where each episode is supposed to end. I tried looking at the documentation and found out that there is no feature like that, so I thought I would add it. It's a working feature, but stylistically, it might be in the wrong place. so if someone thinks that it needs to be moved, tell me.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [ ] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [ ] `-S` select index works
- [x] `-r` range selection works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
