### PR TITLE
fix: added support for shows with quotes in the title

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -329,7 +329,7 @@ search_anime() {
     #shellcheck disable=SC2016
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes airedStart __typename } }}'
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
-| g' | sed -e 's#\"airedStart\":{}#\"airedStart\":{"year":0,}#' | sed -nrE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\",.*${mode}\":([1-9][^,]*).*(year\":([0-9][^,]*)).*|\1	\2 (\3 episodes) (\5)|p" | sed -e 's#(0)##' | sed 's/\\"//g'
+| g' | sed -e 's#\"airedStart\":{}#\"airedStart\":{"year":0,}#' | sed -nrE "s@.*_id\":\"([^\"]*)\",\"name\":\"(([^\"\\\\]|\\\\.)*)\",.*${mode}\":([1-9][^,]*).*(year\":([0-9][^,]*)).*@\1	\2 (\4 episodes) (\6)@p" | sed -e 's#(0)##' | sed 's/\\"/"/g'
 }
 
 time_until_next_ep() {
@@ -638,7 +638,7 @@ case "$search" in
         # for checking new releases by specifying anime name
         [ "$search" = "nextep" ] && time_until_next_ep "$query"
 
-        query=$(printf "%s" "$query" | sed "s| |+|g")
+        query=$(printf "%s" "$query" | sed "s| |+|g" | sed 's|"|\\"|g')
         anime_list=$(search_anime "$query")
         [ -z "$anime_list" ] && die "No results found!"
         [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")


### PR DESCRIPTION
Solves #1794

Name selector now matches any number of either escaped characters or double quotes. Also had to pre-escape quotes in query construction. Capture numbers were offset because of new inner capture group.