### PR TITLE
Feat/aniskip auto setup

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -214,7 +214,7 @@ get_episode_url() {
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    resp=$(curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}" --data-urlencode "query=$episode_embed_gql" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    resp=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     cache_dir="$(mktemp -d)"
     providers="1 2 3 4"
@@ -238,7 +238,7 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"}" --data-urlencode "query=$search_gql" -A "$agent" | sed 's|Show|\
+    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
 }
 
@@ -261,7 +261,7 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    curl -e "$allanime_refr" -s -G "${allanime_api}/api" --data-urlencode "variables={\"showId\":\"$*\"}" --data-urlencode "query=$episodes_list_gql" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
+    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
 |g; s|"||g' | sort -n -k 1
 }
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.6"
+version_number="4.10.7"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.10.7"
+version_number="4.11.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -306,8 +306,18 @@ download() {
 }
 
 play_episode() {
+
+    skip_flag=""
+
+    [ "$skip_intro" = 1 ] && \
+        skip_flag="$(ani-skip -q "${skip_title:-${title}}" -e "$ep_no")"
+
+    [ -z "$episode" ] && get_episode_url
+
     [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
-    [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
+    if [ "$skip_intro" = 1 ]; then
+        skip_flag="$(ani-skip -q "${skip_title:-${title}}" -e "$ep_no")"
+    fi
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
     case "$player_function" in
@@ -536,6 +546,16 @@ case "$search" in
         title=$(printf "%s" "$result" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
+
+        # ask to skip intro
+        printf "\33[2K\r\033[1;36mSkip Intro? (Y/N) > \033[0m" > /dev/tty
+        read -r choice < /dev/tty
+
+        case "$choice" in
+            [Yy]*) skip_intro=1 ;;
+            *) skip_intro=0 ;;
+        esac
+
         ep_list=$(episodes_list "$id")
         [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.11.0"
+version_number="4.11.1"
 
 # UI
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+# setup.sh — bootstraps ani-skip + aniskip.lua for ani-cli
+# Supports: Linux, macOS, Android-Termux, iOS (iSH), Windows (WSL2/MINGW)
+# Usage: run once after cloning ani-cli, then just use ./ani-cli as normal
+
+set -e
+
+C_CYAN="\033[1;36m"
+C_GREEN="\033[1;32m"
+C_YELLOW="\033[1;33m"
+C_RED="\033[1;31m"
+C_RESET="\033[0m"
+
+info()    { printf "${C_CYAN}[setup]${C_RESET} %s\n" "$*"; }
+success() { printf "${C_GREEN}[setup]${C_RESET} %s\n" "$*"; }
+warn()    { printf "${C_YELLOW}[setup]${C_RESET} %s\n" "$*"; }
+die()     { printf "${C_RED}[setup]${C_RESET} %s\n" "$*" >&2; exit 1; }
+
+# Detect the platform
+UNAME="$(uname -a)"
+case "$UNAME" in
+    *Darwin*)           PLATFORM="macos"   ;;
+    *ndroid*)           PLATFORM="android" ;; # Termux
+    *MINGW* | *MSYS*)  PLATFORM="windows" ;; # Git Bash / MINGW
+    *WSL2* | *WSL*)    PLATFORM="wsl"     ;;
+    *ish*)              PLATFORM="ios"     ;; # iSH
+    *)                  PLATFORM="linux"   ;;
+esac
+info "Detected platform: $PLATFORM"
+
+# Resolve MPV config dir per platform
+case "$PLATFORM" in
+    macos)
+        MPV_CONF_DIR="$HOME/.config/mpv"
+        ;;
+    android)
+        MPV_CONF_DIR="$HOME/.config/mpv"
+        ;;
+    windows)
+        # MINGW / Git Bash
+        MPV_CONF_DIR="${APPDATA:-$HOME/AppData/Roaming}/mpv"
+        ;;
+    wsl)
+        # WSL running
+        WIN_APPDATA="$(cmd.exe /c "echo %APPDATA%" 2>/dev/null | tr -d '\r')"
+        if [ -n "$WIN_APPDATA" ]; then
+            MPV_CONF_DIR="$(wslpath "$WIN_APPDATA")/mpv"
+        else
+            MPV_CONF_DIR="$HOME/.config/mpv"
+            warn "Could not resolve Windows APPDATA, falling back to $MPV_CONF_DIR"
+        fi
+        ;;
+    ios)
+        # iSH uses VLC skip mpv config
+        MPV_CONF_DIR=""
+        ;;
+    *)
+        MPV_CONF_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/mpv"
+        ;;
+esac
+
+# Resolve PATH install dir per platform
+case "$PLATFORM" in
+    android)
+        BIN_DIR="$PREFIX/bin"
+        ;;
+    ios)
+        BIN_DIR="/usr/local/bin"
+        ;;
+    windows | wsl)
+        BIN_DIR="$HOME/.local/bin"
+        ;;
+    *)
+        # Prefer ~/.local/bin (no sudo), fall back to /usr/local/bin
+        BIN_DIR="$HOME/.local/bin"
+        ;;
+esac
+
+# Ensure BIN_DIR exists and is on PATH
+mkdir -p "$BIN_DIR"
+case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;   #already on PATH
+    *)
+        warn "$BIN_DIR is not on your PATH."
+        warn "Add this to your shell rc file (~/.bashrc / ~/.zshrc / ~/.profile):"
+        warn "  export PATH=\"\$PATH:$BIN_DIR\""
+        # Add it for this session so the rest of setup works
+        export PATH="$PATH:$BIN_DIR"
+        ;;
+esac
+
+# Check for git
+command -v git >/dev/null 2>&1 || die "git is required but not found. Please install git first."
+
+# Clone or update ani-skip
+ANISKIP_REPO="https://github.com/synacktraa/ani-skip"
+ANISKIP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/ani-skip"
+
+if [ -d "$ANISKIP_DIR/.git" ]; then
+    info "ani-skip already cloned, pulling latest..."
+    git -C "$ANISKIP_DIR" pull --ff-only 2>/dev/null && success "ani-skip updated" || warn "ani-skip update skipped (local changes?)"
+else
+    info "Cloning ani-skip into $ANISKIP_DIR ..."
+    git clone --depth=1 "$ANISKIP_REPO" "$ANISKIP_DIR" || die "Failed to clone ani-skip"
+    success "ani-skip cloned"
+fi
+
+# Install ani-skip binary
+ANISKIP_BIN="$ANISKIP_DIR/ani-skip"
+[ -f "$ANISKIP_BIN" ] || die "ani-skip binary not found at $ANISKIP_BIN — repo structure may have changed"
+chmod +x "$ANISKIP_BIN"
+
+# Symlink into BIN_DIR (overwrite if stale)
+ln -sf "$ANISKIP_BIN" "$BIN_DIR/ani-skip"
+success "ani-skip linked to $BIN_DIR/ani-skip"
+
+# Verify it's callable
+if command -v ani-skip >/dev/null 2>&1; then
+    success "ani-skip is available in PATH"
+else
+    warn "ani-skip not found in PATH yet — you may need to restart your shell or source your rc file"
+fi
+
+# Write aniskip.lua
+if [ -z "$MPV_CONF_DIR" ]; then
+    warn "Platform '$PLATFORM' does not use mpv — skipping aniskip.lua install"
+else
+    SCRIPTS_DIR="$MPV_CONF_DIR/scripts"
+    mkdir -p "$SCRIPTS_DIR"
+    LUA_PATH="$SCRIPTS_DIR/aniskip.lua"
+
+    info "Writing aniskip.lua to $LUA_PATH ..."
+    cat > "$LUA_PATH" << 'EOF'
+-- aniskip.lua — auto-skip OP/ED via ani-skip timestamps
+-- Reads --script-opts=skip-op_start=N,skip-op_end=N,skip-ed_start=N,skip-ed_end=N
+-- passed by ani-cli when launched with --skip flag
+local mp  = require('mp')
+local msg = require('mp.msg')
+
+local options = { op_start=0, op_end=0, ed_start=0, ed_end=0 }
+require('mp.options').read_options(options, 'skip')
+
+msg.info(string.format(
+    "aniskip loaded: op=[%s,%s] ed=[%s,%s]",
+    options.op_start, options.op_end,
+    options.ed_start, options.ed_end
+))
+
+local function skip_segment(_, time)
+    if not time then return end
+    if options.op_end > 0
+        and time >= options.op_start
+        and time <  options.op_end then
+        msg.info("Skipping OP -> " .. options.op_end)
+        mp.set_property_number("time-pos", options.op_end)
+        return
+    end
+    if options.ed_end > 0
+        and time >= options.ed_start
+        and time <  options.ed_end then
+        msg.info("Skipping ED -> " .. options.ed_end)
+        mp.set_property_number("time-pos", options.ed_end)
+    end
+end
+
+mp.observe_property("time-pos", "number", skip_segment)
+EOF
+
+    success "aniskip.lua written to $LUA_PATH"
+fi
+
+# Verify ani-skip works
+info "Testing ani-skip with a known title (Cowboy Bebop ep 1)..."
+TEST_OUT="$(ani-skip -q "Cowboy Bebop" -e 1 2>/dev/null || true)"
+if printf "%s" "$TEST_OUT" | grep -q "skip-op_start"; then
+    success "ani-skip test passed: $TEST_OUT"
+else
+    warn "ani-skip test returned no timestamps — network may be unavailable, or title not in DB"
+    warn "This is non-fatal; skipping will work for titles that have skip data"
+fi
+
+# Done
+printf "\n"
+success "Setup complete!"
+printf "  ${C_CYAN}ani-skip${C_RESET}    → $BIN_DIR/ani-skip\n"
+[ -n "$MPV_CONF_DIR" ] && \
+printf "  ${C_CYAN}aniskip.lua${C_RESET} → $MPV_CONF_DIR/scripts/aniskip.lua\n"
+printf "\n"
+info "You can now run: ${C_GREEN}./ani-cli --skip \"anime name\"${C_RESET}"
+info "Or let ani-cli ask you interactively when you search."


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description
SOME INTROS ARE TOO GOOD TO SKIP MEHN !!!
Added an interactive **Skip Intro? (Y/N)** prompt after anime selection, 

For users who don't have ani-skip configured, a `setup.sh` script is 
included that automatically:
- Clones [ani-skip](https://github.com/synacktraa/ani-skip) and links 
  the binary to PATH
- Writes aniskip.lua to the correct mpv scripts directory
- Works across Linux, macOS, Termux (Android), WSL2, MINGW, and iSH (iOS)

The setup runs once on first ./ani-cli launch via a marker file — no 
manual configuration needed.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text

https://github.com/user-attachments/assets/6aa460b6-892e-49a4-8dea-838b73e21894

