### PR TITLE
fix: escape sed special chars in update_history to handle & in titles

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.6"
+version_number="4.10.7"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -277,7 +277,9 @@ process_hist_entry() {
 
 update_history() {
     if grep -q -- "$id" "$histfile"; then
-        sed -E "s|^[^	]+	${id}	[^	]+$|${ep_no}	${id}	${title}|" "$histfile" >"${histfile}.new"
+        # escape sed special chars in replacement: & and \ and delimiter |
+        safe_title=$(printf '%s' "$title" | sed 's/[&\|]/\\&/g')
+        sed -E "s|^[^	]+	${id}	[^	]+$|${ep_no}	${id}	${safe_title}|" "$histfile" >"${histfile}.new"
     else
         cp "$histfile" "${histfile}.new"
         printf "%s\t%s\t%s\n" "$ep_no" "$id" "$title" >>"${histfile}.new"


### PR DESCRIPTION
## Bug
https://github.com/pystardust/ani-cli/issues/1576 — Anime titles containing `&` (e.g. "Panty & Stocking with Garterbelt") corrupt the history file, breaking the continue-watching feature.

## Root Cause
In `update_history()`, the title is used directly in a `sed` replacement string:
```bash
sed -E "s|...|...${title}|" "$histfile"
```
In sed's replacement, `&` is a special character meaning "the entire matched text". So a title like `Panty & Stocking with Garterbelt` causes the entire matched line to be inserted where `&` appears, producing:
```
2	z3E78qds49jd4BSK9	Panty 1	z3E78qds49jd4BSK9	Panty & Stocking with Garterbelt (13 episodes) Stocking with Garterbelt (13 episodes)
```
This garbled line can't be parsed back, so history continuation fails.

## Fix
Escape `&`, `\`, and the delimiter `|` in the title before passing it to the sed replacement string. The new entry path (`printf` append) is unaffected since `printf "%s"` doesn't interpret these characters.

## Testing
Verified with titles containing `&`, `\`, and `|`:
- `Panty & Stocking with Garterbelt` → history line written correctly
- Continue-watching resumes from correct episode

Happy to address any feedback.

Greetings, saschabuehrle