### PR TITLE
fix: pass MAL ID to ani-skip via -i instead of deprecated -q

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -383,7 +383,7 @@ download() {
 
 play_episode() {
     [ "$log_episode" = 1 ] && [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && command -v logger >/dev/null && logger -t ani-cli "${allanime_title}${ep_no}"
-    [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -q "$mal_id" -e "$ep_no")"
+    [ "$skip_intro" = 1 ] && skip_flag="$(ani-skip -i "$mal_id" -e "$ep_no")"
     [ -z "$episode" ] && get_episode_url
     # shellcheck disable=SC2086
     case "$player_function" in


### PR DESCRIPTION
## Problem

With current `ani-skip`, intro skipping (`--skip`) fails silently and prints:

```
Warning: passing MAL ID via -q is deprecated, use -i instead
```

`play_episode()` calls `ani-skip -q "$mal_id" -e "$ep_no"`, passing the **numeric MAL ID** to `-q`, which newer ani-skip interprets as a **title search query**. The ID gets searched literally, no match is found, and no skip chapters are returned.

## Fix

Use `-i` (direct MAL ID lookup) for `$mal_id`. The other call site (line 624, `ani-skip -q "${skip_title:-${title}}"`) is a genuine title search and is left unchanged.

## Verification

```
$ ani-skip -q "naruto shippuden"      # -> 1735
$ ani-skip -i 1735 -e 1               # -> --chapters-file=... skip-op/ed timestamps
```

Before fix: `ani-skip -q 1735` searches MAL for the string "1735" -> no result, no skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)