### PR TITLE
refactor: remove defunct filemoon provider

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -197,11 +197,8 @@ generate_link() {
         2) provider_init "youtube" "/Yt-mp4 :/p" ;;   # youtube(mp4)(single)
         3) provider_init "sharepoint" "/S-mp4 :/p" ;; # sharepoint(mp4)(single)
         4) provider_init "mp4upload" "/Mp4 :/p" ;;    # mp4upload(mp4)(single)
-        *)
-            # provider_init "Filemoon" "/Fm-Hls :/p"
-            # get_filemoon_links "$provider_id"
-            # return 0
-            ;; # filemoon(m3u8)(single)
+        *) true
+            ;;
     esac
     [ -n "$provider_id" ] && get_links "$provider_id"
 }
@@ -276,46 +273,6 @@ get_aa_req() {
     ) | base64 -w 0
 }
 
-b64url_to_hex() {
-    _len=$(printf '%s' "$1" | wc -c | tr -d ' ')
-    _mod=$((_len % 4))
-    case $_mod in
-        2) _pad="==" ;;
-        3) _pad="=" ;;
-        *) _pad="" ;;
-    esac
-    printf '%s%s' "$1" "$_pad" | tr -- '-_' '+/' | base64 -d | od -A n -t x1 | tr -d ' \n'
-}
-
-get_filemoon_links() {
-    response="$(curl -e "$allanime_refr" -s "https://${allanime_base}$1" -A "$agent")"
-    _fm_json="$(printf '%s' "$response" | tr -d '\n ' | tr ',' '\n')"
-    iv="$(printf '%s' "$_fm_json" | sed -nE 's|^"iv":"([^"]*)"$|\1|p')"
-    payload="$(printf '%s' "$_fm_json" | sed -nE 's|^"payload":"([^"]*)"$|\1|p')"
-    kp1="$(printf '%s' "$_fm_json" | sed -nE 's|^"key_parts":\["([^"]*)"$|\1|p')"
-    kp2="$(printf '%s' "$_fm_json" | sed -nE 's|^"([A-Za-z0-9_-]+)"\]$|\1|p' | head -1)"
-    _kp1_hex="$(b64url_to_hex "$kp1")"
-    _kp2_hex="$(b64url_to_hex "$kp2")"
-    key_hex="$_kp1_hex$_kp2_hex"
-    iv_hex="$(b64url_to_hex "$iv")00000002"
-    tmp="$(mktemp)"
-    _fm_len=$(printf '%s' "$payload" | wc -c | tr -d ' ')
-    _fm_mod=$((_fm_len % 4))
-    case $_fm_mod in
-        2) _fm_pad="==" ;;
-        3) _fm_pad="=" ;;
-        *) _fm_pad="" ;;
-    esac
-    printf '%s%s' "$payload" "$_fm_pad" | tr -- '-_' '+/' | base64 -d >"$tmp"
-    ct_len=$(($(wc -c <"$tmp") - 16))
-    plain="$(dd if="$tmp" bs=1 count="$ct_len" 2>/dev/null | openssl enc -d -aes-256-ctr -K "$key_hex" -iv "$iv_hex" -nosalt -nopad 2>/dev/null)"
-    rm -f "$tmp"
-    printf '%s' "$plain" | tr '{}[]' '\n' |
-        sed -nE 's|.*"url":"([^"]*)".*"height":([0-9]+).*|\2 >\1|p;s|.*"height":([0-9]+).*"url":"([^"]*)".*|\1 >\2|p' |
-        sed 's|\\u0026|\&|g;s|\\u003D|=|g' | sort -rn
-    printf "\033[1;32m%s\033[0m Links Fetched\n" "Filemoon" 1>&2
-}
-
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
@@ -326,7 +283,6 @@ get_episode_url() {
     resp="$(process_response "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
     # generate links into sequential files
     cache_dir="$(mktemp -d)"
-    #providers="1 2 3 4 5"
     providers="1 2 3 4"
     for provider in $providers; do
         generate_link "$provider" >"$cache_dir"/"$provider" &

--- a/ani-cli
+++ b/ani-cli
@@ -647,7 +647,7 @@ tput sc
 
 # playback & loop
 play
-[ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
+[ "$player_function" = "download" ] || [ "$player_function" = "debug" ]
 
 while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
     case "$cmd" in

--- a/ani-cli
+++ b/ani-cli
@@ -647,7 +647,7 @@ tput sc
 
 # playback & loop
 play
-[ "$player_function" = "download" ] || [ "$player_function" = "debug" ]
+[ "$player_function" = "download" ] || [ "$player_function" = "debug" ] && exit 0
 
 while cmd=$(printf "next\nreplay\nprevious\nselect\nchange_quality\nquit" | nth "Playing episode $ep_no of $title... "); do
     case "$cmd" in


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
