### PR TITLE
feat: add support for dubbed/subbed status in history

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.0"
+version_number="4.14.1"
 
 # UI
 
@@ -348,15 +348,15 @@ process_hist_entry() {
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
     ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
-    [ -n "$ep_no" ] && printf "%s\t%s - episode %s\n" "$id" "$title" "$ep_no"
+    [ -n "$ep_no" ] && printf "%s|%s\t%s - episode %s (%s)\n" "$id" "$mode" "$title" "$ep_no" "$mode"
 }
 
 update_history() {
-    if grep -q -- "$id" "$histfile"; then
-        sed -E "s|^[^	]+	${id}	[^	]+$|${ep_no}	${id}	${title}|" "$histfile" >"${histfile}.new"
+    if grep -qE "^[^	]+	${id}	" "$histfile"; then
+        sed -E "s|^[^	]+	${id}	.*$|${ep_no}	${id}	${mode}	${title}|" "$histfile" >"${histfile}.new"
     else
         cp "$histfile" "${histfile}.new"
-        printf "%s\t%s\t%s\n" "$ep_no" "$id" "$title" >>"${histfile}.new"
+        printf "%s\t%s\t%s\t%s\n" "$ep_no" "$id" "$mode" "$title" >>"${histfile}.new"
     fi
     mv "${histfile}.new" "$histfile"
 }
@@ -584,15 +584,23 @@ esac
 # searching
 case "$search" in
     history)
-        anime_list=$(while read -r ep_no id title; do process_hist_entry & done <"$histfile")
+        anime_list=$(while read -r ep_no id hist_mode title; do
+            if [ "$hist_mode" != "sub" ] && [ "$hist_mode" != "dub" ]; then
+                [ -z "$title" ] && title="$hist_mode" || title="$hist_mode $title"
+                hist_mode="sub"
+            fi
+            mode="$hist_mode" process_hist_entry &
+        done <"$histfile")
         wait
         [ -z "$anime_list" ] && die "No unwatched series in history!"
-        [ -z "${index##*[!0-9]*}" ] && id=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: " | cut -f1)
-        [ -z "${index##*[!0-9]*}" ] || id=$(printf "%s" "$anime_list" | sed -n "${index}p" | cut -f1)
-        [ -z "$id" ] && exit 1
-        title=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed 's/ - episode.*//')
+        [ -z "${index##*[!0-9]*}" ] && combined_id=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: " | cut -f1)
+        [ -z "${index##*[!0-9]*}" ] || combined_id=$(printf "%s" "$anime_list" | sed -n "${index}p" | cut -f1)
+        [ -z "$combined_id" ] && exit 1
+        title=$(printf "%s" "$anime_list" | grep "^$combined_id	" | cut -f2 | sed 's/ - episode.*//')
+        id="${combined_id%|*}"
+        mode="${combined_id##*|}"
         ep_list=$(episodes_list "$id")
-        ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)$/\1/p')
+        ep_no=$(printf "%s" "$anime_list" | grep "^$combined_id	" | cut -f2 | sed -nE 's/.*- episode ([^ ]+) .*/\1/p')
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ;;
     *)


### PR DESCRIPTION
# fix: remember dub/sub mode in history and resume correctly with -c

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

This PR fixes an issue where the history mechanism (`ani-cli -c`) would not remember if the user was watching the dub or sub version of an anime, causing it to incorrectly default to `sub` when resuming.

## Background

While using `ani-cli -c`, the CLI reads from the `ani-hsts` file which originally only stored `ep_no`, `id`, and `title`. Because `mode` (sub/dub) wasn't saved to history, continuing an anime would always use the globally set mode (which defaults to `sub`), forcing users to manually add the `--dub` flag every time they wanted to resume a dubbed anime.

## What this PR changes

- `ani-cli` now securely stores the `mode` parameter (sub or dub) as an additional field in the `ani-hsts` history file.
- The `-c` interactive menu properly extracts the tracked mode and seamlessly restores the user's preference when fetching the next episode.
- The history prompt interface has been upgraded to display the tracked mode, showing a clear visual indicator like `(dub)` or `(sub)` alongside the title and episode number.

## Testing

Tested manually:
**Core feature**
- `ani-cli --dub [anime]` → plays dubbed episode and records mode in history ✓
- `ani-cli -c` → correctly shows `[Anime Title] - episode X (dub)` in the menu and successfully fetches/plays dubbed episodes upon selection ✓

**Regression**
- Legacy history entries (from previous versions of ani-cli) load perfectly, reconstruct the title without issues, and default to `sub` ✓
- Normal subbed playback functions correctly and updates history with `sub` ✓

## Checklist

- [x] any anime playing
- [x] bumped version
- [x] next, prev and replay work
- [x] -c history and continue work
- [x] -d downloads work
- [x] -s syncplay works
- [x] -q quality works
- [x] -v vlc works
- [x] -e (select episode) aka -r (range selection) works
- [x] -S select index works
- [x] --skip ani-skip works
- [x] --skip-title ani-skip title argument works
- [x] --no-detach no detach works
- [x] --exit-after-play auto exit after playing works
- [x] --nextep-countdown countdown to next ep works
- [x] --dub and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
- [x] -h help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e
- The examples of the help text
