### PR TITLE
fix: Incorrect episode number for Conan and reduce API calls on -c

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -361,13 +361,21 @@ episodes_list() {
 
 # PLAYING
 
-process_hist_entry() {
-    episodes_list "$id"
-    if [ -s "$tmp_dir/ep_list_$id" ]; then
-        ep_list="$(cat "$tmp_dir/ep_list_$id")"
-    else
-        exit 0
+check_hist_entry() {
+    ep_list_file="$tmp_dir/ep_list_$id"
+    if [ ! -s "$ep_list_file" ]; then
+        episodes_list "$id"
+        return 0
     fi
+    # if file age is less than 20 min, skip curl
+    if [ -f "$ep_list_file" ] && [ -n "$(find "$ep_list_file" -mmin +20 2>/dev/null)" ]; then
+        episodes_list "$id"
+    fi
+}
+
+process_hist_entry() {
+    check_hist_entry "$id"
+    ep_list="$(cat "$ep_list_file")"
 
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
@@ -521,7 +529,7 @@ hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
 [ ! -f "$histfile" ] && : >"$histfile"
-tmp_dir="/tmp/ani-cli"
+tmp_dir="$hist_dir/tmp"
 [ ! -d "$tmp_dir" ] && mkdir -p "$tmp_dir"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
 branch="${ANI_CLI_BRANCH:-master}"
@@ -563,6 +571,7 @@ while [ $# -gt 0 ]; do
             ;;
         -D | --delete)
             : >"$histfile"
+            rm -rf "$tmp_dir"
             exit 0
             ;;
         -l | --logview)
@@ -659,7 +668,7 @@ case "$search" in
         title=$(printf "%s" "$result" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
-        episodes_list "$id"
+        check_hist_entry "$id"
         ep_list="$(cat "$tmp_dir/ep_list_$id")"
         [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.1"
+version_number="4.14.2"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -352,11 +352,10 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    # use sort -g for anime such as Meitantei Conan, which has float number episodes
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" \
         --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" |
         sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
-|g; s|"||g' | sort -g -k 1 >"$tmp_dir/ep_list_$id"
+|g; s|"||g' | sort -n -k 1 >"$tmp_dir/ep_list_$id"
 }
 
 # PLAYING

--- a/ani-cli
+++ b/ani-cli
@@ -353,13 +353,18 @@ episodes_list() {
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
-|g; s|"||g' | sort -g -k 1
+|g; s|"||g' | sort -g -k 1 > "$tmp_dir/ep_list_$id"
 }
 
 # PLAYING
 
 process_hist_entry() {
-    ep_list=$(episodes_list "$id")
+    episodes_list "$id"
+    if [ -s "$tmp_dir/ep_list_$id" ]; then
+      ep_list="$(cat "$tmp_dir/ep_list_$id")"
+    else
+      exit 0
+    fi
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
     ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null
@@ -509,6 +514,8 @@ hist_dir="${ANI_CLI_HIST_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/ani-cli}"
 [ ! -d "$hist_dir" ] && mkdir -p "$hist_dir"
 histfile="$hist_dir/ani-hsts"
 [ ! -f "$histfile" ] && : >"$histfile"
+tmp_dir="/tmp/ani-cli"
+[ ! -d "$tmp_dir" ] && mkdir -p "$tmp_dir"
 search="${ANI_CLI_DEFAULT_SOURCE:-scrape}"
 branch="${ANI_CLI_BRANCH:-master}"
 
@@ -619,7 +626,7 @@ case "$search" in
         [ -z "${index##*[!0-9]*}" ] || id=$(printf "%s" "$anime_list" | sed -n "${index}p" | cut -f1)
         [ -z "$id" ] && exit 1
         title=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed 's/ - episode.*//')
-        ep_list=$(episodes_list "$id")
+        ep_list="$(cat "$tmp_dir/ep_list_$id")"
         ep_no=$(printf "%s" "$anime_list" | grep "$id" | cut -f2 | sed -nE 's/.*- episode (.+)$/\1/p')
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         ;;
@@ -644,7 +651,8 @@ case "$search" in
         title=$(printf "%s" "$result" | cut -f2)
         allanime_title="$(printf "%s" "$title" | cut -d'(' -f1 | tr -d '[:punct:]')"
         id=$(printf "%s" "$result" | cut -f1)
-        ep_list=$(episodes_list "$id")
+        episodes_list "$id"
+        ep_list="$(cat "$tmp_dir/ep_list_$id")"
         [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$multi_selection_flag")
         [ -z "$ep_no" ] && exit 1
         ;;

--- a/ani-cli
+++ b/ani-cli
@@ -367,7 +367,8 @@ check_hist_entry() {
         return 0
     fi
     # if file age is less than 20 min, skip curl
-    if [ -f "$ep_list_file" ] && [ -n "$(find "$ep_list_file" -mmin +20 2>/dev/null)" ]; then
+    mtime="$(find "$ep_list_file" -mmin +20 2>/dev/null)"
+    if [ -f "$ep_list_file" ] && [ -n "$mtime" ]; then
         episodes_list "$id"
     fi
 }

--- a/ani-cli
+++ b/ani-cli
@@ -353,7 +353,7 @@ episodes_list() {
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
-|g; s|"||g' | sort -n -k 1
+|g; s|"||g' | sort -g -k 1
 }
 
 # PLAYING

--- a/ani-cli
+++ b/ani-cli
@@ -352,8 +352,11 @@ episodes_list() {
     #shellcheck disable=SC2016
     episodes_list_gql='query ($showId: String!) { show( _id: $showId ) { _id availableEpisodesDetail }}'
 
-    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" | sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
-|g; s|"||g' | sort -g -k 1 > "$tmp_dir/ep_list_$id"
+    # use sort -g for anime such as Meitantei Conan, which has float number episodes
+    curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" \
+        --data "{\"variables\":{\"showId\":\"$*\"},\"query\":\"$episodes_list_gql\"}" -A "$agent" |
+        sed -nE "s|.*$mode\":\[([0-9.\",]*)\].*|\1|p" | sed 's|,|\
+|g; s|"||g' | sort -g -k 1 >"$tmp_dir/ep_list_$id"
 }
 
 # PLAYING
@@ -361,10 +364,11 @@ episodes_list() {
 process_hist_entry() {
     episodes_list "$id"
     if [ -s "$tmp_dir/ep_list_$id" ]; then
-      ep_list="$(cat "$tmp_dir/ep_list_$id")"
+        ep_list="$(cat "$tmp_dir/ep_list_$id")"
     else
-      exit 0
+        exit 0
     fi
+
     latest_ep=$(printf "%s\n" "$ep_list" | tail -n1)
     title=$(printf "%s\n" "$title" | sed "s|[0-9]\+ episodes|${latest_ep} episodes|")
     ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

### Fixing sort -n
The anime "Detecitve Conan' has many episodes. The episodes_list() curl returns some strange numbers such as "348.349", which the current "sort -n" will put after latest ep "1201". This issue will also embed itself into the histfile.

To fix this, it is enough to use `sort -g`.
```
$ echo -e "348.349\n1201\n100\n800" | sort -n
100
800
1201
348.349

$ echo -e "348.349\n1201\n100\n800" | sort -g
100
348.349
800
1201
```

### episodes_list is called many times
In the -c option we first call episodes_list() which processes all anime in histfile, then ep_list will call episodes_list again. We could instead have the episodes_list save the result in tmp so we don't curl again.


## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] not using -c also works 
- [x] `-q` quality works
