### PR TITLE
chore: formula version bump

### DIFF
--- a/Formula/ani-cli.rb
+++ b/Formula/ani-cli.rb
@@ -1,17 +1,17 @@
 class AniCli < Formula
   desc "Cli tool to browse and play anime"
   homepage "https://github.com/pystardust/ani-cli"
-  url "https://github.com/pystardust/ani-cli/archive/refs/tags/v4.14.tar.gz"
-  sha256 "be40c779605b9b5eb4c09e63a1f460bcc69d73a3ab6e707279548fb8513c96c0"
+  url "https://github.com/pystardust/ani-cli/archive/refs/tags/v4.15.tar.gz"
+  sha256 "7ede3794978dc2eec87475e0ea96449a604a2589e940c1eab6bfbddb8529f973"
   license "GPL-3.0"
   head "https://github.com/pystardust/ani-cli.git", branch: "master"
 
   depends_on "aria2"
+  depends_on "botan"
   depends_on "ffmpeg"
   depends_on "fzf"
   depends_on "grep"
   depends_on "yt-dlp"
-  depends_on "botan"
   depends_on "mpv" => :recommended
 
   def install


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev, replay and select work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `-q` quality works
- [ ] `-s` syncplay works
- [ ] `-v` vlc works
- [ ] `--dub` and regular (sub) mode both work
- [ ] `--nextep-countdown` countdown to next ep works
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

*(these don't block a merge)*

- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)

### Particular anime
- [ ] The safe bet: One Piece
- [ ] Episode 0: Saenai Heroine no Sodatekata ♭
- [ ] Unicode: Saenai Heroine no Sodatekata ♭
- [ ] Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- [ ] The examples of the help text
