### PR TITLE
feat: tty render modes

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -59,6 +59,10 @@ help_info() {
         Delete history
       -l, --logview
         Show logs
+    -t, --tty
+        Use tct or drm backend to use it in tty
+        tty 1 = tct (default)
+        tty 2 = drm
       -s, --syncplay
         Use Syncplay to watch with friends
       -S, --select-nth

--- a/ani-cli
+++ b/ani-cli
@@ -427,10 +427,7 @@ play_episode() {
                         tty_flags="--vo=tct --really-quiet"
                         ;;
                     2)
-                        tty_flags="--vo=gpu --gpu-context=drm"
-                        ;;
-                    *)
-                        tty_flags="--vo=tct --realy-quiet"
+                        tty_flags="--vo=drm"
                         ;;
                 esac
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -2,6 +2,9 @@
 
 version_number="4.14.1"
 
+#flags
+use_tty=0
+tty_mode=0
 # UI
 
 external_menu() {
@@ -414,10 +417,23 @@ play_episode() {
             printf "%s\n" "$episode"
             ;;
         mpv*)
+            if [ "$use_tty" = 1 ]; then
+                case "$tty_mode" in
+                    1)
+                        tty_flags="--vo=tct --really-quiet"
+                        ;;
+                    2)
+                        tty_flags="--vo=gpu --gpu-context=drm"
+                        ;;
+                    *)
+                        tty_flags="--vo=tct --realy-quiet"
+                        ;;
+                esac
+            fi
             if [ "$no_detach" = 0 ]; then
-                nohup $player_function $skip_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $refr_flag >/dev/null 2>&1 &
+                nohup $player_function $tty_flags $skip_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $refr_flag >/dev/null 2>&1 &
             else
-                $player_function $skip_flag $refr_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
+                $player_function $tty_flags $skip_flag $refr_flag --tls-verify=no --force-media-title="${allanime_title}Episode ${ep_no}" "$episode"
                 mpv_exitcode=$?
                 [ "$exit_after_play" = 1 ] && [ -z "$range" ] && exit "$mpv_exitcode"
             fi
@@ -514,6 +530,19 @@ branch="${ANI_CLI_BRANCH:-master}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        -t | --tty)
+            use_tty=1
+            no_detach=1
+            tty_mode=1
+            if [ $# -gt 1 ]; then
+                case "$2" in
+                    1|2)
+                        tty_mode="$2"
+                        shift
+                        ;;
+                esac
+            fi
+            ;;
         -v | --vlc)
             case "$(uname -a | cut -d " " -f 1,3-)" in
                 *ndroid*) player_function="android_vlc" ;;

--- a/ani-cli
+++ b/ani-cli
@@ -429,6 +429,7 @@ play_episode() {
                     2)
                         tty_flags="--vo=drm"
                         ;;
+                    *) tty_flags="" ;;
                 esac
             fi
             if [ "$no_detach" = 0 ]; then
@@ -537,9 +538,12 @@ while [ $# -gt 0 ]; do
             tty_mode=1
             if [ $# -gt 1 ]; then
                 case "$2" in
-                    1|2)
+                    1 | 2)
                         tty_mode="$2"
                         shift
+                        ;;
+                    *)
+                        tty_mode="1"
                         ;;
                 esac
             fi


### PR DESCRIPTION
# feat: tty render modes

## Type of change

- [X] Feature

## Description

This version of ani-cli adds tty support for those users who don't want to use the terminal through a GUI. It adds two modes --tty 1 or --tty 2 which works with mpv video outputs as tct and drm respectively. 
So why would you even want to use ani-cli from pure tty?
- Well sometimes when i update something or try to do something i am not well informed about and then delete my DE/WM i would still like to be able to enjoy anime although that might not be the best way to enjoy it. 
- Or maybe someone just likes to watch anime as ascii art from their tty instance. 
-  Or, check out anime from ssh sessions where you would like to download them but can't verify them as you don't have a vnc setup and you just need to see if its the right one.
### Disclaimer
- I have tested this on kitty as well as my tty. I am currently on arch linux, with kernel 7.0.12-arch1-1. I assume the functionality is going to be same on other setups as well as it is depended on mpv rather than the terminal and operating system's behaviour to my knowledge.
- As of creating this PR the links are not working right now which is not caused my changes as they are not working properly even on a clean instance from github. I had checked it on my previous PR where it was working as intended and i haven't made any changes that should affect it and only have changed minor things which is only done to be compliant with the different CI/CD checks. 

This is the second PR i am requesting as my previous ones were failing the CI/CD checks which i have tried to fix in this one. 


## Checklist

- [X] any anime playing
---
- [X] next, prev and replay work
- [X] `-c` history and continue work
- [X] `-d` downloads work
- [X] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [X] `-h` help info is up to date
- [X] Readme is up to date
- [X] Man page is up to date

