### PR TITLE
fix: allanime openssl aes-256-ctr decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ pkg install termux-am
 
 For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note that these cannot be checked from termux so a warning is generated when checking dependencies.
 
+**Note:** The `openssl` CLI utility is in the `openssl-tool` package on Termux, not `openssl`. Install it with:
+```sh
+pkg install openssl-tool
+```
+
 </details>
 
 ### Tier 2 Support: Windows, WSL, iOS, Steam Deck, FreeBSD
@@ -507,7 +512,7 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 - yt-dlp - m3u8 Downloader
 - ffmpeg - m3u8 Downloader (fallback)
 - fzf - User interface
-- openssl (for decrypting encrypted video sources)
+- openssl (for decrypting encrypted video sources; on Termux, the CLI is in the `openssl-tool` package)
 - ani-skip (optional, for auto-skipping anime intros)
 - patch - Self updating
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,8 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 - yt-dlp - m3u8 Downloader
 - ffmpeg - m3u8 Downloader (fallback)
 - fzf - User interface
-- ani-skip (optional)
+- openssl (for decrypting encrypted video sources)
+- ani-skip (optional, for auto-skipping anime intros)
 - patch - Self updating
 
 ### Ani-Skip

--- a/ani-cli
+++ b/ani-cli
@@ -212,7 +212,7 @@ decode_tobeparsed() {
     blob="$1"
     tmp="$(mktemp)"
     ct="$(mktemp)"
-    printf '%s' "$blob" | openssl enc -d -base64 -A >"$tmp"
+    printf '%s' "$blob" | base64 -d >"$tmp"
     len="$(wc -c <"$tmp" | tr -d ' ')"
     iv="$(dd if="$tmp" bs=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
     ct_len=$((len - 28))

--- a/ani-cli
+++ b/ani-cli
@@ -506,7 +506,11 @@ done
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
-dep_ch "curl" "sed" "grep" "openssl" || true
+dep_ch "curl" "sed" "grep" || true
+case "$(uname -o 2>/dev/null)" in
+    *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
+    *) dep_ch "openssl" || true ;;
+esac
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 dep_ch "fzf" || true
 case "$player_function" in

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.11.0"
+version_number="4.12.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -511,7 +511,7 @@ done
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
-dep_ch "curl" "sed" "grep" || true
+dep_ch "curl" "sed" "grep" "openssl" || true
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 dep_ch "fzf" || true
 case "$player_function" in

--- a/ani-cli
+++ b/ani-cli
@@ -208,13 +208,35 @@ select_quality() {
     episode=$(printf "%s" "$result" | cut -d'>' -f2)
 }
 
+decode_tobeparsed() {
+    blob="$1"
+    tmp="$(mktemp)"
+    ct="$(mktemp)"
+    key="$(printf '%s' 'SimtVuagFbGR2K7P' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
+    printf '%s' "$blob" | openssl enc -d -base64 -A >"$tmp"
+    len="$(wc -c <"$tmp" | tr -d ' ')"
+    iv="$(dd if="$tmp" bs=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
+    ct_len=$((len - 28))
+    dd if="$tmp" bs=1 skip=12 count="$ct_len" 2>/dev/null >"$ct"
+    ctr="${iv}00000002"
+    plain="$(openssl enc -d -aes-256-ctr -K "$key" -iv "$ctr" -nosalt -nopad <"$ct" 2>/dev/null)"
+    rm -f "$tmp" "$ct"
+    printf '%s' "$plain" | tr '{}' '\n' | sed -nE 's|.*"sourceUrl":"--([^"]*)".*"sourceName":"([^"]*)".*|\2 :\1|p'
+}
+
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
     # get the embed urls of the selected episode
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    resp=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    api_resp="$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")"
+    if printf "%s" "$api_resp" | grep -q '"tobeparsed"'; then
+        blob="$(printf "%s" "$api_resp" | sed -nE 's|.*"tobeparsed":"([^"]*)".*|\1|p')"
+        resp="$(decode_tobeparsed "$blob")"
+    else
+        resp="$(printf "%s" "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
+    fi
     # generate links into sequential files
     cache_dir="$(mktemp -d)"
     providers="1 2 3 4"

--- a/ani-cli
+++ b/ani-cli
@@ -209,17 +209,12 @@ select_quality() {
 }
 
 decode_tobeparsed() {
-    blob="$1"
     tmp="$(mktemp)"
-    ct="$(mktemp)"
-    printf '%s' "$blob" | base64 -d >"$tmp"
-    len="$(wc -c <"$tmp" | tr -d ' ')"
+    printf '%s' "$1" | base64 -d >"$tmp"
     iv="$(dd if="$tmp" bs=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
-    ct_len=$((len - 28))
-    dd if="$tmp" bs=1 skip=12 count="$ct_len" 2>/dev/null >"$ct"
     ctr="${iv}00000002"
-    plain="$(openssl enc -d -aes-256-ctr -K "$allanime_key" -iv "$ctr" -nosalt -nopad <"$ct" 2>/dev/null)"
-    rm -f "$tmp" "$ct"
+    plain="$(dd if="$tmp" bs=1 skip=12 2>/dev/null | openssl enc -d -aes-256-ctr -K "$allanime_key" -iv "$ctr" -nosalt -nopad 2>/dev/null)"
+    rm -f "$tmp"
     printf '%s' "$plain" | tr '{}' '\n' | sed -nE 's|.*"sourceUrl":"--([^"]*)".*"sourceName":"([^"]*)".*|\2 :\1|p'
 }
 

--- a/ani-cli
+++ b/ani-cli
@@ -212,14 +212,13 @@ decode_tobeparsed() {
     blob="$1"
     tmp="$(mktemp)"
     ct="$(mktemp)"
-    key="$(printf '%s' 'SimtVuagFbGR2K7P' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
     printf '%s' "$blob" | openssl enc -d -base64 -A >"$tmp"
     len="$(wc -c <"$tmp" | tr -d ' ')"
     iv="$(dd if="$tmp" bs=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
     ct_len=$((len - 28))
     dd if="$tmp" bs=1 skip=12 count="$ct_len" 2>/dev/null >"$ct"
     ctr="${iv}00000002"
-    plain="$(openssl enc -d -aes-256-ctr -K "$key" -iv "$ctr" -nosalt -nopad <"$ct" 2>/dev/null)"
+    plain="$(openssl enc -d -aes-256-ctr -K "$allanime_key" -iv "$ctr" -nosalt -nopad <"$ct" 2>/dev/null)"
     rm -f "$tmp" "$ct"
     printf '%s' "$plain" | tr '{}' '\n' | sed -nE 's|.*"sourceUrl":"--([^"]*)".*"sourceName":"([^"]*)".*|\2 :\1|p'
 }
@@ -409,6 +408,7 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefo
 allanime_refr="https://allmanga.to"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
+allanime_key="$(printf '%s' 'SimtVuagFbGR2K7P' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
