### PR TITLE
fix: Fix Mac OS downloading

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -325,7 +325,8 @@ play_episode() {
         *iina*)
             [ -n "$subs_flag" ] && subs_flag="--mpv-${subs_flag#--}"
             [ -n "$refr_flag" ] && refr_flag="--mpv-${refr_flag#--}"
-            nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & ;;
+            nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+            ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
         vlc*) nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         *yncpla*) nohup $player_function "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -295,7 +295,7 @@ download() {
             # [ -e "$download_dir/$2.vtt" ] && ffmpeg -i "$download_dir/$2.mp4" -i "$download_dir/$2.vtt" -c copy -c:s mov_text "$download_dir/$2.bak.mp4" && mv "$download_dir/$2.bak.mp4" "$download_dir/$2.mp4"
             ;;
         *)
-            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue --async-dns=false --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue $extra_arg --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
             ;;
     esac
 }
@@ -429,7 +429,10 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -c | --continue) search=history ;;
-        -d | --download) player_function=download ;;
+        -d | --download) 
+            ["$ANI_CLI_PLAYER" = "-iSH" ] && extra_arg="--async-dns=false"
+            player_function=download 
+            ;;
         -D | --delete)
             : >"$histfile"
             exit 0

--- a/ani-cli
+++ b/ani-cli
@@ -153,8 +153,8 @@ get_links() {
             extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
             relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
             m3u8_streams="$(curl -e "$m3u8_refr" -s "$extract_link" -A "$agent")"
-            printf "%s" "$m3u8_streams" | grep -q "EXTM3U" && printf "%s" "$m3u8_streams" | sed 's|^#EXT-X-STREAM.*x||g; s|,.*|p|g; /^#/d; $!N; s|\
-| >|;/EXT-X-I-FRAME/d' | sed "s|>|cc>${relative_link}|g" | sort -nr
+            printf "%s" "$m3u8_streams" | grep -q "EXTM3U" && printf "%s" "$m3u8_streams" | sed 's|^#EXT-X-STREAM.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|;/EXT-X-I-FRAME/d' |
+                sed "s|>|cc>${relative_link}|g" | sort -nr
             printf '%s' "$response" | sed -nE 's|.*"subtitles":\[\{"lang":"en","label":"English","default":"default","src":"([^"]*)".*|subtitle >\1|p' >"$cache_dir/suburl"
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -295,7 +295,8 @@ download() {
             # [ -e "$download_dir/$2.vtt" ] && ffmpeg -i "$download_dir/$2.mp4" -i "$download_dir/$2.vtt" -c copy -c:s mov_text "$download_dir/$2.bak.mp4" && mv "$download_dir/$2.bak.mp4" "$download_dir/$2.mp4"
             ;;
         *)
-            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue "$extra_arg" --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+            # shellcheck disable=SC2086
+            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue $iSH_DownFix --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
             ;;
     esac
 }
@@ -430,7 +431,7 @@ while [ $# -gt 0 ]; do
             ;;
         -c | --continue) search=history ;;
         -d | --download)
-            [ "$player_function" = "iSH" ] && extra_arg="--async-dns=false"
+            [ "$player_function" = "iSH" ] && iSH_DownFix="--async-dns=false"
             player_function=download
             ;;
         -D | --delete)

--- a/ani-cli
+++ b/ani-cli
@@ -430,7 +430,7 @@ while [ $# -gt 0 ]; do
             ;;
         -c | --continue) search=history ;;
         -d | --download) 
-            ["$ANI_CLI_PLAYER" = "-iSH" ] && extra_arg="--async-dns=false"
+            [ "$player_function" = "iSH" ] && extra_arg="--async-dns=false"
             player_function=download 
             ;;
         -D | --delete)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.0"
+version_number="4.10.1"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -322,7 +322,10 @@ play_episode() {
             ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
-        *iina*) nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & ;;
+        *iina*)
+            [ -n "$subs_flag" ] && subs_flag="--mpv-${subs_flag#--}"
+            [ -n "$refr_flag" ] && refr_flag="--mpv-${refr_flag#--}"
+            nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
         vlc*) nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         *yncpla*) nohup $player_function "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 & ;;

--- a/ani-cli
+++ b/ani-cli
@@ -295,7 +295,7 @@ download() {
             # [ -e "$download_dir/$2.vtt" ] && ffmpeg -i "$download_dir/$2.mp4" -i "$download_dir/$2.vtt" -c copy -c:s mov_text "$download_dir/$2.bak.mp4" && mv "$download_dir/$2.bak.mp4" "$download_dir/$2.mp4"
             ;;
         *)
-            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue $extra_arg --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue "$extra_arg" --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
             ;;
     esac
 }

--- a/ani-cli
+++ b/ani-cli
@@ -429,9 +429,9 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -c | --continue) search=history ;;
-        -d | --download) 
+        -d | --download)
             [ "$player_function" = "iSH" ] && extra_arg="--async-dns=false"
-            player_function=download 
+            player_function=download
             ;;
         -D | --delete)
             : >"$histfile"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

A simple fix to make asynch-dns = false only apply to iOS

The items not marked don’t work on iOS (likely due to how you can only launch VLC with the link and nothing more)

also, this wasn’t tested on Mac OS as I do not have a Mac. It should work tho

## Checklist

- [X] any anime playing
- [X] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [ ] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [C] `-e` (select episode) aka `-r` (range selection) works
- [X] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
