### PR TITLE
docs: bump min version to 4.12 for packaging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A cli to browse and watch anime (alone AND with friends). This tool scrapes the 
 <h1 align="center">
 	Showcase
 </h1>
-I'm blue abedee abedai
+
 [ani-cli-demo.webm](https://user-images.githubusercontent.com/44473782/224679247-0856e652-f187-4865-bbcf-5a8e5cf830da.webm)
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A cli to browse and watch anime (alone AND with friends). This tool scrapes the 
 <h1 align="center">
 	Showcase
 </h1>
-
+I'm blue abedee abedai
 [ani-cli-demo.webm](https://user-images.githubusercontent.com/44473782/224679247-0856e652-f187-4865-bbcf-5a8e5cf830da.webm)
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If after this the issue persists then open an issue.
 
 ## Install
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg?minversion=4.0)](https://repology.org/project/ani-cli/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg?minversion=4.12)](https://repology.org/project/ani-cli/versions)
 
 ### Tier 1 Support: Linux, Mac, Android
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If after this the issue persists then open an issue.
 
 ## Install
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg?minversion=4.12)](https://repology.org/project/ani-cli/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ani-cli.svg?minversion=4.14)](https://repology.org/project/ani-cli/versions)
 
 ### Tier 1 Support: Linux, Mac, Android
 


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Documentation update

## Description

the min version in that repology widget is used to indicate that while a version above it may not be latest (green), it still works and has no security issues (light red).
A version below the min version instead turns to a saturated red.
After a long peace of stability, a full outage triggered 4.11 and 4.12.
By bumping this I hope to subtly nudge users and package maintainers to update faster and communicate that state.
This is not urgent.