### PR TITLE
docs: New matrix invite procedure

### DIFF
--- a/matrix.md
+++ b/matrix.md
@@ -1,7 +1,10 @@
-To get invited to ani-cli matrix space send an email to `8klv0leh7 at mozmail.com` with the following contents:
-```
-Subject: ani-cli matrix space invite
-Body: @yourusername:matrixserver
-```
+To get invited to ani-cli matrix space please knock into the `#ani-cli-queue:matrix.org` room. 
+
+In the reason field, please mention that you want to be invited to ani-cli.
+If your main client does not support spaces, please add that to the reason.
+
+Knocking is not supported by every client yet. You can use nheko.
+In nheko, click on a `plus icon` in the down left corner, `join room`, input `#ani-cli-queue:matrix.org` into the "Room ID or alias" input box.
+It will say that you are not allowed to join and ask if you want to knock.
 
 It might take some time before you get invited.

--- a/matrix.md
+++ b/matrix.md
@@ -1,4 +1,4 @@
-To get invited to ani-cli matrix space please knock into the `#ani-cli-queue:matrix.org` room. 
+To get invited to ani-cli matrix space please knock into the `#ani-cli-queue:matrix.org` room.
 
 In the reason field, please mention that you want to be invited to ani-cli.
 If your main client does not support spaces, please add that to the reason.


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

New matrix invite procedure utilising `knocking` feature.

## Checklist - not applicable

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases - not applicable

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
