### PR TITLE
feat: made the ui a bit better and colourful

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,8 +1,43 @@
 #!/bin/sh
 
-version_number="4.14.1"
+version_number="4.15.0"
 
-# UI
+# themes
+
+c_reset='\033[0m'
+c_dim='\033[2m'
+c_red='\033[1;31m'
+c_green='\033[1;32m'
+c_yellow='\033[1;33m'
+c_blue='\033[1;34m'
+c_magenta='\033[1;35m'
+c_cyan='\033[1;36m'
+
+# ui
+
+print_banner() {
+    printf '\n' >&2
+    printf '%b  ╭───────────────────────────────────╮%b\n' "$c_magenta" "$c_reset" >&2
+    printf '%b  │%b        %b★  A N I - C L I  ★%b        %b│%b\n' "$c_magenta" "$c_reset" "$c_cyan" "$c_reset" "$c_magenta" "$c_reset" >&2
+    printf '%b  │%b  %bStream anime from the terminal%b   %b│%b\n' "$c_magenta" "$c_reset" "$c_dim" "$c_reset" "$c_magenta" "$c_reset" >&2
+    printf '%b  │%b            %b✦ v%s ✦%b            %b│%b\n' "$c_magenta" "$c_reset" "$c_yellow" "$version_number" "$c_reset" "$c_magenta" "$c_reset" >&2
+    printf '%b  ╰───────────────────────────────────╯%b\n' "$c_magenta" "$c_reset" >&2
+    printf '\n' >&2
+}
+
+print_success() {
+    printf '\33[2K\r%b✓ %s%b\n' "$c_green" "$*" "$c_reset" >&2
+}
+
+print_info() {
+    printf '\33[2K\r%b● %b%s%b\n' "$c_cyan" "$c_blue" "$*" "$c_reset" >&2
+}
+
+print_warning() {
+    printf '\33[2K\r%b⚠ %s%b\n' "$c_yellow" "$*" "$c_reset" >&2
+}
+
+# ui
 
 external_menu() {
     [ "$use_external_menu" = "1" ] && rofi "$1" -sort -dmenu -i -width 1500 -p "$2" "$3"
@@ -36,84 +71,70 @@ nth() {
 }
 
 die() {
-    printf "\33[2K\r\033[1;31m%s\033[0m\n" "$*" >&2
+    printf '\33[2K\r%b✗ %s%b\n' "$c_red" "$*" "$c_reset" >&2
     exit 1
 }
 
 help_info() {
-    printf "
-    Usage:
-    %s [options] [query]
-    %s [query] [options]
-    %s [options] [query] [options]
-
-    Options:
-      -c, --continue
-        Continue watching from history
-      -d, --download
-        Download the video instead of playing it
-      -D, --delete
-        Delete history
-      -l, --logview
-        Show logs
-      -s, --syncplay
-        Use Syncplay to watch with friends
-      -S, --select-nth
-        Select nth entry
-      -q, --quality
-        Specify the video quality
-      -v, --vlc
-        Use VLC to play the video
-      -V, --version
-        Show the version of the script
-      -h, --help
-        Show this help message and exit
-      -e, --episode, -r, --range
-        Specify the number of episodes to watch
-      --dub
-        Play dubbed version
-      --rofi
-        Use rofi instead of fzf for the interactive menu
-      --dmenu
-        Use dmenu instead of fzf for the interactive menu
-      --skip
-        Use ani-skip to skip the intro of the episode (mpv only)
-      --no-detach
-        Don't detach the player (useful for in-terminal playback, mpv only)
-      --exit-after-play
-        Exit the player, and return the player exit code (useful for non interactive scenarios, mpv only)
-      --skip-title <title>
-        Use given title as ani-skip query
-      -N, --nextep-countdown
-        Display a countdown to the next episode
-      -U, --update
-        Update the script
-    Some example usages:
-      %s -q 720p banana fish
-      %s --skip --skip-title \"one piece\" -S 2 one piece
-      %s -d -e 2 cyberpunk edgerunners
-      %s --vlc cyberpunk edgerunners -q 1080p -e 4
-      %s blue lock -e 5-6
-      %s -e \"5 6\" blue lock
-    \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
+    print_banner
+    cmd="${0##*/}"
+    printf '%b  USAGE%b\n' "$c_cyan" "$c_reset"
+    printf '%b  ─────────────────────────────────%b\n' "$c_dim" "$c_reset"
+    printf '    %s [options] [query]\n\n' "$cmd"
+    printf '%b  PLAYBACK%b\n' "$c_cyan" "$c_reset"
+    printf '%b  ─────────────────────────────────%b\n' "$c_dim" "$c_reset"
+    printf '    %b-c%b, %b--continue%b            Continue watching from history\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-e%b, %b--episode%b, %b-r%b         Specify episodes to watch\n' "$c_green" "$c_reset" "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-q%b, %b--quality%b              Specify video quality\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-S%b, %b--select-nth%b           Select nth entry\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b--dub%b                       Play dubbed version\n' "$c_green" "$c_reset"
+    printf '    %b--skip%b                      Skip intro (mpv only)\n' "$c_green" "$c_reset"
+    printf '    %b--skip-title%b <title>        Custom title for ani-skip\n' "$c_green" "$c_reset"
+    printf '    %b--no-detach%b                 Don'"'"'t detach player (mpv only)\n' "$c_green" "$c_reset"
+    printf '    %b--exit-after-play%b           Exit after playback (mpv only)\n\n' "$c_green" "$c_reset"
+    printf '%b  PLAYER%b\n' "$c_cyan" "$c_reset"
+    printf '%b  ─────────────────────────────────%b\n' "$c_dim" "$c_reset"
+    printf '    %b-v%b, %b--vlc%b                  Use VLC to play the video\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-s%b, %b--syncplay%b             Watch with friends via Syncplay\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b--rofi%b                      Use rofi for interactive menu\n' "$c_green" "$c_reset"
+    printf '    %b--dmenu%b                     Use dmenu for interactive menu\n\n' "$c_green" "$c_reset"
+    printf '%b  DOWNLOAD%b\n' "$c_cyan" "$c_reset"
+    printf '%b  ─────────────────────────────────%b\n' "$c_dim" "$c_reset"
+    printf '    %b-d%b, %b--download%b             Download instead of playing\n\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '%b  INFO%b\n' "$c_cyan" "$c_reset"
+    printf '%b  ─────────────────────────────────%b\n' "$c_dim" "$c_reset"
+    printf '    %b-h%b, %b--help%b                 Show this help message\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-V%b, %b--version%b              Show version\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-l%b, %b--logview%b              Show logs\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-D%b, %b--delete%b               Delete history\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-N%b, %b--nextep-countdown%b     Next episode countdown\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '    %b-U%b, %b--update%b               Update the script\n\n' "$c_green" "$c_reset" "$c_green" "$c_reset"
+    printf '%b  EXAMPLES%b\n' "$c_cyan" "$c_reset"
+    printf '%b  ─────────────────────────────────%b\n' "$c_dim" "$c_reset"
+    printf '    %b$%b %s -q 720p banana fish\n' "$c_magenta" "$c_reset" "$cmd"
+    printf '    %b$%b %s --skip -S 2 one piece\n' "$c_magenta" "$c_reset" "$cmd"
+    printf '    %b$%b %s -d -e 2 cyberpunk edgerunners\n' "$c_magenta" "$c_reset" "$cmd"
+    printf '    %b$%b %s --vlc -q 1080p -e 4 cyberpunk\n' "$c_magenta" "$c_reset" "$cmd"
+    printf '    %b$%b %s blue lock -e 5-6\n' "$c_magenta" "$c_reset" "$cmd"
+    printf '\n'
     exit 0
 }
 
 version_info() {
-    printf "%s\n" "$version_number"
+    print_banner
     exit 0
 }
 
 update_script() {
-    printf "[branch:%s] Checking for Update..\n" "$branch"
+    printf '\033[1;36m● \033[1;34m[branch:%s] Checking for Update..\033[0m\n' "$branch"
     update="$(curl --fail-with-body -sL -A "$agent" "https://raw.githubusercontent.com/pystardust/ani-cli/$branch/ani-cli")" || die "[branch:$branch] Connection error: $update"
     printf '%s' "$update" | grep -q "^version_number" || die "[branch:$branch] Invalid Response."
     update="$(printf '%s\n' "$update" | diff -u "$0" -)"
     if [ -z "$update" ]; then
-        printf "[branch:%s] Script is up to date :)\n" "$branch"
+        printf '\033[1;32m✓ [branch:%s] Script is up to date :)\033[0m\n' "$branch"
     else
         if printf '%s\n' "$update" | patch "$0" -; then
-            printf "[branch:%s] Script has been updated\n" "$branch"
+            printf '\033[1;32m✓ [branch:%s] Script has been updated\033[0m\n' "$branch"
         else
             die "[branch:$branch] Can't update for some reason!"
         fi
@@ -179,7 +200,7 @@ get_links() {
             ;;
         *) [ -n "$episode_link" ] && printf "%s\n" "$episode_link" ;;
     esac
-    printf "\033[1;32m%s\033[0m Links Fetched\n" "$provider_name" 1>&2
+    printf '\033[1;32m✓ %s Links Fetched\033[0m\n' "$provider_name" 1>&2
 }
 
 # initialises provider_name and provider_id. First argument is the provider name, 2nd is the regex that matches that provider's link
@@ -215,7 +236,7 @@ select_quality() {
         worst) result=$(printf "%s" "$links" | grep -E '^[0-9]{3,4}' | tail -n1) ;;
         *) result=$(printf "%s" "$links" | grep -m 1 "$1") ;;
     esac
-    [ -z "$result" ] && printf "Specified quality not found, defaulting to best\n" 1>&2 && result=$(printf "%s" "$links" | head -n1)
+    [ -z "$result" ] && printf '\033[1;33m⚠ Specified quality not found, defaulting to best\033[0m\n' 1>&2 && result=$(printf "%s" "$links" | head -n1)
 
     # add refr for m3u8 and refr flag for yt
     case "$result" in
@@ -286,7 +307,7 @@ get_filemoon_links() {
     printf '%s' "$plain" | tr '{}[]' '\n' |
         sed -nE 's|.*"url":"([^"]*)".*"height":([0-9]+).*|\2 >\1|p;s|.*"height":([0-9]+).*"url":"([^"]*)".*|\1 >\2|p' |
         sed 's|\\u0026|\&|g;s|\\u003D|=|g' | sort -rn
-    printf "\033[1;32m%s\033[0m Links Fetched\n" "Filemoon" 1>&2
+    printf '\033[1;32m✓ %s Links Fetched\033[0m\n' "Filemoon" 1>&2
 }
 
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
@@ -342,7 +363,7 @@ time_until_next_ep() {
         color="33"
         printf "%s\n" "$data"
         ! (printf "%s\n" "$data" | grep -q "Next Raw Release:") && status="Finished" && color="32"
-        printf "Status:  \033[1;%sm%s\033[0m\n---\n" "$color" "$status"
+        printf "Status:  \033[1;%sm%s\033[0m\n\033[2m───────────────────────\033[0m\n" "$color" "$status"
     done
     exit 0
 }
@@ -410,7 +431,7 @@ play_episode() {
     # shellcheck disable=SC2086
     case "$player_function" in
         debug)
-            printf "All links:\n%s\nSelected link:\n" "$links"
+            printf '\033[1;36m● All links:\033[0m\n%s\n\033[1;36m● Selected link:\033[0m\n' "$links"
             printf "%s\n" "$episode"
             ;;
         mpv*)
@@ -466,7 +487,7 @@ play() {
         for i in $range; do
             tput clear
             ep_no=$i
-            printf "\33[2K\r\033[1;34mPlaying episode %s...\033[0m\n" "$ep_no"
+            printf '\33[2K\r\033[1;35m▶ \033[1;34mPlaying episode \033[1;36m%s\033[1;34m...\033[0m\n' "$ep_no"
             [ "$i" = "$end" ] && unset range
             play_episode
         done
@@ -589,7 +610,8 @@ done
 [ "$use_external_menu" = "0" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-m"}"
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
-printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
+print_banner
+printf '\33[2K\r\033[1;36m● \033[1;34mChecking dependencies...\033[0m\n'
 dep_ch "curl" "sed" "grep" || true
 case "$(uname -o 2>/dev/null)" in
     *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
@@ -600,8 +622,8 @@ dep_ch "fzf" || true
 case "$player_function" in
     debug) ;;
     download) dep_ch "ffmpeg" "aria2c" ;;
-    android*) printf "\33[2K\rChecking of players on Android is disabled.\nANI-CLI recommends Android MPV for full compatibility.\nAdd:\n include='/storage/emulated/0/mpv/mpv.config.mp4'\nto:\n MPV > Settings > Advanced > mpv.conf\nfor full functionality.\nIgnore, If Done.\n" ;;
-    *iSH*) printf "\33[2K\rChecking of players on iOS is disabled\n" ;;
+    android*) printf "\33[2K\r\033[1;33m⚠ Checking of players on Android is disabled.\nANI-CLI recommends Android MPV for full compatibility.\nAdd:\n include='/storage/emulated/0/mpv/mpv.config.mp4'\nto:\n MPV > Settings > Advanced > mpv.conf\nfor full functionality.\nIgnore, If Done.\033[0m\n" ;;
+    *iSH*) printf '\33[2K\r\033[1;33m⚠ Checking of players on iOS is disabled\033[0m\n' ;;
     flatpak_mpv) true ;; # handled out of band in where_mpv
     *) dep_ch "$player_function" ;;
 esac
@@ -626,7 +648,7 @@ case "$search" in
     *)
         if [ "$use_external_menu" = "0" ]; then
             while [ -z "$query" ]; do
-                printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
+                printf '\33[2K\r\033[1;35m▸ \033[1;36mSearch anime: \033[0m' && read -r query
             done
         else
             [ -z "$query" ] && query=$(printf "" | external_menu "" "Search anime: " "$external_menu_args")
@@ -660,7 +682,7 @@ tput sc
 play
 [ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
 
-while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
+while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "▶ Episode $ep_no · $title "); do
     case "$cmd" in
         next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
         replay) episode="$replay" ;;


### PR DESCRIPTION
I wanted to make the script look a bit nicer in the terminal without breaking any existing code.

I didn't touch any of the actual scraping, playing, or any other logic. I just updated the text outputs so things are easier to read. 

Here is what I changed:
- Added a simple color theme using standard ANSI escape codes.
- Added a small text banner on startup and in the help menu.
- Cleaned up the `--help` output by putting options into categories so it's not just a wall of text.
- Added simple icons (like ✓ and ✗) to the standard logs and error messages so it's easier to tell what's happening at a glance.
- Made the search and playback prompts a bit more colorful so they stand out.

[PREVIEW]

https://github.com/user-attachments/assets/03d542d3-f233-44e9-8715-83799220f1d5




