### PR TITLE
fix: generically use botan3 when available

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -616,13 +616,16 @@ done
 [ "$external_menu_normal_window" = "1" ] && external_menu_args="-normal-window"
 printf "\33[2K\r\033[1;34mChecking dependencies...\033[0m\n"
 dep_ch "curl" "sed" "grep" || true
+botan_exe=botan
+command -v "botan3" >/dev/null && botan_exe=botan3
+dep_ch "${botan_exe}"
 case "$(uname -o 2>/dev/null)" in
     *ndroid*)
-        dep_ch "botan3" && botan_exe=botan3
-        command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool' ;;
+        command -v openssl >/dev/null || die 'Program "openssl" not found. On Termux, install with: pkg install openssl-tool'
+        ;;
     *)
-        dep_ch "botan" && botan_exe=botan
-        dep_ch "openssl" || true ;;
+        dep_ch "openssl" || true
+        ;;
 esac
 [ "$skip_intro" = 1 ] && (dep_ch "ani-skip" || true)
 dep_ch "fzf" || true


### PR DESCRIPTION
This also fixes other platforms such as Gentoo Linux, if botan3 is not found, use botan.

# Pull Request Template

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

Uses `botan3` generically if found (not just on Termux / Android systems). This also fixes things e.g. on Gentoo Linux. 
Note: PR is against the `fix` branch. 
Hence, version not bumped and `README` not changed. Let me know if this should still be done. 

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev and replay work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-s` syncplay works
- [x] `-q` quality works
- [x] `-v` vlc works
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `--skip` ani-skip works
- [x] `--skip-title` ani-skip title argument works
- [x] `--no-detach` no detach works
- [x] `--exit-after-play` auto exit after playing works
- [x] `--nextep-countdown` countdown to next ep works
- [x] `--dub` and regular (sub) mode both work
- [x] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [x] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date
