### PR TITLE
New MAL integration with MAL ID search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v4.10.2
+- Toegevoegd: Interactieve prompt voor het instellen van de MAL client ID als deze nog niet is geconfigureerd. Bij het starten van ani-cli zonder opties wordt nu gevraagd om je MAL client ID, met uitleg en automatische opslag in ~/.config/ani-cli/mal.conf.
+- Toegevoegd: Nieuwe `--mal-id` optie voor deterministisch zoeken naar anime via MyAnimeList ID. Gebruikt de officiële MAL API voor betrouwbare resultaten.
+- Toegevoegd: MAL API integratie met functie `search_anime_by_mal_id()` voor het ophalen van anime data.
+- Bijgewerkt: Help tekst en README met documentatie voor de nieuwe MAL ID zoekfunctionaliteit.
+- Bijgewerkt: Versienummer naar 4.10.2.
+- Opgelost: linter-warnings voor POSIX-compatibiliteit en printf i.p.v. echo gebruikt. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v4.10.8
+- Toegevoegd: Nieuwe `--add-favorite <name>` optie voor het toevoegen van anime aan favorieten op basis van naam.
+- Toegevoegd: Functie `add_favorite_by_name()` voor het zoeken en selecteren van anime om toe te voegen.
+- Toegevoegd: Interactief menu uitgebreid met "Add to favorites" optie (optie 6).
+- Toegevoegd: Automatische zoekfunctionaliteit met gebruikersselectie voor favorieten toevoegen.
+- Bijgewerkt: Help tekst met documentatie en voorbeeld voor de nieuwe `--add-favorite` optie.
+- Bijgewerkt: Versienummer naar 4.10.8.
+
+## v4.10.7
+- Toegevoegd: Volledig favorieten systeem voor het opslaan en beheren van favoriete anime.
+- Toegevoegd: Nieuwe `--favorites` optie voor het browsen van je favoriete anime.
+- Toegevoegd: Interactief menu uitgebreid met favorieten optie (optie 5).
+- Toegevoegd: Favorieten functies: `add_to_favorites()`, `remove_from_favorites()`, `get_favorites()`, `is_in_favorites()`, en `show_favorites_menu()`.
+- Toegevoegd: Favorieten opties in de playback loop: "add_favorite" en "remove_favorite".
+- Toegevoegd: Automatische controle of anime al in favorieten staat voordat toevoegen.
+- Toegevoegd: Favorieten worden opgeslagen in `~/.local/state/ani-cli/ani-favorites`.
+- Bijgewerkt: Help tekst met documentatie voor de nieuwe favorieten optie.
+- Bijgewerkt: Versienummer naar 4.10.7.
+
+## v4.10.6
+- Performance: Added comprehensive caching system for MAL API responses, search results, and episode lists.
+- Performance: Cache expiry set to 1 hour for optimal balance between speed and freshness.
+- Feature: Added --clear-cache option to manually clear cache when needed.
+- Performance: Significantly faster repeated searches and MAL API calls.
+
+## v4.10.5
+- UI: Interactive menu now features color, emoji, and anime ASCII-art for a more vibrant and fun experience.
+
+## v4.10.4
+- UI: All user-facing prompts, menu, and errors are now fully in English for a consistent experience.
+
+## v4.10.3
+- Toegevoegd: Interactief menu bij het starten van ani-cli met 4 opties: normaal zoeken, zoeken op MAL ID, seizoen overview (MAL), en top anime (MAL).
+- Toegevoegd: Nieuwe `--mal-season` optie voor het browsen van huidige seizoen anime via MyAnimeList API.
+- Toegevoegd: Nieuwe `--mal-top` optie voor het browsen van top anime via MyAnimeList API.
+- Toegevoegd: Functies `get_mal_season_anime()` en `get_mal_top_anime()` voor MAL API integratie.
+- Bijgewerkt: Help tekst met documentatie voor de nieuwe seizoen en top anime opties.
+- Bijgewerkt: Versienummer naar 4.10.3.
+- Opgelost: Linter warnings voor subshell variabele modificaties in MAL API functies.
+
 ## v4.10.2
 - Toegevoegd: Interactieve prompt voor het instellen van de MAL client ID als deze nog niet is geconfigureerd. Bij het starten van ani-cli zonder opties wordt nu gevraagd om je MAL client ID, met uitleg en automatische opslag in ~/.config/ani-cli/mal.conf.
 - Toegevoegd: Nieuwe `--mal-id` optie voor deterministisch zoeken naar anime via MyAnimeList ID. Gebruikt de officiële MAL API voor betrouwbare resultaten.

--- a/README.md
+++ b/README.md
@@ -522,6 +522,36 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 
 **Note:** It may be, that ani-skip won't know the anime you're trying to watch. Try using the `--skip-title <title>` command line argument. (It uses the [aniskip API](https://github.com/lexesjan/typescript-aniskip-extension/tree/main/src/api/aniskip-http-client) and you can contribute missing anime or ask for including it in the database on their [discord server](https://discord.com/invite/UqT55CbrbE)).
 
+## MyAnimeList API Integration
+
+ani-cli now supports searching for anime by MyAnimeList ID using the official MAL API. This provides deterministic search results and is especially useful for finding specific anime.
+
+### Setup
+
+1. **Get a MAL API Client ID:**
+   - Go to [MAL API Panel](https://myanimelist.net/apiconfig)
+   - Create a new application and copy your client ID
+
+2. **Configure ani-cli:**
+   - The first time you run ani-cli, it will prompt you to enter your MAL client ID
+   - This will be saved in `~/.config/ani-cli/mal.conf`
+
+### Usage
+
+```bash
+# Search by MAL ID
+ani-cli --mal-id 21
+
+# Combine with other options
+ani-cli --mal-id 21 -q 1080p -e 1
+```
+
+### Benefits
+
+- **Deterministic results:** Always find the exact anime you're looking for
+- **No ambiguity:** Avoid confusion with similar titles
+- **Direct access:** Skip the search interface for known anime
+
 ## FAQ
 <details>
 	
@@ -534,6 +564,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 * How can I download? - Use `-d`, it will download into your working directory.
 * Can i change download folder? - Yes, set the `ANI_CLI_DOWNLOAD_DIR` to your desired location.
 * How can I bulk download? - `Use -d -e firstepisode-lastepisode`, for example `ani-cli onepiece -d -e 1-1000`.
+* How do I search by MAL ID? - Use `--mal-id <id>`, for example `ani-cli --mal-id 21`.
 
 **Note:** All features are documented in `ani-cli --help`.
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.2"
+version_number="4.10.8"
 
 # UI
 
@@ -86,6 +86,16 @@ help_info() {
         Update the script
       --mal-id <id>
         Search for anime by MyAnimeList ID (requires MAL API client ID)
+      --mal-season
+        Browse current season anime from MyAnimeList
+      --mal-top
+        Browse top anime from MyAnimeList
+      --clear-cache
+        Clear the cache directory
+      --favorites
+        Browse your favorite anime
+      --add-favorite <name>
+        Add anime to favorites by name
     Some example usages:
       %s -q 720p banana fish
       %s --skip --skip-title \"one piece\" -S 2 one piece
@@ -94,6 +104,7 @@ help_info() {
       %s blue lock -e 5-6
       %s -e \"5 6\" blue lock
       %s --mal-id 21 one piece
+      %s --add-favorite "one piece"
     \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
     exit 0
 }
@@ -142,30 +153,145 @@ search_anime_by_mal_id() {
     mal_id="$1"
     response=""
     title=""
+    cache_file="$MAL_CACHE_DIR/mal_id_${mal_id}"
     
-    printf "\33[2K\r\033[1;34mZoeken naar anime met MAL ID: %s...\033[0m\n" "$mal_id" >&2
-    
-    if ! response=$(curl -s -H "X-MAL-CLIENT-ID: $MAL_CLIENT_ID" \
-        "https://api.myanimelist.net/v2/anime/$mal_id?fields=id,title"); then
-        die "Fout bij het ophalen van anime data van MAL API"
-    fi
-    
-    # Check if response contains error
-    if printf "%s" "$response" | grep -q '"error"'; then
-        die "Anime met MAL ID $mal_id niet gevonden"
+    # Try to get from cache first
+    if response=$(cache_get "$cache_file"); then
+        printf "\33[2K\r\033[1;34mFound anime with MAL ID %s in cache...\033[0m\n" "$mal_id" >&2
+    else
+        printf "\33[2K\r\033[1;34mSearching for anime with MAL ID: %s...\033[0m\n" "$mal_id" >&2
+        
+        if ! response=$(curl -s -H "X-MAL-CLIENT-ID: $MAL_CLIENT_ID" \
+            "https://api.myanimelist.net/v2/anime/$mal_id?fields=id,title"); then
+            die "Error fetching anime data from MAL API"
+        fi
+        
+        # Check if response contains error
+        if printf "%s" "$response" | grep -q '"error"'; then
+            die "Anime with MAL ID $mal_id not found"
+        fi
+        
+        # Cache the response
+        cache_set "$cache_file" "$response"
     fi
     
     # Extract title
     title=$(printf "%s" "$response" | sed -n 's/.*"title":"\([^"]*\)".*/\1/p')
     if [ -z "$title" ]; then
-        die "Kon geen titel vinden voor MAL ID $mal_id"
+        die "Could not find title for MAL ID $mal_id"
     fi
     
-    # Zoek met deze titel via de bestaande search_anime functie
+    # Search with this title via the existing search_anime function
     anime_list=$(search_anime "$title")
-    [ -z "$anime_list" ] && die "Geen resultaten gevonden voor titel van MAL ID $mal_id: $title"
-    # Geef het eerste resultaat terug
+    [ -z "$anime_list" ] && die "No results found for MAL ID title: $title"
+    # Return the first result
     printf "%s\n" "$(printf "%s" "$anime_list" | head -n1)"
+}
+
+# get current season anime from MAL API
+get_mal_season_anime() {
+    response=""
+    current_year=$(date +%Y)
+    current_month=$(date +%m)
+    
+    # Determine current season
+    case $current_month in
+        12|01|02) season="winter" ;;
+        03|04|05) season="spring" ;;
+        06|07|08) season="summer" ;;
+        09|10|11) season="fall" ;;
+    esac
+    
+    # Adjust year for winter (December belongs to next year's winter)
+    [ "$current_month" = "12" ] && current_year=$((current_year + 1))
+    
+    cache_file="$MAL_CACHE_DIR/season_${current_year}_${season}"
+    
+    # Try to get from cache first
+    if response=$(cache_get "$cache_file"); then
+        printf "\33[2K\r\033[1;34mFound %s %s season anime in cache...\033[0m\n" "$season" "$current_year" >&2
+    else
+        printf "\33[2K\r\033[1;34mFetching %s %s season anime...\033[0m\n" "$season" "$current_year" >&2
+        
+        # Try current season first, if it fails, try previous season
+        if ! response=$(curl -s -H "X-MAL-CLIENT-ID: $MAL_CLIENT_ID" \
+            "https://api.myanimelist.net/v2/anime/season/$current_year/$season?limit=20&fields=id,title"); then
+            die "Error fetching season anime from MAL API"
+        fi
+        
+        # Check if response contains error, try previous season
+        if printf "%s" "$response" | grep -q '"error"'; then
+            # Try previous season
+            case $season in
+                winter) prev_season="fall"; prev_year=$((current_year - 1)) ;;
+                spring) prev_season="winter"; prev_year=$current_year ;;
+                summer) prev_season="spring"; prev_year=$current_year ;;
+                fall) prev_season="summer"; prev_year=$current_year ;;
+            esac
+            
+            printf "\33[2K\r\033[1;34mCurrent season not available, trying %s %s...\033[0m\n" "$prev_season" "$prev_year" >&2
+            
+            if ! response=$(curl -s -H "X-MAL-CLIENT-ID: $MAL_CLIENT_ID" \
+                "https://api.myanimelist.net/v2/anime/season/$prev_year/$prev_season?limit=20&fields=id,title"); then
+                die "Error fetching season anime from MAL API"
+            fi
+            
+            if printf "%s" "$response" | grep -q '"error"'; then
+                die "Could not fetch season anime"
+            fi
+        fi
+        
+        # Cache the response
+        cache_set "$cache_file" "$response"
+    fi
+    
+    # Extract anime data from the correct JSON structure
+    anime_data=$(printf "%s" "$response" | sed 's/},{/\n/g' | sed -n 's/.*"id":\([0-9]*\),"title":"\([^"]*\)".*/\1\t\2/p')
+    printf "%s" "$anime_data" | while read -r mal_id title; do
+        if [ -n "$mal_id" ] && [ -n "$title" ]; then
+            anime_result=$(search_anime "$title" | head -n1)
+            if [ -n "$anime_result" ]; then
+                printf "%s\n" "$anime_result"
+            fi
+        fi
+    done
+}
+
+# get top anime from MAL API
+get_mal_top_anime() {
+    response=""
+    cache_file="$MAL_CACHE_DIR/top_anime"
+    
+    # Try to get from cache first
+    if response=$(cache_get "$cache_file"); then
+        printf "\33[2K\r\033[1;34mFound top anime in cache...\033[0m\n" >&2
+    else
+        printf "\33[2K\r\033[1;34mFetching top anime...\033[0m\n" >&2
+        
+        if ! response=$(curl -s -H "X-MAL-CLIENT-ID: $MAL_CLIENT_ID" \
+            "https://api.myanimelist.net/v2/anime/ranking?ranking_type=all&limit=20&fields=id,title,alternative_titles"); then
+            die "Error fetching top anime from MAL API"
+        fi
+        
+        # Check if response contains error
+        if printf "%s" "$response" | grep -q '"error"'; then
+            die "Could not fetch top anime"
+        fi
+        
+        # Cache the response
+        cache_set "$cache_file" "$response"
+    fi
+    
+    # Extract anime data and search for each
+    anime_data=$(printf "%s" "$response" | sed 's/},{/\n/g' | sed -n 's/.*"id":\([0-9]*\),"title":"\([^"]*\)".*/\1\t\2/p')
+    printf "%s" "$anime_data" | while read -r mal_id title; do
+        if [ -n "$mal_id" ] && [ -n "$title" ]; then
+            anime_result=$(search_anime "$title" | head -n1)
+            if [ -n "$anime_result" ]; then
+                printf "%s\n" "$anime_result"
+            fi
+        fi
+    done
 }
 
 # SCRAPING
@@ -270,8 +396,23 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
-| g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
+    cache_key=$(cache_key "$1" "$mode")
+    cache_file="$SEARCH_CACHE_DIR/${cache_key}"
+    
+    # Try to get from cache first
+    if cached_result=$(cache_get "$cache_file"); then
+        printf "%s" "$cached_result"
+        return 0
+    fi
+    
+    # Perform the search
+    result=$(curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
+| g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g')
+    
+    # Cache the result
+    cache_set "$cache_file" "$result"
+    
+    printf "%s" "$result"
 }
 
 time_until_next_ep() {
@@ -293,8 +434,23 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
-|g; s|"||g' | sort -n -k 1
+    cache_key=$(cache_key "$1" "$mode")
+    cache_file="$EPISODE_CACHE_DIR/${cache_key}"
+    
+    # Try to get from cache first
+    if cached_result=$(cache_get "$cache_file"); then
+        printf "%s" "$cached_result"
+        return 0
+    fi
+    
+    # Fetch episode list
+    result=$(curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
+|g; s|"||g' | sort -n -k 1)
+    
+    # Cache the result
+    cache_set "$cache_file" "$result"
+    
+    printf "%s" "$result"
 }
 
 # PLAYING
@@ -437,24 +593,151 @@ hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
 [ ! -f "$histfile" ] && : >"$histfile"
+favorites_file="$hist_dir/ani-favorites"
+[ ! -f "$favorites_file" ] && : >"$favorites_file"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
 
 CONFIG_DIR="$HOME/.config/ani-cli"
 CONFIG_FILE="$CONFIG_DIR/mal.conf"
 
 if [ ! -f "$CONFIG_FILE" ]; then
-    printf "\n🔑 Je hebt een MyAnimeList API client ID nodig om bepaalde functies te gebruiken.\n"
-    printf "1. Ga naar https://myanimelist.net/apiconfig en maak een nieuwe applicatie aan.\n"
-    printf "2. Kopieer je client ID.\n"
-    printf "3. Vul hieronder je client ID in.\n"
-    printf "Voer je MAL client ID in: "
+    printf "\n🔑 You need a MyAnimeList API client ID for certain features.\n"
+    printf "1. Go to https://myanimelist.net/apiconfig and create a new application.\n"
+    printf "2. Copy your client ID.\n"
+    printf "3. Enter your client ID below.\n"
+    printf "Enter your MAL client ID: "
     read -r MAL_CLIENT_ID
     mkdir -p "$CONFIG_DIR"
     echo "MAL_CLIENT_ID=$MAL_CLIENT_ID" > "$CONFIG_FILE"
-    printf "Client ID opgeslagen in %s.\n" "$CONFIG_FILE"
+    printf "Client ID saved in %s.\n" "$CONFIG_FILE"
 fi
 # shellcheck disable=SC1090
 . "$CONFIG_FILE"
+
+# Cache system
+CACHE_DIR="$HOME/.cache/ani-cli"
+MAL_CACHE_DIR="$CACHE_DIR/mal"
+SEARCH_CACHE_DIR="$CACHE_DIR/search"
+EPISODE_CACHE_DIR="$CACHE_DIR/episodes"
+CACHE_EXPIRY=3600  # 1 hour in seconds
+
+# Create cache directories
+mkdir -p "$MAL_CACHE_DIR" "$SEARCH_CACHE_DIR" "$EPISODE_CACHE_DIR"
+
+# Cache functions
+cache_get() {
+    local cache_file="$1"
+    local current_time=$(date +%s)
+    local file_time
+    
+    if [ -f "$cache_file" ]; then
+        file_time=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
+        if [ $((current_time - file_time)) -lt "$CACHE_EXPIRY" ]; then
+            cat "$cache_file"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+cache_set() {
+    local cache_file="$1"
+    local data="$2"
+    printf "%s" "$data" > "$cache_file"
+}
+
+cache_key() {
+    printf "%s" "$*" | md5sum | cut -d' ' -f1
+}
+
+# FAVORITES SYSTEM
+
+# get favorites list
+get_favorites() {
+    if [ -f "$favorites_file" ]; then
+        cat "$favorites_file"
+    fi
+}
+
+# add anime to favorites
+add_to_favorites() {
+    local anime_id="$1"
+    local anime_title="$2"
+    
+    # Check if already in favorites
+    if [ -f "$favorites_file" ] && grep -q "^${anime_id}	" "$favorites_file"; then
+        printf "\033[1;33m%s is already in your favorites!\033[0m\n" "$anime_title" >&2
+        return 1
+    fi
+    
+    # Add to favorites
+    printf "%s	%s\n" "$anime_id" "$anime_title" >> "$favorites_file"
+    printf "\033[1;32m%s added to favorites!\033[0m\n" "$anime_title" >&2
+}
+
+# add anime to favorites by name
+add_favorite_by_name() {
+    local anime_name="$1"
+    local search_results
+    local selected_anime
+    
+    printf "\033[1;34mSearching for '%s'...\033[0m\n" "$anime_name" >&2
+    
+    # Search for the anime
+    search_results=$(search_anime "$anime_name")
+    if [ -z "$search_results" ]; then
+        printf "\033[1;31mNo anime found with name '%s'\033[0m\n" "$anime_name" >&2
+        return 1
+    fi
+    
+    # Let user select from results
+    selected_anime=$(printf "%s" "$search_results" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime to add to favorites: ")
+    if [ -z "$selected_anime" ]; then
+        printf "\033[1;33mNo anime selected\033[0m\n" >&2
+        return 1
+    fi
+    
+    # Extract ID and title
+    local anime_id=$(printf "%s" "$selected_anime" | cut -f1)
+    local anime_title=$(printf "%s" "$selected_anime" | cut -f2)
+    
+    # Add to favorites
+    add_to_favorites "$anime_id" "$anime_title"
+}
+
+# remove anime from favorites
+remove_from_favorites() {
+    local anime_id="$1"
+    local anime_title="$2"
+    
+    if [ -f "$favorites_file" ]; then
+        if grep -q "^${anime_id}	" "$favorites_file"; then
+            sed -i "/^${anime_id}	/d" "$favorites_file"
+            printf "\033[1;32m%s removed from favorites!\033[0m\n" "$anime_title" >&2
+        else
+            printf "\033[1;33m%s is not in your favorites!\033[0m\n" "$anime_title" >&2
+        fi
+    fi
+}
+
+# check if anime is in favorites
+is_in_favorites() {
+    local anime_id="$1"
+    [ -f "$favorites_file" ] && grep -q "^${anime_id}	" "$favorites_file"
+}
+
+# show favorites menu
+show_favorites_menu() {
+    local favorites_list
+    favorites_list=$(get_favorites)
+    
+    if [ -z "$favorites_list" ]; then
+        printf "\033[1;33mNo favorites yet. Add some anime to get started!\033[0m\n" >&2
+        return 1
+    fi
+    
+    printf "%s" "$favorites_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select favorite anime: "
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -528,6 +811,27 @@ while [ $# -gt 0 ]; do
             search=mal_id
             shift
             ;;
+        --mal-season)
+            search=mal_season
+            ;;
+        --mal-top)
+            search=mal_top
+            ;;
+        --clear-cache)
+            printf "Clearing cache...\n"
+            rm -rf "$CACHE_DIR"
+            mkdir -p "$MAL_CACHE_DIR" "$SEARCH_CACHE_DIR" "$EPISODE_CACHE_DIR"
+            printf "Cache cleared successfully.\n"
+            exit 0
+            ;;
+        --favorites)
+            search=favorites
+            ;;
+        --add-favorite)
+            [ $# -lt 2 ] && die "missing argument!"
+            add_favorite_by_name "$2"
+            exit 0
+            ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
     esac
     shift
@@ -548,14 +852,101 @@ case "$player_function" in
     *) dep_ch "$player_function" ;;
 esac
 
+# Color codes
+CYAN='\033[1;36m'
+YELLOW='\033[1;33m'
+MAGENTA='\033[1;35m'
+RESET='\033[0m'
+
+# show interactive menu if no search type is specified
+if [ "$search" = "scrape" ] && [ -z "$query" ] && [ "$use_external_menu" = "0" ]; then
+    printf "${MAGENTA}   ／人◕ ‿‿ ◕人＼   ${RESET}\n"
+    printf "${CYAN}🎌 ani-cli - Anime Browser${RESET}\n"
+    printf "${YELLOW}1.${RESET} 🔍 Normal search\n"
+    printf "${YELLOW}2.${RESET} 🆔 Search by MAL ID\n"
+    printf "${YELLOW}3.${RESET} 📅 Season overview (MAL)\n"
+    printf "${YELLOW}4.${RESET} ⭐ Top anime (MAL)\n"
+    printf "${YELLOW}5.${RESET} ❤️  Favorites\n"
+    printf "${YELLOW}6.${RESET} ➕ Add to favorites\n"
+    printf "${CYAN}\nChoose an option (1-6): ${RESET}"
+    read -r menu_choice
+    
+    case "$menu_choice" in
+        1) 
+            printf "\n${CYAN}Search anime: ${RESET}"
+            read -r query
+            search="scrape"
+            ;;
+        2)
+            printf "\n${CYAN}Enter MAL ID: ${RESET}"
+            read -r mal_search_id
+            search="mal_id"
+            ;;
+        3)
+            search="mal_season"
+            ;;
+        4)
+            search="mal_top"
+            ;;
+        5)
+            search="favorites"
+            ;;
+        6)
+            printf "\n${CYAN}Enter anime name to add to favorites: ${RESET}"
+            read -r anime_name
+            add_favorite_by_name "$anime_name"
+            exit 0
+            ;;
+        *)
+            die "Invalid choice"
+            ;;
+    esac
+fi
+
 # searching
 case "$search" in
     mal_id)
         anime_list=$(search_anime_by_mal_id "$mal_search_id")
-        [ -z "$anime_list" ] && die "Anime met MAL ID $mal_search_id niet gevonden!"
+        [ -z "$anime_list" ] && die "Anime with MAL ID $mal_search_id not found!"
         title=$(printf "%s" "$anime_list" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$anime_list" | cut -f1)
+        ep_list=$(episodes_list "$id")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        [ -z "$ep_no" ] && exit 1
+        ;;
+    mal_season)
+        anime_list=$(get_mal_season_anime)
+        [ -z "$anime_list" ] && die "No season anime found!"
+        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
+        [ -n "$index" ] && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
+        [ -z "$result" ] && exit 1
+        title=$(printf "%s" "$result" | cut -f2)
+        allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        id=$(printf "%s" "$result" | cut -f1)
+        ep_list=$(episodes_list "$id")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        [ -z "$ep_no" ] && exit 1
+        ;;
+    mal_top)
+        anime_list=$(get_mal_top_anime)
+        [ -z "$anime_list" ] && die "No top anime found!"
+        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
+        [ -n "$index" ] && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
+        [ -z "$result" ] && exit 1
+        title=$(printf "%s" "$result" | cut -f2)
+        allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        id=$(printf "%s" "$result" | cut -f1)
+        ep_list=$(episodes_list "$id")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        [ -z "$ep_no" ] && exit 1
+        ;;
+    favorites)
+        result=$(show_favorites_menu)
+        [ -z "$result" ] && exit 1
+        id=$(printf "%s" "$result" | cut -f1)
+        title=$(printf "%s" "$result" | cut -f2)
+        allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ep_list=$(episodes_list "$id")
         [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1
@@ -609,7 +1000,7 @@ tput sc
 play
 [ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
 
-while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
+while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nadd_favorite\nremove_favorite\nquit" | nth "Playing episode $ep_no of $title... "); do
     case "$cmd" in
         next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
         replay) episode="$replay" ;;
@@ -618,6 +1009,22 @@ while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth 
         change_quality)
             new_quality="$(printf "%s" "$links" | launcher | cut -d\> -f1)"
             select_quality "$new_quality"
+            ;;
+        add_favorite)
+            if is_in_favorites "$id"; then
+                printf "\033[1;33m%s is already in your favorites!\033[0m\n" "$title" >&2
+            else
+                add_to_favorites "$id" "$title"
+            fi
+            continue
+            ;;
+        remove_favorite)
+            if is_in_favorites "$id"; then
+                remove_from_favorites "$id" "$title"
+            else
+                printf "\033[1;33m%s is not in your favorites!\033[0m\n" "$title" >&2
+            fi
+            continue
             ;;
         *) exit 0 ;;
     esac

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.1"
+version_number="4.10.2"
 
 # UI
 
@@ -84,6 +84,8 @@ help_info() {
         Display a countdown to the next episode
       -U, --update
         Update the script
+      --mal-id <id>
+        Search for anime by MyAnimeList ID (requires MAL API client ID)
     Some example usages:
       %s -q 720p banana fish
       %s --skip --skip-title \"one piece\" -S 2 one piece
@@ -91,7 +93,8 @@ help_info() {
       %s --vlc cyberpunk edgerunners -q 1080p -e 4
       %s blue lock -e 5-6
       %s -e \"5 6\" blue lock
-    \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
+      %s --mal-id 21 one piece
+    \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
     exit 0
 }
 
@@ -130,6 +133,39 @@ where_iina() {
 where_mpv() {
     command -v "flatpak" >/dev/null && flatpak info io.mpv.Mpv >/dev/null 2>&1 && printf "%s" "flatpak_mpv" && return 0
     printf "%s" "mpv" && return 0
+}
+
+# MAL API
+
+# search anime by MAL ID using the official MAL API
+search_anime_by_mal_id() {
+    mal_id="$1"
+    response=""
+    title=""
+    
+    printf "\33[2K\r\033[1;34mZoeken naar anime met MAL ID: %s...\033[0m\n" "$mal_id" >&2
+    
+    if ! response=$(curl -s -H "X-MAL-CLIENT-ID: $MAL_CLIENT_ID" \
+        "https://api.myanimelist.net/v2/anime/$mal_id?fields=id,title"); then
+        die "Fout bij het ophalen van anime data van MAL API"
+    fi
+    
+    # Check if response contains error
+    if printf "%s" "$response" | grep -q '"error"'; then
+        die "Anime met MAL ID $mal_id niet gevonden"
+    fi
+    
+    # Extract title
+    title=$(printf "%s" "$response" | sed -n 's/.*"title":"\([^"]*\)".*/\1/p')
+    if [ -z "$title" ]; then
+        die "Kon geen titel vinden voor MAL ID $mal_id"
+    fi
+    
+    # Zoek met deze titel via de bestaande search_anime functie
+    anime_list=$(search_anime "$title")
+    [ -z "$anime_list" ] && die "Geen resultaten gevonden voor titel van MAL ID $mal_id: $title"
+    # Geef het eerste resultaat terug
+    printf "%s\n" "$(printf "%s" "$anime_list" | head -n1)"
 }
 
 # SCRAPING
@@ -353,7 +389,7 @@ play() {
     line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")
     if [ "$line_count" != 1 ] || [ -n "$start" ]; then
         [ -z "$start" ] && start=$(printf "%s\n" "$ep_no" | head -n1)
-        [ -z "$end" ] && end=$(printf "%s\n" "$ep_no" | tail -n1)
+        [ -z "$end" ] && end=$(printf "%s" "$ep_no" | tail -n1)
         range=$(printf "%s\n" "$ep_list" | sed -nE "/^${start}\$/,/^${end}\$/p")
         [ -z "$range" ] && die "Invalid range!"
         for i in $range; do
@@ -402,6 +438,23 @@ hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 histfile="$hist_dir/ani-hsts"
 [ ! -f "$histfile" ] && : >"$histfile"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
+
+CONFIG_DIR="$HOME/.config/ani-cli"
+CONFIG_FILE="$CONFIG_DIR/mal.conf"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    printf "\n🔑 Je hebt een MyAnimeList API client ID nodig om bepaalde functies te gebruiken.\n"
+    printf "1. Ga naar https://myanimelist.net/apiconfig en maak een nieuwe applicatie aan.\n"
+    printf "2. Kopieer je client ID.\n"
+    printf "3. Vul hieronder je client ID in.\n"
+    printf "Voer je MAL client ID in: "
+    read -r MAL_CLIENT_ID
+    mkdir -p "$CONFIG_DIR"
+    echo "MAL_CLIENT_ID=$MAL_CLIENT_ID" > "$CONFIG_FILE"
+    printf "Client ID opgeslagen in %s.\n" "$CONFIG_FILE"
+fi
+# shellcheck disable=SC1090
+. "$CONFIG_FILE"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -469,6 +522,12 @@ while [ $# -gt 0 ]; do
             ;;
         -N | --nextep-countdown) search=nextep ;;
         -U | --update) update_script ;;
+        --mal-id)
+            [ $# -lt 2 ] && die "missing argument!"
+            mal_search_id="$2"
+            search=mal_id
+            shift
+            ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
     esac
     shift
@@ -491,6 +550,16 @@ esac
 
 # searching
 case "$search" in
+    mal_id)
+        anime_list=$(search_anime_by_mal_id "$mal_search_id")
+        [ -z "$anime_list" ] && die "Anime met MAL ID $mal_search_id niet gevonden!"
+        title=$(printf "%s" "$anime_list" | cut -f2)
+        allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        id=$(printf "%s" "$anime_list" | cut -f1)
+        ep_list=$(episodes_list "$id")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        [ -z "$ep_no" ] && exit 1
+        ;;
     history)
         anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
         wait


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

added mal api connection. User needs to reqeust mal api acces and will be saved in .conf
syntax ani-cli --mal-id <id>

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [ ] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
