### PR TITLE
feat: add support for selecting all episodes in episode selection

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.11.0"
+version_number="4.12.0"
 
 # UI
 
@@ -70,6 +70,8 @@ help_info() {
         Show this help message and exit
       -e, --episode, -r, --range
         Specify the number of episodes to watch
+      -a, --all
+        Select all of the episodes
       --dub
         Play dubbed version
       --rofi
@@ -468,6 +470,7 @@ while [ $# -gt 0 ]; do
             ep_no="$2"
             shift
             ;;
+        -a | --all) ep_no="All" ;;
         --dub) mode="dub" ;;
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 && no_detach=1 ;;
@@ -537,7 +540,20 @@ case "$search" in
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
         ep_list=$(episodes_list "$id")
-        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+        if [[ -z "$ep_no" ]]; then
+            ep_count=$(printf "%s\n" "$ep_list" | grep -c .)
+            if [ "$ep_count" -gt 1 ]; then
+                ep_no=$(printf "All\n%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+            else
+                ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
+            fi
+        fi
+
+        if [ "$ep_no" = "All" ]; then
+            first_ep=$(printf "%s" "$ep_list" | head -n1)
+            last_ep=$(printf "%s" "$ep_list" | tail -n1)
+            ep_no="$first_ep-$last_ep"
+        fi
         [ -z "$ep_no" ] && exit 1
         ;;
 esac


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Documentation update

## Description

i got an issue when downloading all episodes for "hajime no ippo" series. I didn't know the episode count of it. so i made an option for selecting all of the episodes of an anime.

### Usage:
```bash
ani-cli -d "hajime no ippo" --all
```
or
```bash
ani-cli -d "hajime no ippo" -a
```

## Checklist

- [X] any anime playing
- [x] bumped version
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] `-s` syncplay works
- [X] `-q` quality works
- [X] `-v` vlc works
- [X] `-e` (select episode) aka `-r` (range selection) works
- [X] `-S` select index works
- [X] `--skip` ani-skip works
- [X] `--skip-title` ani-skip title argument works
- [X] `--no-detach` no detach works
- [X] `--exit-after-play` auto exit after playing works
- [X] `--nextep-countdown` countdown to next ep works
- [X] `--dub` and regular (sub) mode both work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

## Additional Testcases

- Hajime no Ippo: `-d` (download) all episodes - success
