### PR TITLE
Feature/mpv tty

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -59,6 +59,10 @@ help_info() {
         Delete history
       -l, --logview
         Show logs
+    -t, --tty
+        Use tct or drm backend to use it in tty
+        tty 1 = tct (default)
+        tty 2 = drm
       -s, --syncplay
         Use Syncplay to watch with friends
       -S, --select-nth

--- a/ani-cli
+++ b/ani-cli
@@ -427,10 +427,7 @@ play_episode() {
                         tty_flags="--vo=tct --really-quiet"
                         ;;
                     2)
-                        tty_flags="--vo=gpu --gpu-context=drm"
-                        ;;
-                    *)
-                        tty_flags="--vo=tct --realy-quiet"
+                        tty_flags="--vo=drm"
                         ;;
                 esac
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -2,6 +2,9 @@
 
 version_number="4.14.1"
 
+#flags
+use_tty=0
+tty_mode=0
 # UI
 
 external_menu() {
@@ -414,10 +417,23 @@ play_episode() {
             printf "%s\n" "$episode"
             ;;
         mpv*)
+            if [ "$use_tty" = 1 ]; then
+                case "$tty_mode" in
+                    1)
+                        tty_flags="--vo=tct --really-quiet"
+                        ;;
+                    2)
+                        tty_flags="--vo=gpu --gpu-context=drm"
+                        ;;
+                    *)
+                        tty_flags="--vo=tct --realy-quiet"
+                        ;;
+                esac
+            fi
             if [ "$no_detach" = 0 ]; then
-                nohup $player_function $skip_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $refr_flag >/dev/null 2>&1 &
+                nohup $player_function $tty_flags $skip_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $refr_flag >/dev/null 2>&1 &
             else
-                $player_function $skip_flag $refr_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
+                $player_function $tty_flags $skip_flag $refr_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
                 [ "$exit_after_play" = 1 ] && [ -z "$range" ] && exit "$mpv_exitcode"
             fi
@@ -514,6 +530,19 @@ branch="${ANI_CLI_BRANCH:-master}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        -t | --tty)
+            use_tty=1
+            no_detach=1
+            tty_mode=1
+            if [ $# -gt 1 ]; then
+                case "$2" in
+                    1|2)
+                        tty_mode="$2"
+                        shift
+                        ;;
+                esac
+            fi
+            ;;
         -v | --vlc)
             case "$(uname -a | cut -d " " -f 1,3-)" in
                 *ndroid*) player_function="android_vlc" ;;


### PR DESCRIPTION
# PR: TTY Addition

## Type of change
- [X] Feature

## Description

For the all the folks rocking the tty this fork adds the option to enjoy anime in tty using the tct and drm backend. This can be used by using the --tty or -t flag.

## Checklist

- [x] any anime playing
---
- [x] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
---
- [X] `-h` help info is up to date
- [x] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
