### PR TITLE
Added dmenu support

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,17 +1,22 @@
 #!/bin/sh
 
-version_number="4.10.4"
+version_number="4.10.5"
+launcher_choice=0
 
 # UI
 
 external_menu() {
-    rofi "$1" -sort -dmenu -i -width 1500 -p "$2" "$3"
+	case $launcher_choice in
+		1) rofi "$1" -sort -dmenu -i -width 1500 -p "$2" "$3" ;;
+		2) dmenu -l 20 -p "$1" ;;
+	esac
 }
 
 launcher() {
     [ "$use_external_menu" = "0" ] && [ -z "$1" ] && set -- "+m" "$2"
     [ "$use_external_menu" = "0" ] && fzf "$1" --reverse --cycle --prompt "$2"
     [ "$use_external_menu" = "1" ] && external_menu "$1" "$2" "$external_menu_args"
+    [ "$use_external_menu" = "2" ] && external_menu "$1"
 }
 
 nth() {
@@ -72,6 +77,8 @@ help_info() {
         Play dubbed version
       --rofi
         Use rofi instead of fzf for the interactive menu
+			--dmenu
+				Use dmenu instead of fzf for the interactive menu
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
       --no-detach
@@ -346,7 +353,7 @@ play_episode() {
     replay="$episode"
     unset episode
     update_history
-    [ "$use_external_menu" = "1" ] && wait
+    [ "$use_external_menu" = $launcher_choice ] && wait
 }
 
 play() {
@@ -401,7 +408,7 @@ external_menu_normal_window="${ANI_CLI_EXTERNAL_MENU_NORMAL_WINDOW:-0}"
 skip_intro="${ANI_CLI_SKIP_INTRO:-0}"
 # shellcheck disable=SC2154
 skip_title="$ANI_CLI_SKIP_TITLE"
-[ -t 0 ] || use_external_menu=1
+[ -t 0 ] || use_external_menu=$launcher_choice
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
@@ -465,7 +472,8 @@ while [ $# -gt 0 ]; do
         --dub) mode="dub" ;;
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 && no_detach=1 ;;
-        --rofi) use_external_menu=1 ;;
+        --rofi) use_external_menu=1 && launcher_choice=1 ;;
+        --dmenu) use_external_menu=2 && launcher_choice=2 ;;
         --skip) skip_intro=1 ;;
         --skip-title)
             [ $# -lt 2 ] && die "missing argument!"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
