### PR TITLE
feat: add possibility to display rofi menus as normal windows

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -65,8 +65,6 @@ help_info() {
         Play dubbed version
       --rofi
         Use rofi instead of fzf for the interactive menu
-      --normal-window
-        Make rofi menus appear as windows (only effective when --rofi is used)
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach
@@ -427,7 +425,6 @@ while [ $# -gt 0 ]; do
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 ;;
         --rofi) use_external_menu=1 ;;
-        --normal-window) external_menu_normal_window=1 ;;
         --skip) skip_intro=1 ;;
         --skip-title)
             [ $# -lt 2 ] && die "missing argument!"
@@ -443,9 +440,9 @@ done
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 if [ "$external_menu_normal_window" = "1" ]; then
-  external_menu_args="-normal-window"
+    external_menu_args="-normal-window"
 else
-  external_menu_args=""
+    external_menu_args=""
 fi
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.7"
+version_number="4.10.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.0"
+version_number="4.9.9"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -5,13 +5,13 @@ version_number="4.9.7"
 # UI
 
 external_menu() {
-    rofi "$1" -sort -dmenu -i -width 1500 -p "$2"
+    rofi "$1" -sort -dmenu -i -width 1500 -p "$2" "$3"
 }
 
 launcher() {
     [ "$use_external_menu" = "0" ] && [ -z "$1" ] && set -- "+m" "$2"
     [ "$use_external_menu" = "0" ] && fzf "$1" --reverse --cycle --prompt "$2"
-    [ "$use_external_menu" = "1" ] && external_menu "$1" "$2"
+    [ "$use_external_menu" = "1" ] && external_menu "$1" "$2" "$external_menu_args"
 }
 
 nth() {
@@ -65,6 +65,8 @@ help_info() {
         Play dubbed version
       --rofi
         Use rofi instead of fzf for the interactive menu
+      --normal-window
+        Make rofi menus appear as windows (effective only when --rofi is used)
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach
@@ -358,6 +360,7 @@ esac
 no_detach="${ANI_CLI_NO_DETACH:-0}"
 exit_after_play="${ANI_CLI_EXIT_AFTER_PLAY:-0}"
 use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
+external_menu_normal_window="${ANI_CLI_EXTERNAL_MENU_NORMAL_WINDOW:-0}"
 skip_intro="${ANI_CLI_SKIP_INTRO:-0}"
 # shellcheck disable=SC2154
 skip_title="$ANI_CLI_SKIP_TITLE"
@@ -424,6 +427,7 @@ while [ $# -gt 0 ]; do
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 ;;
         --rofi) use_external_menu=1 ;;
+        --normal-window) external_menu_normal_window=1 ;;
         --skip) skip_intro=1 ;;
         --skip-title)
             [ $# -lt 2 ] && die "missing argument!"
@@ -438,6 +442,11 @@ while [ $# -gt 0 ]; do
 done
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
+if [ "$external_menu_normal_window" = "1" ]; then
+  external_menu_args="-normal-window"
+else
+  external_menu_args=""
+fi
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
@@ -472,7 +481,8 @@ case "$search" in
                 printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
             done
         else
-            [ -z "$query" ] && query=$(printf "" | external_menu "" "Search anime: ")
+            echo $external_menu_args
+            [ -z "$query" ] && query=$(printf "" | external_menu "" "Search anime: " "$external_menu_args")
             [ -z "$query" ] && exit 1
         fi
         # for checking new releases by specifying anime name

--- a/ani-cli
+++ b/ani-cli
@@ -481,7 +481,6 @@ case "$search" in
                 printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
             done
         else
-            echo $external_menu_args
             [ -z "$query" ] && query=$(printf "" | external_menu "" "Search anime: " "$external_menu_args")
             [ -z "$query" ] && exit 1
         fi

--- a/ani-cli
+++ b/ani-cli
@@ -439,11 +439,7 @@ while [ $# -gt 0 ]; do
 done
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
-if [ "$external_menu_normal_window" = "1" ]; then
-    external_menu_args="-normal-window"
-else
-    external_menu_args=""
-fi
+[ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)

--- a/ani-cli
+++ b/ani-cli
@@ -66,7 +66,7 @@ help_info() {
       --rofi
         Use rofi instead of fzf for the interactive menu
       --normal-window
-        Make rofi menus appear as windows (effective only when --rofi is used)
+        Make rofi menus appear as windows (only effective when --rofi is used)
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -58,6 +58,9 @@ Play the dubbed version. Without this flag, it'll always play the subbed version
 \fB\--rofi\fR
 Use rofi instead of fzf for the interactive menu
 .TP
+\fB\--normal-window\fR
+Make rofi menus appear as windows (only effective when --rofi is used)
+.TP
 \fB\--skip\fR
 Use ani-skip to skip the intro of the episode (mpv only)
 .TP
@@ -88,6 +91,9 @@ Sets the player ani-cli uses. Can be debug (print links), download (equivalent t
 .TP
 \fBANI_CLI_EXTERNAL_MENU\fR
 Controls the frontend of ani-cli. Can be 0 (uses fzf) or 1 (uses rofi dmenu). Default is 0.
+.TP
+\fBANI_CLI_EXTERNAL_MENU_NORMAL_WINDOW\fR
+Controls the way rofi displays the window. Can be 0 (no additional arguments passed to rofi) or 1 (the menu is displayed as a normal window, -normal-window argument is passed to rofi). Default is 0.
 .TP
 \fBANI_CLI_LOG_EPISODE\fR
 Controls the logging feature for playback. Can be 1(logs) or 0(doesn't log). Default is 1.

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -58,9 +58,6 @@ Play the dubbed version. Without this flag, it'll always play the subbed version
 \fB\--rofi\fR
 Use rofi instead of fzf for the interactive menu
 .TP
-\fB\--normal-window\fR
-Make rofi menus appear as windows (only effective when --rofi is used)
-.TP
 \fB\--skip\fR
 Use ani-skip to skip the intro of the episode (mpv only)
 .TP


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

On GNOME rofi doesn't receive keyboard input as it is not by default a normal window. Since I'm on Wayland I also tried the rofi-wayland package but it failed to launch because rofi on Wayland requires support for the layer shell protocol. Therefore I decided to implement the option inside ani-cli. The user can add the flag --normal-window (alongside --rofi) to pass -normal-window to rofi. I also added the possibility to set the environment variable ANI_CLI_EXTERNAL_MENU_NORMAL_WINDOW to make it happen always.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` select episode works
- [x] `-S` select index works
- [x] `-r` range selection works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
