### PR TITLE
feat: fetch chapter information regardless of --skip argument

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -275,8 +275,7 @@ download() {
 play_episode() {
     [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
     skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
-    skip_flag_arr=($skip_flag)
-    [ "$skip_intro" = 0 ] && skip_flag=${skip_flag_arr[0]}
+    [ "$skip_intro" = 0 ] && skip_flag=$(echo $skip_flag | cut -d ' ' -f 1)
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
     case "$player_function" in

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.6"
+version_number="4.9.7"
 
 # UI
 
@@ -274,7 +274,9 @@ download() {
 
 play_episode() {
     [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
-    [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
+    skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
+    skip_flag_arr=($skip_flag)
+    [ "$skip_intro" = 0 ] && skip_flag=${skip_flag_arr[0]}
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
     case "$player_function" in
@@ -440,7 +442,6 @@ done
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
-[ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 if [ -z "$ANI_CLI_NON_INTERACTIVE" ]; then dep_ch fzf || true; fi
 case "$player_function" in
     debug) ;;
@@ -492,7 +493,7 @@ case "$search" in
         [ -z "$ep_no" ] && exit 1
         ;;
 esac
-[ "$skip_intro" = 1 ] && mal_id="$(ani-skip -q "${skip_title:-${title}}")"
+(dep_ch "ani-skip" || true) && mal_id="$(ani-skip -q "${skip_title:-${title}}")"
 
 # moves the cursor up one line and clears that line
 tput cuu1 && tput el

--- a/ani-cli
+++ b/ani-cli
@@ -275,7 +275,7 @@ download() {
 play_episode() {
     [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
     skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
-    [ "$skip_intro" = 0 ] && skip_flag=$(echo $skip_flag | cut -d ' ' -f 1)
+    [ "$skip_intro" = 0 ] && skip_flag=$(echo "$skip_flag" | cut -d " " -f 1)
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
     case "$player_function" in


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

I'd like to have chapter information even without the --skip argument. This way, depending on my mood, I can manually skip or re-watch the op or ed by moving between chapters.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
