### PR TITLE
feat: add English title option

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -72,8 +72,6 @@ help_info() {
         Specify the number of episodes to watch
       --dub
         Play dubbed version
-      --en
-        Show english anime titile if available
       --rofi
         Use rofi instead of fzf for the interactive menu
       --dmenu
@@ -235,36 +233,38 @@ get_episode_url() {
     fi
 }
 
-
 search_anime() {
     if [ "$english_title" = false ]; then
         #shellcheck disable=SC2016
-    search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
+        search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
+        curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
 
     else
-    curl -e "$allanime_refr" -s -X POST "${allanime_api}/api" -H "Content-Type: application/json" -d "{\"query\":\"query(\$search:SearchInput,\$limit:Int,\$page:Int,\$translationType:VaildTranslationTypeEnumType,\$countryOrigin:VaildCountryOriginEnumType){shows(search:\$search,limit:\$limit,page:\$page,translationType:\$translationType,countryOrigin:\$countryOrigin){edges{_id name englishName availableEpisodes}}}\",\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}}" -A "$agent" | sed 's/\\u002F/\//g;s/\\"//g' | grep -oE '"_id":"[^"]*","name":"[^"]*","englishName":(null|"[^"]*"),"availableEpisodes":{[^}]*}' | while IFS= read -r e; do
-        id=${e#*_id\":\"}
-        id=${id%%\"*}
-        name=${e#*\"name\":\"}
-        name=${name%%\"*}
-        
-        # Check for englishName:null using case statement (POSIX compliant)
-        case "$e" in
-            *'"englishName":null'*) en="" ;;
-            *) en=${e#*\"englishName\":\"}; en=${en%%\"*} ;;
-        esac
-        
-        eps=${e#*\"$mode\":}
-        eps=${eps%%,*}
-        eps=${eps%\}*}
-        
-        title=${en:-$name}
-        echo "$id	$title (${eps:-0} episodes)"
-    done
-fi
+        curl -e "$allanime_refr" -s -X POST "${allanime_api}/api" -H "Content-Type: application/json" -d "{\"query\":\"query(\$search:SearchInput,\$limit:Int,\$page:Int,\$translationType:VaildTranslationTypeEnumType,\$countryOrigin:VaildCountryOriginEnumType){shows(search:\$search,limit:\$limit,page:\$page,translationType:\$translationType,countryOrigin:\$countryOrigin){edges{_id name englishName availableEpisodes}}}\",\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}}" -A "$agent" | sed 's/\\u002F/\//g;s/\\"//g' | grep -oE '"_id":"[^"]*","name":"[^"]*","englishName":(null|"[^"]*"),"availableEpisodes":{[^}]*}' | while IFS= read -r e; do
+            id=${e#*_id\":\"}
+            id=${id%%\"*}
+            name=${e#*\"name\":\"}
+            name=${name%%\"*}
+
+            # Check for englishName:null using case statement (POSIX compliant)
+            case "$e" in
+                *'"englishName":null'*) en="" ;;
+                *)
+                    en=${e#*\"englishName\":\"}
+                    en=${en%%\"*}
+                    ;;
+            esac
+
+            eps=${e#*\"$mode\":}
+            eps=${eps%%,*}
+            eps=${eps%\}*}
+
+            title=${en:-$name}
+            echo "$id	$title (${eps:-0} episodes)"
+        done
+    fi
 }
 
 time_until_next_ep() {


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

--en option will show the "englishName" of the anime. If "englishName"=null then it will will display "name" instead and it will not effect the search results

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
