### PR TITLE
fix: handle AllAnime aaReq token for episode sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ For players you can use the apk (playstore/fdroid) versions of mpv and vlc. Note
 pkg install openssl-tool
 ```
 
+**Note:** `nodejs` is also required for AllAnime source decryption. Install it with:
+```sh
+pkg install nodejs
+```
+
 **Important Note:** To get all providers working with android MPV, Please follow below steps:
 - Run this command and allow storage permissions:
 ```sh
@@ -527,7 +532,8 @@ apk del grep sed curl fzf git aria2 ffmpeg ncurses
 - yt-dlp - m3u8 Downloader
 - ffmpeg - m3u8 Downloader (fallback)
 - fzf - User interface
-- openssl (for decrypting encrypted video sources; on Termux, the CLI is in the `openssl-tool` package)
+- openssl (for decrypting Filemoon video sources; on Termux, the CLI is in the `openssl-tool` package)
+- nodejs (for decrypting AllAnime video sources)
 - ani-skip (optional, for auto-skipping anime intros)
 - patch - Self updating
 

--- a/ani-cli
+++ b/ani-cli
@@ -239,14 +239,21 @@ process_response() {
         return 0
     fi
 
-    tmp="$(mktemp)"
-    printf '%s' "$1" | sed -nE 's|.*"tobeparsed":"([^"]*)".*|\1|p' | base64 -d >"$tmp"
-    file_size="$(wc -c <"$tmp")"
-    iv="$(dd if="$tmp" bs=1 skip=1 count=12 2>/dev/null | od -A n -t x1 | tr -d ' \n')"
-    ctr="${iv}00000002"
-    ct_len=$((file_size - 13 - 16))
-    dd if="$tmp" bs=1 skip=13 count="$ct_len" 2>/dev/null | openssl enc -d -aes-256-ctr -K "$allanime_key" -iv "$ctr" -nosalt -nopad 2>/dev/null
-    rm -f "$tmp"
+    printf '%s' "$1" | sed -nE 's|.*"tobeparsed":"([^"]*)".*|\1|p' | node -e "
+const crypto = require('crypto');
+const key = Buffer.from('$allanime_key', 'hex');
+let d = '';
+process.stdin.on('data', c => d += c);
+process.stdin.on('end', () => {
+  const raw = Buffer.from(d.trim(), 'base64');
+  const iv = raw.subarray(1, 13);
+  const ct = raw.subarray(13, -16);
+  const tag = raw.subarray(-16);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  process.stdout.write(Buffer.concat([decipher.update(ct), decipher.final()]));
+});
+" 2>/dev/null
 }
 
 b64url_to_hex() {
@@ -296,13 +303,21 @@ get_episode_url() {
 
     query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
-    query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$query_hash\"}}"
+    query_ext="$(node -e "
+const crypto = require('crypto');
+const key = Buffer.from('$allanime_key', 'hex');
+const qh = '$query_hash';
+const ts = Math.floor(Date.now() / 300000) * 300000;
+const payload = JSON.stringify({v:1,ts:ts,epoch:4128,buildId:'9',qh:qh});
+const iv = crypto.createHash('sha256').update('4128:9:'+qh+':'+ts).digest().subarray(0,12);
+const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+const ct = Buffer.concat([cipher.update(payload), cipher.final()]);
+const tag = cipher.getAuthTag();
+const aareq = Buffer.concat([Buffer.from([1]), iv, ct, tag]).toString('base64');
+console.log(JSON.stringify({persistedQuery:{version:1,sha256Hash:qh},aaReq:aareq}));
+")"
 
     api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
-
-    if [ -z "$api_resp" ] || ! printf "%s" "$api_resp" | grep -q "tobeparsed"; then
-        api_resp="$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")"
-    fi
 
     resp="$(process_response "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
     # generate links into sequential files
@@ -484,7 +499,7 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefo
 allanime_refr="https://youtu-chan.com"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
-allanime_key="$(printf '%s' 'Xot36i3lK3:v1' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
+allanime_key="22196fa6afca95309fdabe9a3534b87cd2454e50efeabfcbdbdfd3de678b3982"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"

--- a/ani-cli
+++ b/ani-cli
@@ -607,8 +607,10 @@ done
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
 case "$(uname -o 2>/dev/null)" in
-    *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
-    *) dep_ch "openssl" || true ;;
+    *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool'
+             command -v node >/dev/null || die 'Program "node" not found. On Termux, install with: pkg install nodejs' ;;
+    *) dep_ch "openssl" || true
+       dep_ch "node" || true ;;
 esac
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 dep_ch "fzf" || true


### PR DESCRIPTION
AllAnime changed its GraphQL API. Episode source requests now require an
AES-256-GCM `aaReq` token in the `extensions` object and must be sent as GET
with query parameters. POST requests fail with `AA_CRYPTO_MISSING`.

#### Changes:
- `process_response()` — Decrypt `tobeparsed` with AES-256-GCM instead of
  AES-256-CTR (openssl `enc` doesn't support AEAD, so uses Node.js `crypto`)
- `get_episode_url()` — Generate dynamic `aaReq` token via the same XOR-derived
  key and include it in the GraphQL extensions; removed dead POST fallback
- `allanime_key` — XOR-derived key from two static secrets (matching the
  official site's build) instead of SHA256(`Xot36i3lK3:v1`)

The aaReq token is time-bound (5-minute window) and encrypted with AES-256-GCM
using the same key, matching the exact protocol the AllAnime website uses.

No new runtime dependencies — Node.js `crypto` is built-in. `nodejs` added to
dependency list in README and dep checker.

#### Before Fix:
<img width="424" height="78" alt="image" src="https://github.com/user-attachments/assets/6c46d5b1-5b66-45fd-a928-2c63deae7f6e" />

#### After Fix:
<img width="581" height="163" alt="image" src="https://github.com/user-attachments/assets/13aaf410-5f3d-41bb-aa42-00531c8c242e" />