### PR TITLE
fix: titles with no airing year info now show

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.5"
+version_number="4.14.6"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -328,9 +328,8 @@ get_episode_url() {
 search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes airedStart __typename } }}'
-
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
-| g' | sed -nE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\",.*${mode}\":([1-9][^,]*).*year\":([1-9][^,]*).*|\1	\2 (\3 episodes) (\4)|p" | sed 's/\\"//g'
+| g'| sed -e 's#\"airedStart\":{}#\"airedStart\":{"year":0,}#' | sed -nrE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\",.*${mode}\":([1-9][^,]*).*(year\":([0-9][^,]*)).*|\1	\2 (\3 episodes) (\5)|p" | sed -e 's#(0)##'| sed 's/\\"//g'
 }
 
 time_until_next_ep() {

--- a/ani-cli
+++ b/ani-cli
@@ -329,7 +329,7 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes airedStart __typename } }}'
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
-| g'| sed -e 's#\"airedStart\":{}#\"airedStart\":{"year":0,}#' | sed -nrE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\",.*${mode}\":([1-9][^,]*).*(year\":([0-9][^,]*)).*|\1	\2 (\3 episodes) (\5)|p" | sed -e 's#(0)##'| sed 's/\\"//g'
+| g' | sed -e 's#\"airedStart\":{}#\"airedStart\":{"year":0,}#' | sed -nrE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\",.*${mode}\":([1-9][^,]*).*(year\":([0-9][^,]*)).*|\1	\2 (\3 episodes) (\5)|p" | sed -e 's#(0)##' | sed 's/\\"//g'
 }
 
 time_until_next_ep() {


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ x] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

PR #1784 added showing the year to be displayed for titles when searching results. However, some titles at the source do not have a valid year. This artificially reduces the shows that can be viewed. This PR fixes this. 
### Command

<img width="1134" height="281" alt="image" src="https://github.com/user-attachments/assets/34a39682-8119-4d24-a2e3-6d9145eaf7b4" />

### Before

<img width="124" height="41" alt="image" src="https://github.com/user-attachments/assets/b99275b1-e130-452a-b1d9-4a063f3f7188" />

### After
<img width="154" height="57" alt="image" src="https://github.com/user-attachments/assets/486c961b-388c-43d1-9a9b-ddcbdb07b120" />


