### PR TITLE
fix: update allanime key and ct_len

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -211,7 +211,7 @@ select_quality() {
 decode_tobeparsed() {
     tmp="$(mktemp)"
     printf '%s' "$1" | base64 -d >"$tmp"
-    file_size="$(wc -c < "$tmp")"
+    file_size="$(wc -c <"$tmp")"
     iv="$(dd if="$tmp" bs=1 skip=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
     ctr="${iv}00000002"
     ct_len=$((file_size - 13 - 16))

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.12.0"
+version_number="4.13.0"
 
 # UI
 
@@ -211,9 +211,11 @@ select_quality() {
 decode_tobeparsed() {
     tmp="$(mktemp)"
     printf '%s' "$1" | base64 -d >"$tmp"
-    iv="$(dd if="$tmp" bs=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
+    file_size="$(wc -c < "$tmp")"
+    iv="$(dd if="$tmp" bs=1 skip=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
     ctr="${iv}00000002"
-    plain="$(dd if="$tmp" bs=1 skip=12 2>/dev/null | openssl enc -d -aes-256-ctr -K "$allanime_key" -iv "$ctr" -nosalt -nopad 2>/dev/null)"
+    ct_len=$((file_size - 13 - 16))
+    plain="$(dd if="$tmp" bs=1 skip=13 count="$ct_len" 2>/dev/null | openssl enc -d -aes-256-ctr -K "$allanime_key" -iv "$ctr" -nosalt -nopad 2>/dev/null)"
     rm -f "$tmp"
     printf '%s' "$plain" | tr '{}' '\n' | sed -nE 's|.*"sourceUrl":"--([^"]*)".*"sourceName":"([^"]*)".*|\2 :\1|p'
 }
@@ -403,7 +405,7 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefo
 allanime_refr="https://allmanga.to"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
-allanime_key="$(printf '%s' 'SimtVuagFbGR2K7P' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
+allanime_key="$(printf '%s' 'Xot36i3lK3:v1' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
