### PR TITLE
feat: Add Celluloid support (with ani-skip)

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -291,7 +291,7 @@ play_episode() {
             ;;
         mpv*|celluloid)
             pfx=""
-            [ "$player_function" = "celluloid" ] && pfx="mpv-" && skip_flag="${skip_flag//--/--${pfx}}"
+            [ "$player_function" = "celluloid" ] && pfx="mpv-" && skip_flag=$(echo "$skip_flag" | sed 's/--/--mpv-/g')
 
             if [ "$no_detach" = 0 ]; then
                 nohup "$player_function" $skip_flag --${pfx}force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.9.9"
+version_number="4.10.0"
 
 # UI
 
@@ -289,11 +289,14 @@ play_episode() {
             [ -z "$ANI_CLI_NON_INTERACTIVE" ] && printf "All links:\n%s\nSelected link:\n" "$links"
             printf "%s\n" "$episode"
             ;;
-        mpv*)
+        mpv*|celluloid)
+            pfx=""
+            [ "$player_function" = "celluloid" ] && pfx="mpv-" && skip_flag="${skip_flag//--/--${pfx}}"
+
             if [ "$no_detach" = 0 ]; then
-                nohup "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
+                nohup "$player_function" $skip_flag --${pfx}force-media-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
             else
-                "$player_function" $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
+                "$player_function" $skip_flag --${pfx}force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
                 [ "$exit_after_play" = 1 ] && exit "$mpv_exitcode"
             fi


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Documentation update

## Description

Celluloid is a popular MPV frontend. Since celluloid can pass mpv arguments by using a 'mpv-' prefix in the command args, I figured it'd be easy to add. It just uses mpv on the backend after all.

I opted for not adding a new case in the switch, but instead adding the "celluloid" pattern in the mpv option. I then added an optional prefix, which is set if the player is celluloid. It could be done as a seperate option, but I wanted to prevent duplicate code. 

I bumped the version to 4.10.0 as I noticed that is what you guys were aiming for in the next release.  I checked 'range selection' as working, as you guys are already aware of the pre-existing bug with range selection and it's not related to this PR. The readme and help still mention that --skip only works with mpv, but since celluloid is still just mpv, I thought it was still correct.

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` select episode works
- [X] `-S` select index works
- [X] `-r` range selection works
- [X] `--skip` ani-skip works
- [X] `--skip-title` ani-skip title argument works
- [X] `--no-detach` no detach works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date
