### PR TITLE
Added support for a new player (Haruna)

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 - sed
 - curl
 - mpv - Video Player
+- haruna - Qt frontend for mpv (Linux, supports --haruna or export ANI_CLI_PLAYER=haruna)
 - iina - mpv replacement for MacOS
 - aria2c - Download manager
 - yt-dlp - m3u8 Downloader
@@ -530,6 +531,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 * Can I change dub language? - No.
 * Can I change media source? - No (unless you can scrape that source yourself).
 * Can I use vlc? - Yes, use `--vlc` or `export ANI_CLI_PLAYER=vlc`.
+* Can I use Haruna? - Yes, use `--haruna` or `export ANI_CLI_PLAYER=haruna`.
 * Can I adjust resolution? - Yes, use `-q resolution`, for example `ani-cli -q 1080`.
 * How can I download? - Use `-d`, it will download into your working directory.
 * Can i change download folder? - Yes, set the `ANI_CLI_DOWNLOAD_DIR` to your desired location.

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.3"
+version_number="4.10.4"
 
 # UI
 
@@ -45,7 +45,7 @@ help_info() {
     %s [query] [options]
     %s [options] [query] [options]
 
-    Options:
+        Options:
       -c, --continue
         Continue watching from history
       -d, --download
@@ -62,6 +62,8 @@ help_info() {
         Specify the video quality
       -v, --vlc
         Use VLC to play the video
+      -H, --haruna
+        Use Haruna to play the video
       -V, --version
         Show the version of the script
       -h, --help
@@ -128,6 +130,9 @@ where_iina() {
 }
 
 where_mpv() {
+where_haruna() {
+    command -v "haruna" >/dev/null && printf "%s" "haruna" && return 0
+}
     command -v "flatpak" >/dev/null && flatpak info io.mpv.Mpv >/dev/null 2>&1 && printf "%s" "flatpak_mpv" && return 0
     printf "%s" "mpv" && return 0
 }
@@ -320,6 +325,9 @@ play_episode() {
                 [ "$exit_after_play" = 1 ] && [ -z "$range" ] && exit "$mpv_exitcode"
             fi
             ;;
+        haruna*)
+            nohup $player_function "$episode" >/dev/null 2>&1 &
+            ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         *iina*)
@@ -412,6 +420,9 @@ while [ $# -gt 0 ]; do
                 *ish*) player_function="iSH" ;;
                 *) player_function="vlc" ;;
             esac
+            ;;
+        -H | --haruna)
+            player_function="haruna"
             ;;
         -s | --syncplay)
             case "$(uname -s)" in


### PR DESCRIPTION
# Pull Request Template Example

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Added support for the Haruna player (Qt frontend for mpv). Users can now use `--haruna` or set `ANI_CLI_PLAYER=haruna` to play anime with Haruna. 

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [ ] Man page is up to date
