### PR TITLE
feat: add English title option

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -72,6 +72,8 @@ help_info() {
         Specify the number of episodes to watch
       --dub
         Play dubbed version
+      --en
+        Display English title if available
       --rofi
         Use rofi instead of fzf for the interactive menu
       --dmenu

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.6"
+version_number="4.10.7"
 
 # UI
 
@@ -72,6 +72,8 @@ help_info() {
         Specify the number of episodes to watch
       --dub
         Play dubbed version
+      --en
+        Show english anime titile if available
       --rofi
         Use rofi instead of fzf for the interactive menu
       --dmenu
@@ -233,13 +235,36 @@ get_episode_url() {
     fi
 }
 
-# search the query and give results
+
 search_anime() {
-    #shellcheck disable=SC2016
+    if [ "$english_title" = false ]; then
+        #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
     curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
+
+    else
+    curl -e "$allanime_refr" -s -X POST "${allanime_api}/api" -H "Content-Type: application/json" -d "{\"query\":\"query(\$search:SearchInput,\$limit:Int,\$page:Int,\$translationType:VaildTranslationTypeEnumType,\$countryOrigin:VaildCountryOriginEnumType){shows(search:\$search,limit:\$limit,page:\$page,translationType:\$translationType,countryOrigin:\$countryOrigin){edges{_id name englishName availableEpisodes}}}\",\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}}" -A "$agent" | sed 's/\\u002F/\//g;s/\\"//g' | grep -oE '"_id":"[^"]*","name":"[^"]*","englishName":(null|"[^"]*"),"availableEpisodes":{[^}]*}' | while IFS= read -r e; do
+        id=${e#*_id\":\"}
+        id=${id%%\"*}
+        name=${e#*\"name\":\"}
+        name=${name%%\"*}
+        
+        # Check for englishName:null using case statement (POSIX compliant)
+        case "$e" in
+            *'"englishName":null'*) en="" ;;
+            *) en=${e#*\"englishName\":\"}; en=${en%%\"*} ;;
+        esac
+        
+        eps=${e#*\"$mode\":}
+        eps=${eps%%,*}
+        eps=${eps%\}*}
+        
+        title=${en:-$name}
+        echo "$id	$title (${eps:-0} episodes)"
+    done
+fi
 }
 
 time_until_next_ep() {
@@ -391,6 +416,7 @@ mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"
 quality="${ANI_CLI_QUALITY:-best}"
+english_title=false
 case "$(uname -a | cut -d " " -f 1,3-)" in
     *Darwin*) player_function="${ANI_CLI_PLAYER:-$(where_iina)}" ;;   # mac OS
     *ndroid*) player_function="${ANI_CLI_PLAYER:-android_mpv}" ;;     # Android OS (termux)
@@ -469,6 +495,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --dub) mode="dub" ;;
+        --en) english_title=true ;;
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 && no_detach=1 ;;
         --rofi) use_external_menu=1 ;;

--- a/ani-cli
+++ b/ani-cli
@@ -72,8 +72,6 @@ help_info() {
         Specify the number of episodes to watch
       --dub
         Play dubbed version
-      --en
-        Show english anime titile if available
       --rofi
         Use rofi instead of fzf for the interactive menu
       --dmenu
@@ -235,36 +233,38 @@ get_episode_url() {
     fi
 }
 
-
 search_anime() {
     if [ "$english_title" = false ]; then
         #shellcheck disable=SC2016
-    search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
+        search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
+        curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
 
     else
-    curl -e "$allanime_refr" -s -X POST "${allanime_api}/api" -H "Content-Type: application/json" -d "{\"query\":\"query(\$search:SearchInput,\$limit:Int,\$page:Int,\$translationType:VaildTranslationTypeEnumType,\$countryOrigin:VaildCountryOriginEnumType){shows(search:\$search,limit:\$limit,page:\$page,translationType:\$translationType,countryOrigin:\$countryOrigin){edges{_id name englishName availableEpisodes}}}\",\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}}" -A "$agent" | sed 's/\\u002F/\//g;s/\\"//g' | grep -oE '"_id":"[^"]*","name":"[^"]*","englishName":(null|"[^"]*"),"availableEpisodes":{[^}]*}' | while IFS= read -r e; do
-        id=${e#*_id\":\"}
-        id=${id%%\"*}
-        name=${e#*\"name\":\"}
-        name=${name%%\"*}
-        
-        # Check for englishName:null using case statement (POSIX compliant)
-        case "$e" in
-            *'"englishName":null'*) en="" ;;
-            *) en=${e#*\"englishName\":\"}; en=${en%%\"*} ;;
-        esac
-        
-        eps=${e#*\"$mode\":}
-        eps=${eps%%,*}
-        eps=${eps%\}*}
-        
-        title=${en:-$name}
-        echo "$id	$title (${eps:-0} episodes)"
-    done
-fi
+        curl -e "$allanime_refr" -s -X POST "${allanime_api}/api" -H "Content-Type: application/json" -d "{\"query\":\"query(\$search:SearchInput,\$limit:Int,\$page:Int,\$translationType:VaildTranslationTypeEnumType,\$countryOrigin:VaildCountryOriginEnumType){shows(search:\$search,limit:\$limit,page:\$page,translationType:\$translationType,countryOrigin:\$countryOrigin){edges{_id name englishName availableEpisodes}}}\",\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}}" -A "$agent" | sed 's/\\u002F/\//g;s/\\"//g' | grep -oE '"_id":"[^"]*","name":"[^"]*","englishName":(null|"[^"]*"),"availableEpisodes":{[^}]*}' | while IFS= read -r e; do
+            id=${e#*_id\":\"}
+            id=${id%%\"*}
+            name=${e#*\"name\":\"}
+            name=${name%%\"*}
+
+            # Check for englishName:null using case statement (POSIX compliant)
+            case "$e" in
+                *'"englishName":null'*) en="" ;;
+                *)
+                    en=${e#*\"englishName\":\"}
+                    en=${en%%\"*}
+                    ;;
+            esac
+
+            eps=${e#*\"$mode\":}
+            eps=${eps%%,*}
+            eps=${eps%\}*}
+
+            title=${en:-$name}
+            echo "$id	$title (${eps:-0} episodes)"
+        done
+    fi
 }
 
 time_until_next_ep() {

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.7"
+version_number="4.11.0"
 
 # UI
 
@@ -216,7 +216,7 @@ get_episode_url() {
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    resp=$(curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    resp=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     cache_dir="$(mktemp -d)"
     providers="1 2 3 4"
@@ -238,11 +238,10 @@ get_episode_url() {
 search_anime() {
     if [ "$english_title" = false ]; then
         #shellcheck disable=SC2016
-        search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
+    search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-        curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
+    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
-
     else
         curl -e "$allanime_refr" -s -X POST "${allanime_api}/api" -H "Content-Type: application/json" -d "{\"query\":\"query(\$search:SearchInput,\$limit:Int,\$page:Int,\$translationType:VaildTranslationTypeEnumType,\$countryOrigin:VaildCountryOriginEnumType){shows(search:\$search,limit:\$limit,page:\$page,translationType:\$translationType,countryOrigin:\$countryOrigin){edges{_id name englishName availableEpisodes}}}\",\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}}" -A "$agent" | sed 's/\\u002F/\//g;s/\\"//g' | grep -oE '"_id":"[^"]*","name":"[^"]*","englishName":(null|"[^"]*"),"availableEpisodes":{[^}]*}' | while IFS= read -r e; do
             id=${e#*_id\":\"}
@@ -288,7 +287,7 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
+    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
 |g; s|"||g' | sort -n -k 1
 }
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

--en option will show the "englishName" of the anime. If "englishName"=null then it will will display "name" instead and it will not effect the search results

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
