### PR TITLE
feat: retry search prompt on no results for interactive TTY sessions

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -613,7 +613,7 @@ case "$search" in
             if [ "$use_external_menu" != "0" ] || [ ! -t 0 ]; then
                 die "No results found!"
             fi
-            printf "\33[2K\r\033[1;31mNo results found for \"%s\". Try alternate spellings or press Ctrl+C to exit.\033[0m\n" "$(printf "%s" "$query" | sed 's|+| |g')" >&2
+            printf "\33[2K\r\033[1;31mNo results found for \"%s\". Try alternate spellings or press Ctrl+C to exit.\033[0m\n\n" "$(printf "%s" "$query" | sed 's|+| |g')" >&2
             query=""
             while [ -z "$query" ]; do
                 printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query || exit 1

--- a/ani-cli
+++ b/ani-cli
@@ -609,7 +609,18 @@ case "$search" in
 
         query=$(printf "%s" "$query" | sed "s| |+|g")
         anime_list=$(search_anime "$query")
-        [ -z "$anime_list" ] && die "No results found!"
+        while [ -z "$anime_list" ]; do
+            if [ "$use_external_menu" != "0" ] || [ ! -t 0 ]; then
+                die "No results found!"
+            fi
+            printf "\33[2K\r\033[1;31mNo results found for \"%s\". Try alternate spellings or press Ctrl+C to exit.\033[0m\n" "$(printf "%s" "$query" | sed 's|+| |g')" >&2
+            query=""
+            while [ -z "$query" ]; do
+                printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query || exit 1
+            done
+            query=$(printf "%s" "$query" | sed "s| |+|g")
+            anime_list=$(search_anime "$query")
+        done
         [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
         [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
         [ -z "$result" ] && exit 1


### PR DESCRIPTION
## Type of change

  - [ ] Bug fix
  - [x] Feature
  - [ ] Documentation update

## Related Issue
 Closes #1723 

## Description

  When a user types an incorrect or partial anime title and gets
   no results,
  ani-cli previously exited immediately with `No results
  found!`. This required
  restarting the script to try again.

  This change wraps the no-results exit in a retry loop for
  interactive TTY
  sessions (fzf/plain terminal mode). Instead of dying, ani-cli
  now prints:

    No results found for "onepiec". Try alternate spellings or
  press Ctrl+C to exit.

  and re-prompts the user with `Search anime:` so they can
  correct the typo
  without restarting.

  Non-interactive behavior is fully preserved:
  - Piped/scripted usage (`[ ! -t 0 ]`) still exits with `No
  results found!`
  - `--rofi` and `--dmenu` modes still exit with `No results
  found!`
  - Queries supplied via CLI args that return no results still
  exit (the retry
    kicks in for the follow-up prompt in a TTY)

  Ctrl+C exits at any point. Ctrl+D (EOF) also exits cleanly.

  ## Checklist

  - [ ] any anime playing
  - [ ] bumped version
  ---
  - [ ] next, prev and replay work
  - [ ] `-c` history and continue work
  - [ ] `-d` downloads work
  - [ ] `-s` syncplay works
  - [ ] `-q` quality works
  - [ ] `-v` vlc works
  - [ ] `-e` (select episode) aka `-r` (range selection) works
  - [ ] `-S` select index works
  - [ ] `--skip` ani-skip works
  - [ ] `--skip-title` ani-skip title argument works
  - [ ] `--no-detach` no detach works
  - [ ] `--exit-after-play` auto exit after playing works
  - [ ] `--nextep-countdown` countdown to next ep works
  - [ ] `--dub` and regular (sub) mode both work
  - [ ] all providers return links (not necessarily on a single
  anime, use debug mode to confirm)
  ---
  - [ ] `-h` help info is up to date
  - [ ] Readme is up to date
  - [ ] Man page is up to date

  ## Additional Testcases

  - The safe bet: One Piece
  - Episode 0: Saenai Heroine no Sodatekata ♭
  - Unicode: Saenai Heroine no Sodatekata ♭
  - Non-whole episodes: Tensei shitara slime datta ken (ep.
  24.5, ep. 24.9)
  - All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu
   e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
  - The examples of the help text