### PR TITLE
feat: keep ongoing anime selectable in -c and integrate nextep countdown

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.1"
+version_number="4.14.2"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -348,7 +348,11 @@ process_hist_entry() {
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
     ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
-    [ -n "$ep_no" ] && printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
+    if [ -n "$ep_no" ]; then
+        printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
+    else
+        printf "%s\t%s - episode %s (up to date)\n" "$id" "$title" "$latest_ep"
+    fi
 }
 
 update_history() {
@@ -594,6 +598,9 @@ case "$search" in
         ep_list=$(episodes_list "$id")
         ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)$/\1/p')
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
+        if printf "%s" "$anime_list" | grep "$id" | cut -f2 | grep -q "(up to date)"; then
+            time_until_next_ep "$allanime_title"
+        fi
         ;;
     *)
         if [ "$use_external_menu" = "0" ]; then

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.0"
+version_number="4.14.1"
 
 # UI
 
@@ -348,11 +348,8 @@ process_hist_entry() {
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
     ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
-    if [ -n "$ep_no" ]; then
-        printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
-    else
-        printf "%s\t%s - episode %s (up to date)\n" "$id" "$title" "$latest_ep"
-    fi
+    [ -n "$ep_no" ] && printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
+    [ -n "$ep_no" ] || printf "%s\t%s - episode %s (up to date)\n" "$id" "$title" "$latest_ep"
 }
 
 update_history() {
@@ -598,9 +595,7 @@ case "$search" in
         ep_list=$(episodes_list "$id")
         ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)$/\1/p')
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
-        if printf "%s" "$anime_list" | grep "$id" | cut -f2 | grep -q "(up to date)"; then
-            time_until_next_ep "$allanime_title"
-        fi
+        printf "%s" "$anime_list" | grep "$id" | cut -f2 | grep -q "(up to date)" && time_until_next_ep "$allanime_title"
         ;;
     *)
         if [ "$use_external_menu" = "0" ]; then


### PR DESCRIPTION
# feat: keep ongoing anime selectable in `-c` and integrate nextep countdown

## Type of change

- [ ] Bug fix  
- [x] Feature  
- [ ] Documentation update  

---

## Description

This PR improves the behavior of `-c` (continue watching) for ongoing anime.

### Background

While using `ani-cli -c`, ongoing anime would disappear from the history menu when there was no new episode available. This made it difficult to:

- keep track of currently watched shows  
- reselect an anime to check release status  
- use nextep functionality naturally from history  

This implementation is based on the feature request by **@port19x** (Mar 14), suggesting that ongoing anime should remain selectable and trigger nextep countdown when selected.

---

### What this PR changes

- Keeps anime visible in the `-c` menu even if no new episode exists, marked as `(up to date)`
- Selecting such entries:
  - does **not attempt playback**
  - instead triggers **nextep countdown** via the existing `time_until_next_ep` function
- Normal playback behavior remains unchanged when a next episode exists  

---

### Implementation details

Two minimal, isolated changes:

**1. `process_hist_entry`** — always emits the history entry regardless of whether a next episode exists. When up to date, emits with `latest_ep` and an `(up to date)` marker instead of silently dropping the entry.

**2. History branch** — after anime selection, checks for the `(up to date)` marker and redirects to `time_until_next_ep` before playback is attempted. Exits cleanly.

No new functions, no new dependencies, no refactoring. Only the history flow is touched.

---

### Testing

Tested manually on WSL2 with mpv:

#### Core feature
- `ani-cli -c`
  - anime with next episode → plays normally ✓
  - anime without next episode → shows `(up to date)` in list, triggers nextep countdown when selected ✓
  - finished anime → shows `Status: Finished` and exits cleanly ✓

#### Playback regression
- `ani-cli "detective conan"` → playback unaffected ✓
- `ani-cli "bleach"` → next episode continues normally from history ✓

#### Nextep
- `ani-cli -N "solo leveling"` → returns countdown or finished status ✓

---

### Why this approach

- Diff is 8 lines — minimal and scoped entirely to history flow
- No new dependencies or functions introduced
- Reuses existing `episodes_list` and `time_until_next_ep` logic directly
- Does not touch scrape path, playback, or any other flow
- POSIX compatible

---

### Credits

Shoutout to **@port19x** for the original idea and discussion — this implementation is based on that suggestion 👍

---

## Checklist

- [x] any anime playing  
- [ ] bumped version  
---
- [x] next, prev and replay work  
- [x] `-c` history and continue work  
- [ ] `-d` downloads work  
- [ ] `-s` syncplay works  
- [x] `-q` quality works  
- [ ] `-v` vlc works  
- [x] `-e` (select episode) aka `-r` (range selection) works  
- [x] `-S` select index works  
- [x] `--skip` ani-skip works  
- [x] `--skip-title` ani-skip title argument works  
- [x] `--no-detach` no detach works  
- [x] `--exit-after-play` auto exit after playing works  
- [x] `--nextep-countdown` countdown to next ep works  
- [x] `--dub` and regular (sub) mode both work  
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)  
---
- [ ] `-h` help info is up to date  
- [ ] Readme is up to date  
- [ ] Man page is up to date  

---

## Additional Testcases

- The safe bet: One Piece  
- Episode 0: Saenai Heroine no Sodatekata ♭  
- Unicode: Saenai Heroine no Sodatekata ♭  
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)  
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e  
- The examples of the help text