### PR TITLE
Updated PR by 71zenith to include botan 2.x syntax since debian based linux does not ship with botan3

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -250,24 +250,36 @@ process_response() {
 }
 
 get_aa_req() {
+    query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
+    allanime_key="22196fa6afca95309fdabe9a3534b87cd2454e50efeabfcbdbdfd3de678b3982"
+    # will very likely change soon
     epoch=4128
-    build_id=9
+    build_id=12
 
     ts="$(($(date +%s) / 300 * 300 * 1000))"
 
+    payload_iv="$epoch:$build_id:$query_hash:$ts"
     payload="{\"v\":1,\"ts\":$ts,\"epoch\":$epoch,\"buildId\":\"$build_id\",\"qh\":\"$query_hash\"}"
 
-    payload_iv="$epoch:$build_id:$query_hash:$ts"
-    iv_raw="$(printf '%s' "$payload_iv" | openssl dgst -sha256 -binary | od -t x1 -An | tr -d ' \n' | cut -c 1-24)"
-    iv_ctr="${iv_raw}00000002"
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT INT
 
-    ct="$(printf '%s' "$payload" | openssl enc -e -aes-256-ctr -K "$allanime_key" -iv "$iv_ctr" -nosalt | od -t x1 -An | tr -d ' \n')"
+    printf '%s' "$payload_iv" | openssl dgst -sha256 -binary | dd bs=1 count=12 of="$tmpdir/iv.bin" 2>/dev/null
 
-    # figure out tag for gcm
-    tag="$(printf '%s' "$ct" | openssl mac -cipher AES-256-GCM -macopt hexiv:$iv_raw -macopt hexkey:$allanime_key GMAC)"
+    iv_hex="$(od -An -t x1 "$tmpdir/iv.bin" | tr -d ' \n')"
 
-    aa_req="$(echo "01${iv_raw}${ct}${tag}" | base64)"
-    printf '%s' "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$aa_req\"}"
+    printf "%s" "$payload" | botan cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - > "$tmpdir/gcm_out.bin"
+
+    file_size="$(wc -c < "$tmpdir/gcm_out.bin")"
+    ct_len=$((file_size - 16))
+
+    dd if="$tmpdir/gcm_out.bin" of="$tmpdir/ct.bin" bs=1 skip=0 count="$ct_len" 2>/dev/null
+    dd if="$tmpdir/gcm_out.bin" of="$tmpdir/tag.bin" bs=1 skip="$ct_len" count=16 2>/dev/null
+
+    (
+        printf '\001'
+        cat "$tmpdir/iv.bin" "$tmpdir/ct.bin" "$tmpdir/tag.bin"
+    ) | base64 -w 0
 }
 
 b64url_to_hex() {
@@ -317,9 +329,9 @@ get_episode_url() {
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
-    query_ext=$(get_aa_req)
+    query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$(get_aa_req)\"}"
 
-    api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
+    api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" -H "x-build-id: ${build_id:-12}" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
 
     resp="$(process_response "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
     # generate links into sequential files
@@ -608,7 +620,7 @@ done
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
-dep_ch "curl" "sed" "grep" || true
+dep_ch "curl" "sed" "grep" "botan" || true
 case "$(uname -o 2>/dev/null)" in
     *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
     *) dep_ch "openssl" || true ;;

--- a/ani-cli
+++ b/ani-cli
@@ -249,7 +249,7 @@ process_response() {
     rm -f "$tmp"
 }
 
-get_aa_rec() {
+get_aa_req() {
     epoch=4128
     build_id=9
 
@@ -264,7 +264,10 @@ get_aa_rec() {
     ct="$(printf '%s' "$payload" | openssl enc -e -aes-256-ctr -K "$allanime_key" -iv "$iv_ctr" -nosalt | od -t x1 -An | tr -d ' \n')"
 
     # figure out tag for gcm
-    printf '%s' "$ct" | openssl mac -cipher AES-256-GCM -macopt hexiv:$iv_raw -macopt hexkey:$allanime_key GMAC
+    tag="$(printf '%s' "$ct" | openssl mac -cipher AES-256-GCM -macopt hexiv:$iv_raw -macopt hexkey:$allanime_key GMAC)"
+
+    aa_req="$(echo "01${iv_raw}${ct}${tag}" | base64)"
+    printf '%s' "{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$aa_req\"}"
 }
 
 b64url_to_hex() {
@@ -314,7 +317,7 @@ get_episode_url() {
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
-    query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$aa_req\"}"
+    query_ext=$(get_aa_req)
 
     api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
 

--- a/ani-cli
+++ b/ani-cli
@@ -262,6 +262,13 @@ get_aa_req() {
 
     iv_hex="$(od -An -t x1 "$tmpdir/iv.bin" | tr -d ' \n')"
 
+    # Checking if botan 2.x is installed, if it is use botan 2.x syntax. If not installed and botan 3.x is installed, use that syntax
+    if [ "$($botan version 2>/dev/null | cut -d. -f1)" = "2" ]; then
+        printf "%s" "$payload" | $botan encryption --mode=aes-256-gcm --key="$allanime_key" --iv="$iv_hex" >"$tmpdir/gcm_out.bin"
+    else
+        printf "%s" "$payload" | $botan cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
+    fi
+
     printf "%s" "$payload" | $botan_exe cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
 
     file_size="$(wc -c <"$tmpdir/gcm_out.bin")"
@@ -618,10 +625,10 @@ printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
 case "$(uname -o 2>/dev/null)" in
     *ndroid*)
-        dep_ch "botan3" && botan_exe=botan3
+        dep_ch "botan3" && botan=botan3
         command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
     *)
-        dep_ch "botan" && botan_exe=botan
+        dep_ch "botan" && botan=botan
         dep_ch "openssl" || true ;;
 esac
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)

--- a/ani-cli
+++ b/ani-cli
@@ -262,9 +262,9 @@ get_aa_req() {
 
     iv_hex="$(od -An -t x1 "$tmpdir/iv.bin" | tr -d ' \n')"
 
-    printf "%s" "$payload" | botan cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - > "$tmpdir/gcm_out.bin"
+    printf "%s" "$payload" | botan cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
 
-    file_size="$(wc -c < "$tmpdir/gcm_out.bin")"
+    file_size="$(wc -c <"$tmpdir/gcm_out.bin")"
     ct_len=$((file_size - 16))
 
     dd if="$tmpdir/gcm_out.bin" of="$tmpdir/ct.bin" bs=1 skip=0 count="$ct_len" 2>/dev/null
@@ -316,12 +316,8 @@ get_filemoon_links() {
     printf "\033[1;32m%s\033[0m Links Fetched\n" "Filemoon" 1>&2
 }
 
-
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
-    #shellcheck disable=SC2016
-    episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
-
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
     query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$(get_aa_req)\"}"
 

--- a/ani-cli
+++ b/ani-cli
@@ -250,16 +250,10 @@ process_response() {
 }
 
 get_aa_req() {
-    query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
-    allanime_key="cf4777b5778aeadc9449e12769ea545d00c43cd8ff65d482364586cde204f359"
-    # will very likely change soon
-    epoch=4130
-    build_id=12
-
     ts="$(($(date +%s) / 300 * 300 * 1000))"
 
-    payload_iv="$epoch:$build_id:$query_hash:$ts"
-    payload="{\"v\":1,\"ts\":$ts,\"epoch\":$epoch,\"buildId\":\"$build_id\",\"qh\":\"$query_hash\"}"
+    payload_iv="$allanime_epoch:$allanime_build_id:$allanime_query_hash:$ts"
+    payload="{\"v\":1,\"ts\":$ts,\"epoch\":$allanime_epoch,\"buildId\":\"$allanime_build_id\",\"qh\":\"$allanime_query_hash\"}"
 
     tmpdir="$(mktemp -d)"
     trap 'rm -rf "$tmpdir"' EXIT INT
@@ -331,7 +325,7 @@ get_episode_url() {
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
     query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$(get_aa_req)\"}"
 
-    api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" -H "x-build-id: ${build_id:-12}" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
+    api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" -H "x-build-id: $allanime_build_id" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
 
     resp="$(process_response "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
     # generate links into sequential files
@@ -518,6 +512,8 @@ allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
 allanime_key="cf4777b5778aeadc9449e12769ea545d00c43cd8ff65d482364586cde204f359"
 allanime_query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
+allanime_epoch=4130
+allanime_build_id=41
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"

--- a/ani-cli
+++ b/ani-cli
@@ -262,7 +262,7 @@ get_aa_req() {
 
     iv_hex="$(od -An -t x1 "$tmpdir/iv.bin" | tr -d ' \n')"
 
-    printf "%s" "$payload" | botan cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
+    printf "%s" "$payload" | $botan_exe cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
 
     file_size="$(wc -c <"$tmpdir/gcm_out.bin")"
     ct_len=$((file_size - 16))
@@ -615,10 +615,14 @@ done
 [ "$use_external_menu" = "1" ] && multi_selection_flag="${ANI_CLI_MULTI_SELECTION:-"-multi-select"}"
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
-dep_ch "curl" "sed" "grep" "botan" || true
+dep_ch "curl" "sed" "grep" || true
 case "$(uname -o 2>/dev/null)" in
-    *ndroid*) command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
-    *) dep_ch "openssl" || true ;;
+    *ndroid*)
+        dep_ch "botan3" && botan_exe=botan3
+        command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
+    *)
+        dep_ch "botan" && botan_exe=botan
+        dep_ch "openssl" || true ;;
 esac
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 dep_ch "fzf" || true

--- a/ani-cli
+++ b/ani-cli
@@ -269,8 +269,6 @@ get_aa_req() {
         printf "%s" "$payload" | $botan cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
     fi
 
-    printf "%s" "$payload" | $botan_exe cipher --cipher=AES-256/GCM --key="$allanime_key" --nonce="$iv_hex" - >"$tmpdir/gcm_out.bin"
-
     file_size="$(wc -c <"$tmpdir/gcm_out.bin")"
     ct_len=$((file_size - 16))
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="4.14.1"
+version_number="4.15.0"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -249,6 +249,24 @@ process_response() {
     rm -f "$tmp"
 }
 
+get_aa_rec() {
+    epoch=4128
+    build_id=9
+
+    ts="$(($(date +%s) / 300 * 300 * 1000))"
+
+    payload="{\"v\":1,\"ts\":$ts,\"epoch\":$epoch,\"buildId\":\"$build_id\",\"qh\":\"$query_hash\"}"
+
+    payload_iv="$epoch:$build_id:$query_hash:$ts"
+    iv_raw="$(printf '%s' "$payload_iv" | openssl dgst -sha256 -binary | od -t x1 -An | tr -d ' \n' | cut -c 1-24)"
+    iv_ctr="${iv_raw}00000002"
+
+    ct="$(printf '%s' "$payload" | openssl enc -e -aes-256-ctr -K "$allanime_key" -iv "$iv_ctr" -nosalt | od -t x1 -An | tr -d ' \n')"
+
+    # figure out tag for gcm
+    printf '%s' "$ct" | openssl mac -cipher AES-256-GCM -macopt hexiv:$iv_raw -macopt hexkey:$allanime_key GMAC
+}
+
 b64url_to_hex() {
     _len=$(printf '%s' "$1" | wc -c | tr -d ' ')
     _mod=$((_len % 4))
@@ -289,20 +307,16 @@ get_filemoon_links() {
     printf "\033[1;32m%s\033[0m Links Fetched\n" "Filemoon" 1>&2
 }
 
+
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
     #shellcheck disable=SC2016
     episode_embed_gql='query ($showId: String!, $translationType: VaildTranslationTypeEnumType!, $episodeString: String!) { episode( showId: $showId translationType: $translationType episodeString: $episodeString ) { episodeString sourceUrls }}'
 
-    query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
-    query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$query_hash\"}}"
+    query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$aa_req\"}"
 
     api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: ${allanime_refr}" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
-
-    if [ -z "$api_resp" ] || ! printf "%s" "$api_resp" | grep -q "tobeparsed"; then
-        api_resp="$(curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"},\"query\":\"$episode_embed_gql\"}" -A "$agent")"
-    fi
 
     resp="$(process_response "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
     # generate links into sequential files
@@ -484,7 +498,8 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefo
 allanime_refr="https://youtu-chan.com"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
-allanime_key="$(printf '%s' 'Xot36i3lK3:v1' | openssl dgst -sha256 -binary | od -A n -t x1 | tr -d ' \n')"
+allanime_key="22196fa6afca95309fdabe9a3534b87cd2454e50efeabfcbdbdfd3de678b3982"
+allanime_query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"

--- a/ani-cli
+++ b/ani-cli
@@ -251,9 +251,9 @@ process_response() {
 
 get_aa_req() {
     query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
-    allanime_key="22196fa6afca95309fdabe9a3534b87cd2454e50efeabfcbdbdfd3de678b3982"
+    allanime_key="cf4777b5778aeadc9449e12769ea545d00c43cd8ff65d482364586cde204f359"
     # will very likely change soon
-    epoch=4128
+    epoch=4130
     build_id=12
 
     ts="$(($(date +%s) / 300 * 300 * 1000))"
@@ -516,7 +516,7 @@ agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefo
 allanime_refr="https://youtu-chan.com"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"
-allanime_key="22196fa6afca95309fdabe9a3534b87cd2454e50efeabfcbdbdfd3de678b3982"
+allanime_key="cf4777b5778aeadc9449e12769ea545d00c43cd8ff65d482364586cde204f359"
 allanime_query_hash="d405d0edd690624b66baba3068e0edc3ac90f1597d898a1ec8db4e5c43c00fec"
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Updated [PR](https://github.com/pystardust/ani-cli/pull/1779) by 71zenith to include botan 2.x syntax since debian based linux does not ship with botan3.

## Checklist

- [x] any anime playing
- [x] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
