### PR TITLE
feat: Add an method to check the version, and prompt user to update ani-cli.

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -122,20 +122,22 @@ update_script() {
 # compare two versions: returns 1 if v1>v2, 0 if equal, -1 if v1<v2
 #compare at each level
 ver_compare() {
-    v1="$1"
-    v2="$2"
-    awk -v a="$v1" -v b="$v2" 'BEGIN {
-        n1 = split(a, A, ".");
-        n2 = split(b, B, ".");
-        n = (n1>n2)?n1:n2;
-        for(i=1;i<=n;i++){
-            ai = (i in A) ? A[i] : 0;
-            bi = (i in B) ? B[i] : 0;
-            if(ai+0 < bi+0){ print -1; exit }
-            if(ai+0 > bi+0){ print 1; exit }
-        }
-        print 0
-    }'
+  IFS='.' read -r -a A <<< "$1"
+  IFS='.' read -r -a B <<< "$2"
+  n=${#A[@]}
+  (( ${#B[@]} > n )) && n=${#B[@]}
+  for ((i=0; i<n; i++)); do
+    ai=${A[i]:-0}
+    bi=${B[i]:-0}
+    if ((ai < bi)); then
+      echo -1
+      return
+    elif ((ai > bi)); then
+      echo 1
+      return
+    fi
+  done
+  echo 0
 }
 #check for newer version on GitHub; we can disable it by setting ANI_CLI_DISABLE_UPDATE_CHECK=1
 check_remote_version() {

--- a/ani-cli
+++ b/ani-cli
@@ -119,6 +119,37 @@ update_script() {
     exit 0
 }
 
+# compare two versions: returns 1 if v1>v2, 0 if equal, -1 if v1<v2
+#compare at each level
+ver_compare() {
+    v1="$1"
+    v2="$2"
+    awk -v a="$v1" -v b="$v2" 'BEGIN {
+        n1 = split(a, A, ".");
+        n2 = split(b, B, ".");
+        n = (n1>n2)?n1:n2;
+        for(i=1;i<=n;i++){
+            ai = (i in A) ? A[i] : 0;
+            bi = (i in B) ? B[i] : 0;
+            if(ai+0 < bi+0){ print -1; exit }
+            if(ai+0 > bi+0){ print 1; exit }
+        }
+        print 0
+    }'
+}
+#check for newer version on GitHub; we can disable it by setting ANI_CLI_DISABLE_UPDATE_CHECK=1
+check_remote_version() {
+    [ "${ANI_CLI_DISABLE_UPDATE_CHECK:-0}" = "1" ] && return 0
+    rem=$(curl -fs -A "$agent" "https://raw.githubusercontent.com/pystardust/ani-cli/master/ani-cli" 2>/dev/null) || return 0
+    [ -z "$rem" ] && return 0
+    remote_ver=$(printf '%s\n' "$rem" | sed -nE 's/^version_number="([^"]*)"/\1/p' | head -n1)
+    [ -z "$remote_ver" ] && return 0
+    cmp=$(ver_compare "$remote_ver" "$version_number")
+    if [ "$cmp" -eq 1 ]; then
+        printf "\33[2K\r\033[1;33mNew version available: %s (installed: %s). Run %s to update.\033[0m\n" "$remote_ver" "$version_number" "${0##*/} -U" >&2
+    fi
+}
+
 # checks if dependencies are present
 dep_ch() {
     for dep; do
@@ -565,6 +596,7 @@ done
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
+check_remote_version &
 dep_ch "curl" "sed" "grep" || true
 case "$(uname -o 2>/dev/null)" in
     *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;

--- a/ani-cli
+++ b/ani-cli
@@ -122,22 +122,41 @@ update_script() {
 # compare two versions: returns 1 if v1>v2, 0 if equal, -1 if v1<v2
 #compare at each level
 ver_compare() {
-  IFS='.' read -r -a A <<< "$1"
-  IFS='.' read -r -a B <<< "$2"
-  n=${#A[@]}
-  (( ${#B[@]} > n )) && n=${#B[@]}
-  for ((i=0; i<n; i++)); do
-    ai=${A[i]:-0}
-    bi=${B[i]:-0}
-    if ((ai < bi)); then
-      echo -1
-      return
-    elif ((ai > bi)); then
-      echo 1
-      return
-    fi
-  done
-  echo 0
+    v1=$1
+    v2=$2
+    while [ -n "$v1" ] || [ -n "$v2" ]; do
+        case "$v1" in
+            *.*) seg1=${v1%%.*}; v1=${v1#*.} ;;
+            "") seg1=0 ;;
+            *) seg1=$v1; v1=;;
+        esac
+        case "$v2" in
+            *.*) seg2=${v2%%.*}; v2=${v2#*.} ;;
+            "") seg2=0 ;;
+            *) seg2=$v2; v2=;;
+        esac
+        # treat non-numeric segments as 0 (like the original awk ai+0 behavior)
+        case "$seg1" in
+            ''|*[!0-9]*) seg1=0 ;;
+        esac
+        case "$seg2" in
+            ''|*[!0-9]*) seg2=0 ;;
+        esac
+        # strip leading zeros to avoid octal interpretation
+        while [ "${seg1#0}" != "$seg1" ]; do seg1=${seg1#0}; done
+        [ -z "$seg1" ] && seg1=0
+        while [ "${seg2#0}" != "$seg2" ]; do seg2=${seg2#0}; done
+        [ -z "$seg2" ] && seg2=0
+        if [ "$seg1" -lt "$seg2" ]; then
+            printf "%s\n" -1
+            return
+        fi
+        if [ "$seg1" -gt "$seg2" ]; then
+            printf "%s\n" 1
+            return
+        fi
+    done
+    printf "%s\n" 0
 }
 #check for newer version on GitHub; we can disable it by setting ANI_CLI_DISABLE_UPDATE_CHECK=1
 check_remote_version() {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description
helps users against no ep released issues cased due to older version of ani-cli

**Version 4.13.0**
<img width="494" height="406" alt="image" src="https://github.com/user-attachments/assets/4b3f029d-d11c-4bbc-8b64-2f4c942b3458" />

**Version 4.14.0**
<img width="489" height="380" alt="image" src="https://github.com/user-attachments/assets/7847bb78-d5d8-401f-8591-08f4499fadeb" />

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
