### PR TITLE
feat: add Homebrew formula for easier installation on macOS

### DIFF
--- a/Formula/ani-cli.rb
+++ b/Formula/ani-cli.rb
@@ -1,0 +1,32 @@
+class AniCli < Formula
+  desc "Cli tool to browse and play anime"
+  homepage "https://github.com/pystardust/ani-cli"
+  url "https://github.com/pystardust/ani-cli/archive/refs/tags/v4.14.tar.gz"
+  sha256 "be40c779605b9b5eb4c09e63a1f460bcc69d73a3ab6e707279548fb8513c96c0"
+  license "GPL-3.0"
+  head "https://github.com/pystardust/ani-cli.git", branch: "master"
+
+  depends_on "aria2"
+  depends_on "ffmpeg"
+  depends_on "fzf"
+  depends_on "grep"
+  depends_on "yt-dlp"
+  depends_on "mpv" => :recommended
+
+  def install
+    bin.install "ani-cli"
+    man1.install "ani-cli.1"
+  end
+
+  def caveats
+    <<~EOS
+      On macOS you can install IINA player instead of mpv for better experience:
+        brew install --cask iina
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ani-cli --version")
+    assert_match "No results found!", shell_output("#{bin}/ani-cli this-title-does-not-exist-for-sure 2>&1", 1)
+  end
+end

--- a/README.md
+++ b/README.md
@@ -127,21 +127,12 @@ You'll get a warning about `Signature verification failed [4-Signatures public k
 
 </details></details><details><summary><b>MacOS</b></summary>
 
-Install dependencies [(See below)](#dependencies)
-
 Install [HomeBrew](https://docs.brew.sh/Installation) if not installed.
 
 ```sh
-git clone "https://github.com/pystardust/ani-cli.git" && cd ./ani-cli
-cp ./ani-cli "$(brew --prefix)"/bin
-cd .. && rm -rf ./ani-cli
-```
-
-*To install (with Homebrew) the dependencies required on Mac OS, you can run:*
-
-```sh
-brew install curl grep aria2 ffmpeg git fzf yt-dlp && \
-brew install --cask iina
+brew tap pystardust/ani-cli https://github.com/pystardust/ani-cli.git
+brew trust pystardust/ani-cli
+brew install ani-cli && brew install --cask iina
 ```
 *Why iina and not mpv? Drop-in replacement for mpv for MacOS. Integrates well with OSX UI. Excellent support for M1. Open Source.*
 
@@ -477,7 +468,7 @@ sudo rm "/usr/local/bin/ani-cli"
 ```
 * Mac:
 ```sh
-rm "$(brew --prefix)/bin/ani-cli"
+brew uninstall ani-cli && brew untap pystardust/ani-cli
 ```
 * Windows:
 In **Git Bash** run (as administrator):


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Documentation update

## Description

Manually adding files to `$HOMEBREW_PREFIX/bin` should be avoided, a much better way to support Homebrew installation is to provide `ani-cli` as a formula in third-party tap. It also simplifies package updates for users. I can help with setting up a workflow that updates formula on version bump if needed

## Checklist

This change is not related to the script itself so there's no need to test anything in the checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
