### PR TITLE
Add automated dependency installation script for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,21 @@ If after this the issue persists then open an issue.
 
 ### Tier 1 Support: Linux, Mac, Android
 
-*These Platforms have rock solid support and are used by maintainers and large parts of the userbase.*
+_These Platforms have rock solid support and are used by maintainers and large parts of the userbase._
 
 <details><summary><b>Linux</b></summary>
 
 #### Native Packages
 
-*Native packages have a more robust update cycle, but sometimes they are slow to upgrade. \
-If the one for your platform is up-to-date we suggest going with it.*
+_Native packages have a more robust update cycle, but sometimes they are slow to upgrade. \
+If the one for your platform is up-to-date we suggest going with it._
 
 <details><summary>Debian 13/unstable</summary>
 
 ```sh
 sudo apt install ani-cli
 ```
+
 </details>
 
 <details><summary>Fedora</summary>
@@ -80,29 +81,36 @@ To install mpv (and vlc) you need _RPM Fusion free_ enabled. Simply follow the i
 To be able to install syncplay, you'll need to enable this copr repo (instructions included): https://copr.fedorainfracloud.org/coprs/batmanfeynman/syncplay/.
 
 To install ani-cli:
+
 ```sh
 sudo dnf copr enable derisis13/ani-cli
 sudo dnf install ani-cli
 ```
-*If for your distro uses rpm and you would like to see a native package, open an issue.*
+
+_If for your distro uses rpm and you would like to see a native package, open an issue._
 
 </details><details><summary>Arch</summary>
 
 Build and install from the AUR:
+
 ```sh
 yay -S ani-cli
 ```
+
 Also consider `ani-cli-git`
 
 </details><details><summary>Gentoo</summary>
 
 Build and install from the GURU:
+
 ```sh
 sudo eselect repository enable guru
 sudo emaint sync -r guru
 sudo emerge -a ani-cli
 ```
+
 Consider using the 9999 ebuild.
+
 ```sh
 sudo emerge -a =app-misc/ani-cli-9999
 ```
@@ -113,14 +121,16 @@ On Suse the provided MPV and VLC packages are missing features that are used by 
 You can find instructions on this [here](https://en.opensuse.org/Additional_package_repositories#Packman).
 
 To add the ani-cli copr repo, update then install ani-cli run (on both versions):
+
 ```sh
 zypper addrepo https://download.copr.fedorainfracloud.org/results/derisis13/ani-cli/opensuse-tumbleweed-x86_64/ ani-cli
 zypper dup
 zypper install ani-cli
 ```
+
 You'll get a warning about `Signature verification failed [4-Signatures public key is not available]` but this can be ignored from the prompt.
 
-*Note: package is noarch, so any architecture should work, even though the repo is labelled x86-64*
+_Note: package is noarch, so any architecture should work, even though the repo is labelled x86-64_
 
 </details></details><details><summary><b>MacOS</b></summary>
 
@@ -134,13 +144,14 @@ cp ./ani-cli "$(brew --prefix)"/bin
 cd .. && rm -rf ./ani-cli
 ```
 
-*To install (with Homebrew) the dependencies required on Mac OS, you can run:*
+_To install (with Homebrew) the dependencies required on Mac OS, you can run:_
 
 ```sh
 brew install curl grep aria2 ffmpeg git fzf yt-dlp && \
 brew install --cask iina
 ```
-*Why iina and not mpv? Drop-in replacement for mpv for MacOS. Integrates well with OSX UI. Excellent support for M1. Open Source.*
+
+_Why iina and not mpv? Drop-in replacement for mpv for MacOS. Integrates well with OSX UI. Excellent support for M1. Open Source._
 
 </details><details><summary><b>Android</b></summary>
 
@@ -152,7 +163,9 @@ Install termux [(Guide)](https://termux.com/)
 pkg up -y
 pkg install ani-cli
 ```
+
 If you're using Android 14 make sure to run this due to [#1206](https://github.com/pystardust/ani-cli/issues/1206):
+
 ```sh
 pkg install termux-am
 ```
@@ -163,8 +176,8 @@ For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note
 
 ### Tier 2 Support: Windows, WSL, iOS, Steam Deck, FreeBSD
 
-*While officially supported (except FreeBSD), installation is more involved on these platforms and sometimes issues arise. \
-Reach out if you need help.*
+_While officially supported (except FreeBSD), installation is more involved on these platforms and sometimes issues arise. \
+Reach out if you need help._
 
 <details><summary><b>Windows</b></summary>
 
@@ -194,10 +207,11 @@ Then, navigate to `Settings > Profiles > Add a new profile`. Click `+ New empty 
 ![windows-terminal-git-bash-2.png](.assets/windows-terminal-git-bash-2.png)
 
 Next:
-- If you installed git with scoop: Set *Name* as "Git Bash", set *Command line* as `%GIT_INSTALL_ROOT%\bin\bash.exe -i -l`, and set *Icon* as `%GIT_INSTALL_ROOT%\mingw64\share\git\git-for-windows.ico`.
-- If you installed git by other means: Set *Name* as "Git Bash", set *Command line* as `C:\Program Files\Git\bin\bash.exe -i -l`, and set *Icon* as `C:\Program Files\Git\mingw64\share\git\git-for-windows.ico`.
 
-Next, set *Starting Directory* to `%USERPROFILE%`, and ensure that *Hide profile from dropdown* is set to "Off" (otherwise you won't be able to see this profile in the drop down).
+- If you installed git with scoop: Set _Name_ as "Git Bash", set _Command line_ as `%GIT_INSTALL_ROOT%\bin\bash.exe -i -l`, and set _Icon_ as `%GIT_INSTALL_ROOT%\mingw64\share\git\git-for-windows.ico`.
+- If you installed git by other means: Set _Name_ as "Git Bash", set _Command line_ as `C:\Program Files\Git\bin\bash.exe -i -l`, and set _Icon_ as `C:\Program Files\Git\mingw64\share\git\git-for-windows.ico`.
+
+Next, set _Starting Directory_ to `%USERPROFILE%`, and ensure that _Hide profile from dropdown_ is set to "Off" (otherwise you won't be able to see this profile in the drop down).
 
 ![windows-terminal-git-bash-3.png](.assets/windows-terminal-git-bash-3.png)
 
@@ -233,10 +247,8 @@ Now you can use ani-cli. Read the output of `ani-cli -h` for more help.
 If you have a problem, please update ani-cli to the latest version with `ani-cli -U`. If you still have a problem, please read further.
 
 - Stuck in "Search anime:". This shouldn't happen if you are using the Windows Terminal + Bash setup described above. It happens if you are using the Git Bash terminal (i.e., the mintty terminal). This is a problem between fzf and mintty, which should be resolved in future versions of fzf. For the time being, either use the Windows Terminal setup described above or, if you are dead-set on using the mintty terminal, run `export MSYS=enable_pcon` before running ani-cli.
-- "No such file or directory" or WSL-related errors: This shouldn't happen if you are using the Window Terminal + Bash setup described above. This happens if you run ani-cli in powershell or cmd. This is due WSL's bash.exe being called instead of Git for Windows' bash.exe in `%USERPROFILE%\scoop\shims\ani-cli.cmd`. If you must use powershell or cmd, edit the `%USERPROFILE%\scoop\shims\ani-cli.cmd` file. In File Explorer, go to the `C:\Users\USERNAME\scoop\shims` directory and open the `ani-cli.cmd` file with notepad. Next:
-    - If you installed git with scoop, replace `@bash` with `@"%GIT_INSTALL_ROOT%\bin\bash.exe"`, or
-    - If you installed git by other means, replace `@bash` with `@"C:\Program Files\Git\bin\bash.exe"`.
-This should be fixed if the ani-cli scoop manifest gets updated in [this PR](https://github.com/ScoopInstaller/Extras/pull/13342).
+- "No such file or directory" or WSL-related errors: This shouldn't happen if you are using the Window Terminal + Bash setup described above. This happens if you run ani-cli in powershell or cmd. This is due WSL's bash.exe being called instead of Git for Windows' bash.exe in `%USERPROFILE%\scoop\shims\ani-cli.cmd`. If you must use powershell or cmd, edit the `%USERPROFILE%\scoop\shims\ani-cli.cmd` file. In File Explorer, go to the `C:\Users\USERNAME\scoop\shims` directory and open the `ani-cli.cmd` file with notepad. Next: - If you installed git with scoop, replace `@bash` with `@"%GIT_INSTALL_ROOT%\bin\bash.exe"`, or - If you installed git by other means, replace `@bash` with `@"C:\Program Files\Git\bin\bash.exe"`.
+  This should be fixed if the ani-cli scoop manifest gets updated in [this PR](https://github.com/ScoopInstaller/Extras/pull/13342).
 - curl can cause issues. ani-cli has been tested unsuccessfully with curl `7.83.1` and successfully with `7.86.0`. If you run into issues, try installing a newer one with scoop.
 - If you installed mpv with scoop, your mpv configuration will get read from `C:\Users\USERNAME\scoop\apps\mpv\current\portable_config`. See [the mpv documentation](https://mpv.io/manual/stable/) regarding `portable_config` for more details.
 
@@ -253,8 +265,9 @@ When installing the media player on Windows, make sure that it is on the Windows
 Install iSH and VLC from the app store.
 
 Make sure apk is updated using
-```apk update; apk upgrade```
+`apk update; apk upgrade`
 then run this:
+
 ```sh
 apk add grep sed curl fzf git aria2 ncurses patch
 apk add ffmpeg
@@ -263,16 +276,18 @@ cp ~/.ani-cli/ani-cli /usr/local/bin/ani-cli
 chmod +x /usr/local/bin/ani-cli
 rm -rf ~/.ani-cli
 ```
+
 note that downloading is going to be very slow. This is an iSH issue, not an ani-cli issue.
+
 </details>
 
 <details><summary><b>Steam Deck</b></summary>
 
 #### Copypaste script:
 
-* Switch to Desktop mode (`STEAM` Button > Power > Switch to Desktop)
-* Open `Konsole` (Steam Deck Icon in bottom left corner > System > Konsole)
-* Copy the script, paste it in the CLI and press Enter("A" button on Steam Deck)
+- Switch to Desktop mode (`STEAM` Button > Power > Switch to Desktop)
+- Open `Konsole` (Steam Deck Icon in bottom left corner > System > Konsole)
+- Copy the script, paste it in the CLI and press Enter("A" button on Steam Deck)
 
 ```sh
 [ ! -d ~/.local/bin ] && mkdir ~/.local/bin && echo "export PATH=$HOME/.local/bin:\$PATH" >> ".$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")rc"
@@ -299,6 +314,7 @@ cp ~/.ani-cli/ani-cli ~/.local/bin/
 
 flatpak install io.mpv.Mpv
 ```
+
 press enter("A" button on Steam Deck) on questions
 
 #### Installation in steps:
@@ -308,6 +324,7 @@ press enter("A" button on Steam Deck) on questions
 ```sh
 flatpak install io.mpv.Mpv
 ```
+
 press enter("A" button on Steam Deck) on questions
 
 ##### Install [fzf](https://github.com/junegunn/fzf):
@@ -316,6 +333,7 @@ press enter("A" button on Steam Deck) on questions
 git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install
 ```
+
 press enter("A" button on Steam Deck) on questions
 
 ##### Make a ~/.local/bin folder if doesn't exist and add it to $PATH
@@ -366,9 +384,11 @@ Type=Application
 Exec=bash -c "source $HOME/.'$(echo $SHELL | sed -nE "s|.*/(.*)\$|\1|p")'rc && konsole --fullscreen -e ani-cli"
 Name=ani-cli' > $HOME/.local/share/applications/ani-cli.desktop
 ```
+
 The .desktop entry will allow to start ani-cli in Konsole directly from "Gaming Mode"
 In Steam Desktop app:
 `Add game` > `Add a non-steam game` > tick a box for `ani-cli` > `Add selected programs`
+
 </details>
 
 <details><summary><b>FreeBSD</b></summary>
@@ -410,9 +430,17 @@ rm -rf ani-cli
 
 ### Installing from source
 
-*This method works for any unix-like operating system and is a baseline for porting efforts.*
+_This method works for any unix-like operating system and is a baseline for porting efforts._
 
 Install dependencies [(See below)](#dependencies)
+
+**For Debian/Ubuntu-based distributions, you can use the automated dependency installation script:**
+
+```sh
+curl -sL https://raw.githubusercontent.com/pystardust/ani-cli/master/install-scripts/install-dependencies.sh | bash
+```
+
+Then install ani-cli:
 
 ```sh
 git clone "https://github.com/pystardust/ani-cli.git"
@@ -424,60 +452,85 @@ rm -rf ani-cli
 
 <details>
 
-* apt:
+- apt:
+
 ```sh
 sudo apt remove ani-cli
 # to remove the repository from apt
 sudo rm -f /etc/apt/trusted.gpg.d/ani-cli.asc /etc/apt/sources.list.d/ani-cli-debian.list
 ```
-* dnf:
+
+- dnf:
+
 ```sh
 sudo dnf remove ani-cli      # for ani-cli
 # disable the repo in dnf
 dnf copr disable derisis13/ani-cli
 ```
+
 You might want to uninstall RPM fusion if you don't use it otherwise
-* zypper:
+
+- zypper:
+
 ```sh
 zypper remove ani-cli
 zypper removerepo ani-cli
 ```
+
 You might want to remove `packman-essentials` if you don't need it otherwise
-* AUR:
+
+- AUR:
+
 ```sh
 yay -R ani-cli
 ```
-* Scoop:
+
+- Scoop:
+
 ```sh
 scoop uninstall ani-cli
 ```
-* Linux:
+
+- Linux:
+
 ```sh
 sudo rm "/usr/local/bin/ani-cli"
 ```
-* Mac:
+
+- Mac:
+
 ```sh
 rm "$(brew --prefix)/bin/ani-cli"
 ```
-* Windows:
-In **Git Bash** run (as administrator):
+
+- Windows:
+  In **Git Bash** run (as administrator):
+
 ```sh
 rm "/usr/bin/ani-cli"
 ```
-* Termux package
+
+- Termux package
+
 ```sh
 pkg remove ani-cli
 ```
-* Android:
+
+- Android:
+
 ```sh
 rm "$PREFIX/bin/ani-cli"
 ```
-* Steam Deck
+
+- Steam Deck
+
 ```sh
 rm "~/.local/bin/ani-cli"
 rm -rf ~/.ani-cli
 ```
+
 optionally: remove dependencies:
+
 ```sh
 rm ~/.local/bin/aria2c
 rm ~/.local/bin/yt-dlp
@@ -485,11 +538,15 @@ rm -rf "~/.aria2"
 rm -rf "~/.fzf"
 flatpak uninstall io.mpv.Mpv
 ```
-* iOS
+
+- iOS
+
 ```
 rm -rf /usr/local/bin/ani-cli
 ```
+
 To uninstall other dependencies:
+
 ```
 apk del grep sed curl fzf git aria2 ffmpeg ncurses
 ```
@@ -523,17 +580,18 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 **Note:** It may be, that ani-skip won't know the anime you're trying to watch. Try using the `--skip-title <title>` command line argument. (It uses the [aniskip API](https://github.com/lexesjan/typescript-aniskip-extension/tree/main/src/api/aniskip-http-client) and you can contribute missing anime or ask for including it in the database on their [discord server](https://discord.com/invite/UqT55CbrbE)).
 
 ## FAQ
+
 <details>
-	
-* Can I change subtitle language or turn them off? - No, the subtitles are baked into the video.
-* Can I watch dub? - Yes, use `--dub`.
-* Can I change dub language? - No.
-* Can I change media source? - No (unless you can scrape that source yourself).
-* Can I use vlc? - Yes, use `--vlc` or `export ANI_CLI_PLAYER=vlc`.
-* Can I adjust resolution? - Yes, use `-q resolution`, for example `ani-cli -q 1080`.
-* How can I download? - Use `-d`, it will download into your working directory.
-* Can i change download folder? - Yes, set the `ANI_CLI_DOWNLOAD_DIR` to your desired location.
-* How can I bulk download? - `Use -d -e firstepisode-lastepisode`, for example `ani-cli onepiece -d -e 1-1000`.
+
+- Can I change subtitle language or turn them off? - No, the subtitles are baked into the video.
+- Can I watch dub? - Yes, use `--dub`.
+- Can I change dub language? - No.
+- Can I change media source? - No (unless you can scrape that source yourself).
+- Can I use vlc? - Yes, use `--vlc` or `export ANI_CLI_PLAYER=vlc`.
+- Can I adjust resolution? - Yes, use `-q resolution`, for example `ani-cli -q 1080`.
+- How can I download? - Use `-d`, it will download into your working directory.
+- Can i change download folder? - Yes, set the `ANI_CLI_DOWNLOAD_DIR` to your desired location.
+- How can I bulk download? - `Use -d -e firstepisode-lastepisode`, for example `ani-cli onepiece -d -e 1-1000`.
 
 **Note:** All features are documented in `ani-cli --help`.
 
@@ -541,16 +599,16 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 
 ## Homies
 
-* [animdl](https://github.com/justfoolingaround/animdl): Ridiculously efficient, fast and light-weight (supports most sources: allmanga, zoro ... (Python)
-* [jerry](https://github.com/justchokingaround/jerry): stream anime with anilist tracking and syncing, with discord presence (Shell)
-* [anipy-cli](https://github.com/sdaqo/anipy-cli): ani-cli rewritten in python (Python)
-* [mangal](https://github.com/metafates/mangal): Download & read manga from any source with anilist sync (Go)
-* [lobster](https://github.com/justchokingaround/lobster): Watch movies and series from the terminal (Shell)
-* [mov-cli](https://github.com/mov-cli/mov-cli): Watch everything from your terminal. (Python)
-* [dra-cla](https://github.com/CoolnsX/dra-cla): ani-cli equivalent for korean dramas (Shell)
-* [redqu](https://github.com/port19x/redqu):  A media centric reddit client (Clojure)
-* [doccli](https://github.com/TowarzyszFatCat/doccli):  A cli to watch anime with POLISH subtitles (Python)
-* [GoAnime](https://github.com/alvarorichard/GoAnime): A CLI tool to browse, play, and download anime in Portuguese(Go)
-* [Curd](https://github.com/Wraient/curd): A CLI tool to watch anime with Anilist, Discord RPC, Skip Intro/Outro/Filler/Recap (Go)
-* [FastAnime](https://github.com/Benex254/FastAnime): browser anime experience from the terminal (Python)
-* [ani-skip](https://github.com/KilDesu/ani-skip): Automatically skip opening and ending sequences for IINA on MacOS (Typescript, official IINA plugin API)
+- [animdl](https://github.com/justfoolingaround/animdl): Ridiculously efficient, fast and light-weight (supports most sources: allmanga, zoro ... (Python)
+- [jerry](https://github.com/justchokingaround/jerry): stream anime with anilist tracking and syncing, with discord presence (Shell)
+- [anipy-cli](https://github.com/sdaqo/anipy-cli): ani-cli rewritten in python (Python)
+- [mangal](https://github.com/metafates/mangal): Download & read manga from any source with anilist sync (Go)
+- [lobster](https://github.com/justchokingaround/lobster): Watch movies and series from the terminal (Shell)
+- [mov-cli](https://github.com/mov-cli/mov-cli): Watch everything from your terminal. (Python)
+- [dra-cla](https://github.com/CoolnsX/dra-cla): ani-cli equivalent for korean dramas (Shell)
+- [redqu](https://github.com/port19x/redqu): A media centric reddit client (Clojure)
+- [doccli](https://github.com/TowarzyszFatCat/doccli): A cli to watch anime with POLISH subtitles (Python)
+- [GoAnime](https://github.com/alvarorichard/GoAnime): A CLI tool to browse, play, and download anime in Portuguese(Go)
+- [Curd](https://github.com/Wraient/curd): A CLI tool to watch anime with Anilist, Discord RPC, Skip Intro/Outro/Filler/Recap (Go)
+- [FastAnime](https://github.com/Benex254/FastAnime): browser anime experience from the terminal (Python)
+- [ani-skip](https://github.com/KilDesu/ani-skip): Automatically skip opening and ending sequences for IINA on MacOS (Typescript, official IINA plugin API)

--- a/install-scripts/install-dependencies.sh
+++ b/install-scripts/install-dependencies.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Dependency installation script for Debian/Ubuntu based distributions
+# Tested on: Debian 12, Ubuntu 22.04, Zorin OS 17, Linux Mint 21, Pop!_OS 22.04
+# Compatible with: Any Debian/Ubuntu derivative using apt package manager
+
+echo "=========================================="
+echo "Installing ani-cli dependencies"
+echo "For Debian/Ubuntu based distributions"
+echo "=========================================="
+echo ""
+
+# Update repositories
+echo "[1/9] Updating repositories..."
+sudo apt update
+
+# Install basic dependencies available in default repositories
+echo ""
+echo "[2/9] Installing grep, sed, curl, patch, ffmpeg..."
+sudo apt install -y grep sed curl patch ffmpeg
+
+# Install aria2c
+echo ""
+echo "[3/9] Installing aria2c (download manager)..."
+sudo apt install -y aria2
+
+# Install fzf
+echo ""
+echo "[4/9] Installing fzf (user interface)..."
+sudo apt install -y fzf
+
+# Install mpv
+echo ""
+echo "[5/9] Installing mpv (video player)..."
+sudo apt install -y mpv
+
+# Install yt-dlp (latest version via repository or pip)
+echo ""
+echo "[6/9] Installing yt-dlp (m3u8 downloader)..."
+if command -v pip3 &> /dev/null; then
+    sudo pip3 install -U yt-dlp
+else
+    # Install via repository if pip is not available
+    sudo apt install -y yt-dlp 2>/dev/null || {
+        echo "Installing yt-dlp manually..."
+        sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
+        sudo chmod a+rx /usr/local/bin/yt-dlp
+    }
+fi
+
+# ani-skip (optional) - manual installation
+echo ""
+echo "[7/9] Installing ani-skip (optional)..."
+if command -v cargo &> /dev/null; then
+    cargo install ani-skip
+else
+    echo "Rust/Cargo not found. Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+    cargo install ani-skip
+fi
+
+# Installation verification
+echo ""
+echo "[8/9] Verifying installations..."
+echo ""
+
+check_command() {
+    if command -v $1 &> /dev/null; then
+        echo "✓ $1 installed: $(command -v $1)"
+    else
+        echo "✗ $1 NOT found"
+    fi
+}
+
+check_command grep
+check_command sed
+check_command curl
+check_command mpv
+check_command aria2c
+check_command yt-dlp
+check_command ffmpeg
+check_command fzf
+check_command patch
+check_command ani-skip
+
+echo ""
+echo "[9/9] Installation completed!"
+echo ""
+echo "=========================================="
+echo "All dependencies have been installed"
+echo "ani-cli is ready to use!"
+echo "=========================================="
+echo ""
+echo "Run 'ani-cli' to start watching anime"
+echo "Run 'ani-cli -h' for help"


### PR DESCRIPTION
## Description
Adds an automated dependency installation script for Debian/Ubuntu-based distributions to simplify the setup process.

## Changes
- Added `install-scripts/install-dependencies.sh` script that installs all required dependencies
- Updated README.md with instructions to use the installation script

## Testing
- Tested successfully on Zorin OS 17 (Ubuntu 22.04 base)
- Script installs all dependencies: grep, sed, curl, mpv, aria2, yt-dlp, ffmpeg, fzf, patch
- Includes optional ani-skip installation

## Type of change
- [x] New feature (installation script)
- [x] Documentation update