### PR TITLE
feat: add -R/--random flag for anime discovery mode (#1601)

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 <details>
 	
 * Can I change subtitle language or turn them off? - No, the subtitles are baked into the video.
+* I don't know what to watch. - Use `-R` or `--random` to browse a random selection of popular anime.
 * Can I watch dub? - Yes, use `--dub`.
 * Can I change dub language? - No.
 * Can I change media source? - No (unless you can scrape that source yourself).

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.4"
+version_number="4.11.0"
 
 # UI
 
@@ -82,6 +82,8 @@ help_info() {
         Use given title as ani-skip query
       -N, --nextep-countdown
         Display a countdown to the next episode
+      -R, --random
+        Browse random anime (discover mode)
       -U, --update
         Update the script
     Some example usages:
@@ -227,6 +229,14 @@ get_episode_url() {
     else
         [ -z "$episode" ] && die "Episode not released!"
     fi
+}
+
+# fetch a random/discovery list of anime (random page of top anime)
+random_anime() {
+    #shellcheck disable=SC2016
+    random_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
+    rand_page=$(($(od -An -N2 -tu2 /dev/urandom | tr -d ' ') % 30 + 1))
+    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"sortBy\":\"Top\"},\"limit\":26,\"page\":${rand_page},\"translationType\":\"$mode\",\"countryOrigin\":\"JP\"}" --data-urlencode "query=$random_gql" -A "$agent" | sed 's|Show|\n|g' | sed -nE "s|.*_id\":\"([^\"]*).*\"name\":\"(.+)\".*${mode}\":\"?([1-9][^,]*).*|\1\t\2 (\3 episodes)|p" | sed 's/\\"//g'
 }
 
 # search the query and give results
@@ -473,6 +483,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -N | --nextep-countdown) search=nextep ;;
+        -R | --random) search=random ;;
         -U | --update) update_script ;;
         *) query="$(printf "%s" "$query $1" | sed "s|^ ||;s| |+|g")" ;;
     esac
@@ -496,6 +507,20 @@ esac
 
 # searching
 case "$search" in
+    random)
+        printf "\33[2K\r\033[1;35mFetching random anime to discover...\033[0m\n"
+        anime_list=$(random_anime)
+        [ -z "$anime_list" ] && die "Could not fetch anime list!"
+        result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//')
+        result=$(printf "%s" "$result" | nth "Discover anime: ")
+        [ -z "$result" ] && exit 1
+        title=$(printf "%s" "$result" | cut -f2)
+        allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        id=$(printf "%s" "$result" | cut -f1)
+        ep_list=$(episodes_list "$id")
+        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        [ -z "$ep_no" ] && exit 1
+        ;;
     history)
         anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
         wait

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -52,6 +52,9 @@ Selects nth entry.
 \fB\-N | --nextep-countdown\fR
 Prints a countdown to the next episode as the last episode in the list. If in history is after the current episode.
 .TP
+\fB\-R | --random\fR
+Browse a random selection of popular anime (discover mode). Useful when you don't know what to watch.
+.TP
 \fB\--dub\fR
 Play the dubbed version. Without this flag, it'll always play the subbed version.
 .TP


### PR DESCRIPTION
[# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Adds a -R / --random flag for anime discovery mode (closes #1601).

When you don't know what to watch, ani-cli -R fetches a random page of popular anime from AllAnime and presents them in the fzf/rofi selection menu. Once you pick one, the normal episode selection flow takes over.



## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date
