### PR TITLE
Fix AllAnime API + add seen history + debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/ani-cli
+++ b/ani-cli
@@ -40,6 +40,22 @@ die() {
     exit 1
 }
 
+curl_or_die() {
+    # Usage: curl_or_die <desc> <curl args...>
+    desc="$1"
+    shift
+
+    err="$(mktemp -t ani-cli.curl.XXXXXX)"
+    body="$(curl -sS "$@" 2>"$err")"
+    rc="$?"
+    curl_err="$(cat "$err" 2>/dev/null || true)"
+    rm -f "$err" >/dev/null 2>&1 || true
+
+    [ "$rc" -eq 0 ] || die "$desc failed (curl rc=$rc): ${curl_err:-unknown error}"
+    [ -n "$body" ] || die "$desc failed: empty response"
+    printf "%s" "$body"
+}
+
 help_info() {
     printf "
     Usage:
@@ -218,7 +234,7 @@ get_episode_url() {
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    resp_raw=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")
+    resp_raw=$(curl_or_die "episode API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
     resp=$(printf "%s" "$resp_raw" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
@@ -244,7 +260,7 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    resp_raw=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent")
+    resp_raw=$(curl_or_die "search API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent")
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
     printf "%s" "$resp_raw" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
@@ -269,7 +285,7 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    resp_raw=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent")
+    resp_raw=$(curl_or_die "episodes API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent")
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
     printf "%s" "$resp_raw" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
 |g; s|"||g' | sort -n -k 1

--- a/ani-cli
+++ b/ani-cli
@@ -82,6 +82,10 @@ help_info() {
         Don't detach the player (useful for in-terminal playback, mpv only)
       --exit-after-play
         Exit the player, and return the player exit code (useful for non interactive scenarios, mpv only)
+      --history-on-exit
+        When detaching the player, update history only after the player exits (more accurate)
+      --seen
+        Browse previously seen episodes from a per-episode log
       --skip-title <title>
         Use given title as ani-skip query
       -N, --nextep-countdown
@@ -214,7 +218,9 @@ get_episode_url() {
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    resp=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
+    resp_raw=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")
+    is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
+    resp=$(printf "%s" "$resp_raw" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     cache_dir="$(mktemp -d)"
     providers="1 2 3 4"
@@ -238,7 +244,9 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
+    resp_raw=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent")
+    is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
+    printf "%s" "$resp_raw" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
 }
 
@@ -261,11 +269,20 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
+    resp_raw=$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent")
+    is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
+    printf "%s" "$resp_raw" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
 |g; s|"||g' | sort -n -k 1
 }
 
 # PLAYING
+
+is_cloudflare_challenge() {
+    case "$1" in
+        *"Just a moment..."* | *"Enable JavaScript and cookies to continue"* | *"cloudflare"* | *"cf-"* ) return 0 ;;
+    esac
+    return 1
+}
 
 process_hist_entry() {
     ep_list=$(episodes_list "$id")
@@ -275,7 +292,28 @@ process_hist_entry() {
     [ -n "$ep_no" ] && printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
 }
 
+hist_lock_acquire() {
+    lockdir="$hist_dir/.ani-cli.lock"
+    while ! mkdir "$lockdir" 2>/dev/null; do
+        sleep 0.05
+    done
+    printf "%s" "$lockdir"
+}
+
+hist_lock_release() {
+    rmdir "$1" 2>/dev/null || true
+}
+
+append_seen() {
+    ts="$(date "+%Y-%m-%dT%H:%M:%S%z")"
+    safe_title="$(printf "%s" "$title" | tr '\t\n\r' ' ' | sed 's/[[:space:]][[:space:]]*/ /g')"
+    lockdir="$(hist_lock_acquire)"
+    printf "%s\t%s\t%s\t%s\n" "$ts" "$id" "$ep_no" "$safe_title" >>"$seenfile"
+    hist_lock_release "$lockdir"
+}
+
 update_history() {
+    lockdir="$(hist_lock_acquire)"
     if grep -q -- "$id" "$histfile"; then
         sed -E "s|^[^	]+	${id}	[^	]+$|${ep_no}	${id}	${title}|" "$histfile" >"${histfile}.new"
     else
@@ -283,6 +321,12 @@ update_history() {
         printf "%s\t%s\t%s\n" "$ep_no" "$id" "$title" >>"${histfile}.new"
     fi
     mv "${histfile}.new" "$histfile"
+    hist_lock_release "$lockdir"
+}
+
+mark_seen() {
+    update_history
+    append_seen
 }
 
 download() {
@@ -317,11 +361,11 @@ play_episode() {
             ;;
         mpv*)
             if [ "$no_detach" = 0 ]; then
-                nohup $player_function $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 &
+                nohup $player_function $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & player_pid=$!
             else
                 $player_function $skip_flag $subs_flag $refr_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
-                [ "$exit_after_play" = 1 ] && [ -z "$range" ] && exit "$mpv_exitcode"
+                [ "$exit_after_play" = 1 ] && [ -z "$range" ] && { mark_seen; exit "$mpv_exitcode"; }
             fi
             ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
@@ -331,25 +375,30 @@ play_episode() {
             [ -n "$refr_flag" ] && refr_flag="--mpv-${refr_flag#--}"
             if pgrep -f "IINA" >/dev/null 2>&1; then
                 # omit --keep-running when an IINA instance exists to prevent hanging
-                nohup $player_function --no-stdin --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+                nohup $player_function --no-stdin --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & player_pid=$!
             else
-                nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+                nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & player_pid=$!
             fi
             ;;
-        flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
-        vlc*) nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
-        *yncpla*) nohup $player_function "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
+        flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & player_pid=$! ;;
+        vlc*) nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & player_pid=$! ;;
+        *yncpla*) nohup $player_function "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 & player_pid=$! ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" "$subtitle" ;;
-        catt) nohup catt cast "$episode" -s "$subtitle" >/dev/null 2>&1 & ;;
+        catt) nohup catt cast "$episode" -s "$subtitle" >/dev/null 2>&1 & player_pid=$! ;;
         iSH)
             printf "\e]8;;vlc://%s\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode"
             sleep 5
             ;;
-        *) nohup $player_function "$episode" >/dev/null 2>&1 & ;;
+        *) nohup $player_function "$episode" >/dev/null 2>&1 & player_pid=$! ;;
     esac
     replay="$episode"
     unset episode
-    update_history
+    if [ "$history_on_exit" = 1 ] && [ -n "${player_pid:-}" ] && [ "$no_detach" = 0 ]; then
+        ( wait "$player_pid"; mark_seen ) >/dev/null 2>&1 &
+    else
+        mark_seen
+    fi
+    unset player_pid
     [ "$use_external_menu" = "1" ] && wait
     [ "$use_external_menu" = "2" ] && wait
 }
@@ -384,9 +433,9 @@ play() {
 
 # setup
 agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
-allanime_refr="https://allmanga.to"
-allanime_base="allanime.day"
-allanime_api="https://api.${allanime_base}"
+allanime_refr="${ANI_CLI_REFERER:-https://allmanga.to}"
+allanime_base="${ANI_CLI_ALLANIME_BASE:-allanime.day}"
+allanime_api="${ANI_CLI_API_URL:-https://api.${allanime_base}}"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"
@@ -401,6 +450,7 @@ esac
 
 no_detach="${ANI_CLI_NO_DETACH:-0}"
 exit_after_play="${ANI_CLI_EXIT_AFTER_PLAY:-0}"
+history_on_exit="${ANI_CLI_HISTORY_ON_EXIT:-0}"
 use_external_menu="${ANI_CLI_EXTERNAL_MENU:-0}"
 external_menu_normal_window="${ANI_CLI_EXTERNAL_MENU_NORMAL_WINDOW:-0}"
 skip_intro="${ANI_CLI_SKIP_INTRO:-0}"
@@ -411,7 +461,9 @@ skip_title="$ANI_CLI_SKIP_TITLE"
 hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
+seenfile="$hist_dir/ani-seen"
 [ ! -f "$histfile" ] && : >"$histfile"
+[ ! -f "$seenfile" ] && : >"$seenfile"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
 
 while [ $# -gt 0 ]; do
@@ -445,12 +497,14 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -c | --continue) search=history ;;
+        --seen) search=seen ;;
         -d | --download)
             [ "$player_function" = "iSH" ] && iSH_DownFix="--async-dns=false"
             player_function=download
             ;;
         -D | --delete)
             : >"$histfile"
+            : >"$seenfile"
             exit 0
             ;;
         -l | --logview)
@@ -471,6 +525,7 @@ while [ $# -gt 0 ]; do
         --dub) mode="dub" ;;
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 && no_detach=1 ;;
+        --history-on-exit) history_on_exit=1 ;;
         --rofi) use_external_menu=1 ;;
         --dmenu) use_external_menu=2 ;;
         --skip) skip_intro=1 ;;
@@ -503,6 +558,23 @@ esac
 
 # searching
 case "$search" in
+    seen)
+        [ ! -s "$seenfile" ] && die "No seen history yet!"
+        if command -v tac >/dev/null 2>&1; then
+            seen_src="$(tac "$seenfile")"
+        elif tail -r "$seenfile" >/dev/null 2>&1; then
+            seen_src="$(tail -r "$seenfile")"
+        else
+            seen_src="$(cat "$seenfile")"
+        fi
+        selection=$(printf "%s\n" "$seen_src" | awk -F '\t' '{printf "%s\t%s\t%s\t[%s]\n", $2, $3, $4, $1}' | launcher "$multi_selection_flag" "Select seen: ")
+        id=$(printf "%s" "$selection" | cut -f1)
+        ep_no=$(printf "%s" "$selection" | cut -f2)
+        title=$(printf "%s" "$selection" | cut -f3)
+        [ -z "$id" ] && exit 1
+        allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        ep_list=$(episodes_list "$id")
+        ;;
     history)
         anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
         wait

--- a/ani-cli
+++ b/ani-cli
@@ -567,7 +567,11 @@ case "$search" in
         else
             seen_src="$(cat "$seenfile")"
         fi
-        selection=$(printf "%s\n" "$seen_src" | awk -F '\t' '{printf "%s\t%s\t%s\t[%s]\n", $2, $3, $4, $1}' | launcher "$multi_selection_flag" "Select seen: ")
+        selection=$(
+            printf "%s\n" "$seen_src" |
+                sed -E 's/^([^\t]*)\t([^\t]*)\t([^\t]*)\t(.*)$/\2\t\3\t\4\t[\1]/' |
+                launcher "$multi_selection_flag" "Select seen: "
+        )
         id=$(printf "%s" "$selection" | cut -f1)
         ep_no=$(printf "%s" "$selection" | cut -f2)
         title=$(printf "%s" "$selection" | cut -f3)

--- a/ani-cli
+++ b/ani-cli
@@ -40,6 +40,34 @@ die() {
     exit 1
 }
 
+debug_enabled() {
+    [ "${ANI_CLI_DEBUG:-0}" = "1" ]
+}
+
+debug_dir_init() {
+    if [ -n "${ANI_CLI_DEBUG_DIR:-}" ]; then
+        mkdir -p "$ANI_CLI_DEBUG_DIR" >/dev/null 2>&1 || true
+        return
+    fi
+    ANI_CLI_DEBUG_DIR="${TMPDIR:-/tmp}/ani-cli-debug.$$"
+    mkdir -p "$ANI_CLI_DEBUG_DIR" >/dev/null 2>&1 || true
+}
+
+debug_slug() {
+    printf "%s" "$1" | tr ' ' '_' | tr -cd 'A-Za-z0-9_.-'
+}
+
+debug_save() {
+    # Usage: debug_save <name> <content>
+    name="$1"
+    content="$2"
+    debug_enabled || return 0
+    debug_dir_init
+    file="$ANI_CLI_DEBUG_DIR/$(debug_slug "$name").txt"
+    printf "%s" "$content" >"$file" 2>/dev/null || true
+    return 0
+}
+
 curl_or_die() {
     # Usage: curl_or_die <desc> <curl args...>
     desc="$1"
@@ -55,6 +83,7 @@ curl_or_die() {
 
     [ "$rc" -eq 0 ] || die "$desc failed (curl rc=$rc): ${curl_err:-unknown error}"
     [ -n "$body" ] || die "$desc failed: empty response"
+    debug_save "curl_${desc}" "$body"
     printf "%s" "$body"
 }
 
@@ -252,9 +281,15 @@ get_episode_url() {
     # select the link with matching quality
     links=$(cat "$cache_dir"/* | sort -g -r -s)
     rm -r "$cache_dir"
+    debug_save "episode_links" "$links"
     select_quality "$quality"
     if printf "%s" "$ep_list" | grep -q "^$ep_no$"; then
-        [ -z "$episode" ] && die "Episode is released, but no valid sources!"
+        if [ -z "$episode" ]; then
+            if debug_enabled; then
+                die "Episode is released, but no valid sources! Debug: ${ANI_CLI_DEBUG_DIR:-unset}"
+            fi
+            die "Episode is released, but no valid sources! Re-run with ANI_CLI_DEBUG=1 to capture provider output."
+        fi
     else
         [ -z "$episode" ] && die "Episode not released!"
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -45,11 +45,13 @@ curl_or_die() {
     desc="$1"
     shift
 
-    err="$(mktemp -t ani-cli.curl.XXXXXX)"
-    body="$(curl -sS "$@" 2>"$err")"
+    out="$(mktemp -t ani-cli.curl.out.XXXXXX)"
+    err="$(mktemp -t ani-cli.curl.err.XXXXXX)"
+    curl -sS "$@" >"$out" 2>"$err"
     rc="$?"
+    body="$(cat "$out" 2>/dev/null || true)"
     curl_err="$(cat "$err" 2>/dev/null || true)"
-    rm -f "$err" >/dev/null 2>&1 || true
+    rm -f "$out" "$err" >/dev/null 2>&1 || true
 
     [ "$rc" -eq 0 ] || die "$desc failed (curl rc=$rc): ${curl_err:-unknown error}"
     [ -n "$body" ] || die "$desc failed: empty response"
@@ -234,7 +236,10 @@ get_episode_url() {
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    resp_raw=$(curl_or_die "episode API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")
+    resp_raw_file="$(mktemp -t ani-cli.episode.XXXXXX)"
+    curl_or_die "episode API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent" >"$resp_raw_file"
+    resp_raw="$(cat "$resp_raw_file" 2>/dev/null || true)"
+    rm -f "$resp_raw_file" >/dev/null 2>&1 || true
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
     resp=$(printf "%s" "$resp_raw" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
@@ -260,7 +265,10 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes __typename } }}'
 
-    resp_raw=$(curl_or_die "search API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent")
+    resp_raw_file="$(mktemp -t ani-cli.searchapi.XXXXXX)"
+    curl_or_die "search API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" >"$resp_raw_file"
+    resp_raw="$(cat "$resp_raw_file" 2>/dev/null || true)"
+    rm -f "$resp_raw_file" >/dev/null 2>&1 || true
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
     printf "%s" "$resp_raw" | sed 's|Show|\
 | g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"(.+)\",.*${mode}\":([1-9][^,]*).*|\1	\2 (\3 episodes)|p" | sed 's/\\"//g'
@@ -285,7 +293,10 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    resp_raw=$(curl_or_die "episodes API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent")
+    resp_raw_file="$(mktemp -t ani-cli.episodesapi.XXXXXX)"
+    curl_or_die "episodes API request" -e "$allanime_refr" -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" >"$resp_raw_file"
+    resp_raw="$(cat "$resp_raw_file" 2>/dev/null || true)"
+    rm -f "$resp_raw_file" >/dev/null 2>&1 || true
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
     printf "%s" "$resp_raw" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
 |g; s|"||g' | sort -n -k 1
@@ -617,7 +628,13 @@ case "$search" in
         title=$(printf "%s" "$selection" | cut -f3)
         [ -z "$id" ] && exit 1
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
-        ep_list=$(episodes_list "$id")
+        ep_list_file="$(mktemp -t ani-cli.episodes.XXXXXX)"
+        if ! episodes_list "$id" >"$ep_list_file"; then
+            rm -f "$ep_list_file" >/dev/null 2>&1 || true
+            exit 1
+        fi
+        ep_list="$(cat "$ep_list_file" 2>/dev/null || true)"
+        rm -f "$ep_list_file" >/dev/null 2>&1 || true
         ;;
     history)
         anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
@@ -627,7 +644,13 @@ case "$search" in
         [ -z "${index##*[!0-9]*}" ] || id=$(printf "%s" "$anime_list" | sed -n "${index}p" | cut -f1)
         [ -z "$id" ] && exit 1
         title=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed 's/ - episode.*//')
-        ep_list=$(episodes_list "$id")
+        ep_list_file="$(mktemp -t ani-cli.episodes.XXXXXX)"
+        if ! episodes_list "$id" >"$ep_list_file"; then
+            rm -f "$ep_list_file" >/dev/null 2>&1 || true
+            exit 1
+        fi
+        ep_list="$(cat "$ep_list_file" 2>/dev/null || true)"
+        rm -f "$ep_list_file" >/dev/null 2>&1 || true
         ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)$/\1/p')
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ;;
@@ -644,7 +667,13 @@ case "$search" in
         [ "$search" = "nextep" ] && time_until_next_ep "$query"
 
         query=$(printf "%s" "$query" | sed "s| |+|g")
-        anime_list=$(search_anime "$query")
+        anime_list_file="$(mktemp -t ani-cli.search.XXXXXX)"
+        if ! search_anime "$query" >"$anime_list_file"; then
+            rm -f "$anime_list_file" >/dev/null 2>&1 || true
+            exit 1
+        fi
+        anime_list="$(cat "$anime_list_file" 2>/dev/null || true)"
+        rm -f "$anime_list_file" >/dev/null 2>&1 || true
         [ -z "$anime_list" ] && die "No results found!"
         [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
         [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
@@ -652,7 +681,13 @@ case "$search" in
         title=$(printf "%s" "$result" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
-        ep_list=$(episodes_list "$id")
+        ep_list_file="$(mktemp -t ani-cli.episodes.XXXXXX)"
+        if ! episodes_list "$id" >"$ep_list_file"; then
+            rm -f "$ep_list_file" >/dev/null 2>&1 || true
+            exit 1
+        fi
+        ep_list="$(cat "$ep_list_file" 2>/dev/null || true)"
+        rm -f "$ep_list_file" >/dev/null 2>&1 || true
         [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1
         ;;

--- a/ani-cli
+++ b/ani-cli
@@ -279,7 +279,7 @@ episodes_list() {
 
 is_cloudflare_challenge() {
     case "$1" in
-        *"Just a moment..."* | *"Enable JavaScript and cookies to continue"* | *"cloudflare"* | *"cf-"* ) return 0 ;;
+        *"Just a moment..."* | *"Enable JavaScript and cookies to continue"* | *"cloudflare"* | *"cf-"*) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -361,11 +361,15 @@ play_episode() {
             ;;
         mpv*)
             if [ "$no_detach" = 0 ]; then
-                nohup $player_function $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & player_pid=$!
+                nohup $player_function $skip_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 &
+                player_pid=$!
             else
                 $player_function $skip_flag $subs_flag $refr_flag --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
-                [ "$exit_after_play" = 1 ] && [ -z "$range" ] && { mark_seen; exit "$mpv_exitcode"; }
+                [ "$exit_after_play" = 1 ] && [ -z "$range" ] && {
+                    mark_seen
+                    exit "$mpv_exitcode"
+                }
             fi
             ;;
         android_mpv) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n is.xyz.mpv/.MPVActivity >/dev/null 2>&1 & ;;
@@ -375,26 +379,46 @@ play_episode() {
             [ -n "$refr_flag" ] && refr_flag="--mpv-${refr_flag#--}"
             if pgrep -f "IINA" >/dev/null 2>&1; then
                 # omit --keep-running when an IINA instance exists to prevent hanging
-                nohup $player_function --no-stdin --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & player_pid=$!
+                nohup $player_function --no-stdin --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+                player_pid=$!
             else
-                nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & player_pid=$!
+                nohup $player_function --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 &
+                player_pid=$!
             fi
             ;;
-        flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & player_pid=$! ;;
-        vlc*) nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & player_pid=$! ;;
-        *yncpla*) nohup $player_function "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 & player_pid=$! ;;
+        flatpak_mpv)
+            flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 &
+            player_pid=$!
+            ;;
+        vlc*)
+            nohup $player_function --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 &
+            player_pid=$!
+            ;;
+        *yncpla*)
+            nohup $player_function "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 &
+            player_pid=$!
+            ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" "$subtitle" ;;
-        catt) nohup catt cast "$episode" -s "$subtitle" >/dev/null 2>&1 & player_pid=$! ;;
+        catt)
+            nohup catt cast "$episode" -s "$subtitle" >/dev/null 2>&1 &
+            player_pid=$!
+            ;;
         iSH)
             printf "\e]8;;vlc://%s\a~~~~~~~~~~~~~~~~~~~~\n~ Tap to open VLC ~\n~~~~~~~~~~~~~~~~~~~~\e]8;;\a\n" "$episode"
             sleep 5
             ;;
-        *) nohup $player_function "$episode" >/dev/null 2>&1 & player_pid=$! ;;
+        *)
+            nohup $player_function "$episode" >/dev/null 2>&1 &
+            player_pid=$!
+            ;;
     esac
     replay="$episode"
     unset episode
     if [ "$history_on_exit" = 1 ] && [ -n "${player_pid:-}" ] && [ "$no_detach" = 0 ]; then
-        ( wait "$player_pid"; mark_seen ) >/dev/null 2>&1 &
+        (
+            wait "$player_pid"
+            mark_seen
+        ) >/dev/null 2>&1 &
     else
         mark_seen
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -68,6 +68,12 @@ debug_save() {
     return 0
 }
 
+decrypt_tobeparsed() {
+    command -v node >/dev/null 2>&1 || die "tobeparsed decode requires node"
+
+    printf "%s" "$1" | node -e 'const {webcrypto}=require("crypto"); const fs=require("fs"); const input=fs.readFileSync(0,"utf8"); (async()=>{const obj=JSON.parse(input); const tb=obj?.data?.tobeparsed; if(!tb){process.stderr.write("missing tobeparsed\\n"); process.exit(2);} const secret="P7K2RGbFgauVtmiS".split("").reverse().join(""); const keyHash=await webcrypto.subtle.digest("SHA-256", new TextEncoder().encode(secret)); const key=await webcrypto.subtle.importKey("raw", keyHash,{name:"AES-GCM"},false,["decrypt"]); const buf=Buffer.from(tb,"base64"); const iv=buf.subarray(0,12); const cipherTag=buf.subarray(12); const plain=await webcrypto.subtle.decrypt({name:"AES-GCM",iv},key,cipherTag); process.stdout.write(new TextDecoder().decode(plain));})().catch(e=>{process.stderr.write(String(e)+"\\n"); process.exit(1);});' || die "Failed to decrypt tobeparsed payload"
+}
+
 curl_or_die() {
     # Usage: curl_or_die <desc> <curl args...>
     desc="$1"
@@ -270,6 +276,9 @@ get_episode_url() {
     resp_raw="$(cat "$resp_raw_file" 2>/dev/null || true)"
     rm -f "$resp_raw_file" >/dev/null 2>&1 || true
     is_cloudflare_challenge "$resp_raw" && die "Upstream blocked by a Cloudflare challenge. Try a different network, or set ANI_CLI_ALLANIME_BASE / ANI_CLI_API_URL."
+    if printf "%s" "$resp_raw" | grep -q '"tobeparsed"'; then
+        resp_raw="$(decrypt_tobeparsed "$resp_raw")"
+    fi
     resp=$(printf "%s" "$resp_raw" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"--([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')
     # generate links into sequential files
     cache_dir="$(mktemp -d)"

--- a/ani-cli
+++ b/ani-cli
@@ -280,8 +280,8 @@ episodes_list() {
 is_cloudflare_challenge() {
     case "$1" in
         *"Just a moment..."* | *"Enable JavaScript and cookies to continue"* | *"cloudflare"* | *"cf-"* ) return 0 ;;
+        *) return 1 ;;
     esac
-    return 1
 }
 
 process_hist_entry() {

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -67,6 +67,12 @@ Don't detach the player (useful for in-terminal playback, mpv only)
 \fB\--exit-after-play\fR
 Exit the player, and return the player exit code (useful for non interactive scenarios, mpv only)
 .TP
+\fB\--history-on-exit\fR
+When detaching the player, update history only after the player exits (more accurate)
+.TP
+\fB\--seen\fR
+Browse previously seen episodes from a per-episode log
+.TP
 \fB\--skip-title\fR \fI\,<title>\/\fR
 Specify the title to use for ani-skip
 .PP
@@ -113,6 +119,18 @@ Controls if mpv is detached from the main process for playback, which can be use
 .TP
 \fBANI_CLI_SKIP_TITLE\fR
 Overrides the anime title to query for skip times. Can be any string value. Default is empty, resolving to the anime title as given by ani-cli.
+.TP
+\fBANI_CLI_HISTORY_ON_EXIT\fR
+When set to 1, defer history updates until the detached player exits.
+.TP
+\fBANI_CLI_ALLANIME_BASE\fR
+Override the allanime base domain (default: allanime.day).
+.TP
+\fBANI_CLI_API_URL\fR
+Override the API base URL (default: https://api.${ANI_CLI_ALLANIME_BASE}/).
+.TP
+\fBANI_CLI_REFERER\fR
+Override the Referer header (default: https://allmanga.to).
 .PP
 .SH EPISODE SELECTION
 .PP

--- a/tests/selftest.sh
+++ b/tests/selftest.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+repo_dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "$repo_dir"
+
+fail() {
+  printf "FAIL: %s\n" "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing dependency: $1"
+}
+
+need rg
+
+tmp="${TMPDIR:-/tmp}/ani-cli-selftest.$$"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+mkdir -p "$tmp"
+
+export ANI_CLI_HIST_DIR="$tmp/state"
+
+sh -n ./ani-cli || fail "sh -n failed"
+
+./ani-cli -h | rg -n -- '--seen' >/dev/null || fail "help missing --seen"
+./ani-cli -h | rg -n -- '--history-on-exit' >/dev/null || fail "help missing --history-on-exit"
+
+./ani-cli --delete >/dev/null 2>&1 || fail "--delete failed"
+[ -f "$ANI_CLI_HIST_DIR/ani-hsts" ] || fail "histfile missing after --delete"
+[ -f "$ANI_CLI_HIST_DIR/ani-seen" ] || fail "seenfile missing after --delete"
+[ ! -s "$ANI_CLI_HIST_DIR/ani-hsts" ] || fail "histfile not empty after --delete"
+[ ! -s "$ANI_CLI_HIST_DIR/ani-seen" ] || fail "seenfile not empty after --delete"
+
+set +e
+./ani-cli --seen >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "--seen should fail when history is empty"
+
+printf "OK\n"
+


### PR DESCRIPTION
Summary
- Switch AllAnime API calls to JSON POST and fail fast on curl errors.
- Add seen history (`--seen`) and optional `--history-on-exit`.
- Add debug capture artifacts for provider/source failures.
- Handle `tobeparsed` payloads (node-based AES-GCM decode).

Verification
- `tests/selftest.sh`
