### PR TITLE
fix: use ani-skip's AllAnime source for skip time lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 
 **Warning:** For now, ani-skip does **not** seem to work under Windows.
 
-**Note:** It may be, that ani-skip won't know the anime you're trying to watch. Try using the `--skip-title <title>` command line argument. (It uses the [aniskip API](https://github.com/lexesjan/typescript-aniskip-extension/tree/main/src/api/aniskip-http-client) and you can contribute missing anime or ask for including it in the database on their [discord server](https://discord.com/invite/UqT55CbrbE)).
+**Note:** ani-skip now resolves MAL IDs through AllAnime directly, so title mismatches (e.g. "1P" for One Piece) are no longer an issue. Requires [ani-skip](https://github.com/synacktraa/ani-skip) >= v1.1.0. If an anime's skip times are missing from the database, you can contribute or request its inclusion on the [aniskip discord server](https://discord.com/invite/UqT55CbrbE).
 
 ## FAQ
 <details>

--- a/ani-cli
+++ b/ani-cli
@@ -325,7 +325,7 @@ download() {
 
 play_episode() {
     [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
-    [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
+    [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -i "$mal_id" -e "$ep_no")"
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
     case "$player_function" in
@@ -564,7 +564,7 @@ case "$search" in
         [ -z "$ep_no" ] && exit 1
         ;;
 esac
-[ "$skip_intro" = 1 ] && mal_id="$(ani-skip -q "${skip_title:-${title}}")"
+[ "$skip_intro" = 1 ] && mal_id="$(ani-skip -i "$id" -s allanime)"
 
 # moves the cursor up one line and clears that line
 tput cuu1 && tput el

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.13.0"
+version_number="4.14.6"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -505,7 +505,6 @@ exit_after_play="${ANI_CLI_EXIT_AFTER_PLAY:-0}"
 use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 external_menu_normal_window="${ANI_CLI_EXTERNAL_MENU_NORMAL_WINDOW:-0}"
 skip_intro="${ANI_CLI_SKIP_INTRO:-0}"
-skip_title="${ANI_CLI_SKIP_TITLE:-}"
 [ -t 0 ] || (command -v dmenu && use_external_menu=2)
 [ -t 0 ] || (command -v rofi && use_external_menu=1)
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
@@ -575,11 +574,7 @@ while [ $# -gt 0 ]; do
         --rofi) use_external_menu=1 ;;
         --dmenu) use_external_menu=2 ;;
         --skip) skip_intro=1 ;;
-        --skip-title)
-            [ $# -lt 2 ] && die "missing argument!"
-            skip_title="$2"
-            shift
-            ;;
+        --skip-title) shift ;;
         -N | --nextep-countdown) search=nextep ;;
         -U | --update)
             branch="${2:-$branch}"

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.6"
+version_number="4.14.7"
 
 # UI
 


### PR DESCRIPTION
Related issue https://github.com/pystardust/ani-cli/issues/1531

### Problem

ani-skip's `--query` flag resolves anime titles through MAL's prefix search API, which frequently fails when given AllAnime display names. For example, ani-cli passes "1P" (AllAnime's name for One Piece) to ani-skip, but MAL has no idea what "1P" is. Same issue with season-specific titles that don't match MAL's naming.

### Fix

ani-skip v1.1.0 added AllAnime as a source (`-s allanime`) and a direct ID flag (`-i`). Since ani-cli already has the AllAnime `_id` in `$id`, we can pass it directly instead of trying to fuzzy-match titles through MAL.

Two lines changed:

**MAL ID resolution (line 544):**
```diff
-[ "$skip_intro" = 1 ] && mal_id="$(ani-skip -q "${skip_title:-${title}}")"
+[ "$skip_intro" = 1 ] && mal_id="$(ani-skip -i "$id" -s allanime)"
```
Passes the AllAnime `_id` directly to ani-skip, which resolves it to a MAL ID via AllAnime's API. No more title fuzzy-matching.

**Skip time fetch (line 310):**
```diff
-[ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
+[ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -i "$mal_id" -e "$ep_no")"
```
Uses `-i` instead of `-q` since `$mal_id` is a numeric ID. `-q` still works for this case but is being soft-deprecated for ID inputs in ani-skip.

### Note on `--skip-title`

`--skip-title` / `ANI_CLI_SKIP_TITLE` is now unused since we no longer pass titles to ani-skip. Left it in for now to avoid breaking anyone's configs — can be removed in a future cleanup if you prefer.

### Requires

ani-skip >= v1.1.0 (https://github.com/synacktraa/ani-skip/releases/tag/1.1.0)