### PR TITLE
fix: iina next button hanging

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -325,7 +325,13 @@ play_episode() {
         *iina*)
             [ -n "$subs_flag" ] && subs_flag="--mpv-${subs_flag#--}"
             [ -n "$refr_flag" ] && refr_flag="--mpv-${refr_flag#--}"
-            nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+            # check for existing instance
+            if pgrep -f "IINA" >/dev/null 2>&1; then
+                # using IINA instance without --keep-running to prevent hanging
+                nohup $player_function --no-stdin --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+            else
+                nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+            fi
             ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
         vlc*) nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
@@ -341,7 +347,16 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
-    [ "$use_external_menu" = "1" ] && wait
+    if [ "$use_external_menu" = "1" ]; then
+        case "$player_function" in
+            *iina*) 
+                # for IINA, don't wait for stopping hanging issue
+                ;;
+            *) 
+                wait 
+                ;;
+        esac
+    fi
 }
 
 play() {

--- a/ani-cli
+++ b/ani-cli
@@ -347,16 +347,6 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
-    if [ "$use_external_menu" = "1" ]; then
-        case "$player_function" in
-            *iina*)
-                # for IINA, don't wait for stopping hanging issue
-                ;;
-            *)
-                wait
-                ;;
-        esac
-    fi
 }
 
 play() {

--- a/ani-cli
+++ b/ani-cli
@@ -346,6 +346,7 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
+    [ "$use_external_menu" = "1" ] && wait
 }
 
 play() {

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.3"
+version_number="4.10.4"
 
 # UI
 
@@ -325,9 +325,8 @@ play_episode() {
         *iina*)
             [ -n "$subs_flag" ] && subs_flag="--mpv-${subs_flag#--}"
             [ -n "$refr_flag" ] && refr_flag="--mpv-${refr_flag#--}"
-            # check for existing instance
             if pgrep -f "IINA" >/dev/null 2>&1; then
-                # using IINA instance without --keep-running to prevent hanging
+                # omit --keep-running when an IINA instance exists to prevent hanging
                 nohup $player_function --no-stdin --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
             else
                 nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &

--- a/ani-cli
+++ b/ani-cli
@@ -349,11 +349,11 @@ play_episode() {
     update_history
     if [ "$use_external_menu" = "1" ]; then
         case "$player_function" in
-            *iina*) 
+            *iina*)
                 # for IINA, don't wait for stopping hanging issue
                 ;;
-            *) 
-                wait 
+            *)
+                wait
                 ;;
         esac
     fi


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Fixes IINA hanging issue when using the Next button with existing instances.

**Problem:** When using the Next button in ani-cli with IINA player on macOS, the program hangs after the sed call if there's already an existing IINA instance running. This only occurs when IINA is already open.

**Root Cause:** The `--keep-running` flag conflicts with existing IINA instances, and the `wait` command can cause deadlocks with IINA processes.

**Solution:**
- **Instance Detection**: Check if IINA is already running using `pgrep -f "IINA"`
- **Conditional Launch**: Skip `--keep-running` flag when IINA instance already exists
- **Wait Command Fix**: Skip `wait` for IINA when using external menu to prevent hanging

**Environment Tested:**
- Version: 4.10.3
- OS: MacOS
- Shell: zsh
- Player: IINA

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [x] `-q` quality works
- [ ] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text