### PR TITLE
fix: replace sed with grep -v in update_history to handle special cha…

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -277,11 +277,11 @@ process_hist_entry() {
 
 update_history() {
     if grep -q -- "$id" "$histfile"; then
-        sed -E "s|^[^	]+	${id}	[^	]+$|${ep_no}	${id}	${title}|" "$histfile" >"${histfile}.new"
+        grep -v -- "$id" "$histfile" >"${histfile}.new"
     else
         cp "$histfile" "${histfile}.new"
-        printf "%s\t%s\t%s\n" "$ep_no" "$id" "$title" >>"${histfile}.new"
     fi
+    printf "%s\t%s\t%s\n" "$ep_no" "$id" "$title" >>"${histfile}.new"
     mv "${histfile}.new" "$histfile"
 }
 


### PR DESCRIPTION
Fixes #1576

## Type of change
- [x] Bug fix

## Description
The `update_history` function used a `sed` expression with `$title` 
directly in the replacement string. This broke silently when anime titles 
contained regex metacharacters like colons, parentheses, or dots 
(e.g. `Re:Zero`, `SAO: Alicization`, `Arslan Senki (TV)`).

The history entry would fail to update, so rewatching an anime would 
always show episode 1 in history instead of the last watched episode.

## Fix
Replaced the broken `sed` substitution with `grep -v` to remove the old 
entry by ID, then always append the fresh entry using `printf`. Since we 
match on `$id` (an alphanumeric hash) instead of `$title`, there are no 
regex metacharacter issues.

## Testing
Tested with `Sword Art Online Alternative: Gun Gale Online II` — 
history correctly updated from episode 1 → 2 after rewatching.