### PR TITLE
docs: update broken aria2c download links for Steam Deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install
 
 mkdir ~/.aria2c
-curl -o ~/.aria2c/aria2-1.36.0.tar.bz2 https://github.com/q3aql/aria2-static-builds/releases/download/v1.36.0/aria2-1.36.0-linux-gnu-64bit-build1.tar.bz2
-tar xvf ~/.aria2c/aria2-1.36.0.tar.bz2 -C ~/.aria2c/
-cp ~/.aria2c/aria2-1.36.0-linux-gnu-64bit-build1/aria2c ~/.local/bin/
+curl -o ~/.aria2c/aria2-1.37.0.tar.bz2 https://github.com/dmesg00/aria2-static-builds/releases/download/v1.37.0/aria2-1.37.0-linux-gnu-64bit-build1.tar.bz2
+tar xvf ~/.aria2c/aria2-1.37.0.tar.bz2 -C ~/.aria2c/
+cp ~/.aria2c/aria2-1.37.0-linux-gnu-64bit-build1/aria2c ~/.local/bin/
 chmod +x ~/.local/bin/aria2c
 
 curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o ~/.local/bin/yt-dlp
@@ -345,9 +345,9 @@ press enter("A" button on Steam Deck) on questions
 
 ```sh
 mkdir ~/.aria2c
-curl -o ~/.aria2c/aria2-1.36.0.tar.bz2 https://github.com/q3aql/aria2-static-builds/releases/download/v1.36.0/aria2-1.36.0-linux-gnu-64bit-build1.tar.bz2
-tar xvf ~/.aria2c/aria2-1.36.0.tar.bz2 -C ~/.aria2c/
-cp ~/.aria2c/aria2-1.36.0-linux-gnu-64bit-build1/aria2c ~/.local/bin/
+curl -o ~/.aria2c/aria2-1.37.0.tar.bz2 https://github.com/dmesg00/aria2-static-builds/releases/download/v1.37.0/aria2-1.37.0-linux-gnu-64bit-build1.tar.bz2
+tar xvf ~/.aria2c/aria2-1.37.0.tar.bz2 -C ~/.aria2c/
+cp ~/.aria2c/aria2-1.37.0-linux-gnu-64bit-build1/aria2c ~/.local/bin/
 chmod +x ~/.local/bin/aria2c
 ```
 


### PR DESCRIPTION
## Description

The aria2 static builds repository used in the Steam Deck installation instructions (`q3aql/aria2-static-builds`) has been removed and returns 404, making the installation steps non-functional.

### Changes

- Replaced `q3aql/aria2-static-builds` with [`dmesg00/aria2-static-builds`](https://github.com/dmesg00/aria2-static-builds) (730+ ★, actively maintained, same naming convention)
- Bumped aria2 version from 1.36.0 to 1.37.0 (latest release)
- Updated both the "Copypaste script" and the step-by-step installation sections

### Before (broken)
```
curl -o ~/.aria2c/aria2-1.36.0.tar.bz2 https://github.com/q3aql/aria2-static-builds/releases/download/v1.36.0/aria2-1.36.0-linux-gnu-64bit-build1.tar.bz2
```

### After (working)
```
curl -o ~/.aria2c/aria2-1.37.0.tar.bz2 https://github.com/dmesg00/aria2-static-builds/releases/download/v1.37.0/aria2-1.37.0-linux-gnu-64bit-build1.tar.bz2
```

Fixes #1575