### PR TITLE
feat: add anidb.app as fallback provider

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -308,22 +308,40 @@ get_aa_req() {
 
 # gets embed urls, collects direct links into provider files, selects one with desired quality into $episode
 get_episode_url() {
+    links=""
+
+    # try allanime first
     query_vars="{\"showId\":\"$id\",\"translationType\":\"$mode\",\"episodeString\":\"$ep_no\"}"
     query_ext="{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"$allanime_query_hash\"}, \"aaReq\":\"$(get_aa_req)\"}"
 
     api_resp="$(curl -e "$allanime_refr" -sG -A "$agent" -H "Origin: $allanime_refr" "${allanime_api}/api" --data-urlencode "variables=${query_vars}" --data-urlencode "extensions=${query_ext}")"
 
     resp="$(process_tobeparsed "$api_resp" | tr '{}' '\n' | sed 's|\\u002F|\/|g;s|\\||g' | sed -nE 's|.*sourceUrl":"([^"]*)".*sourceName":"([^"]*)".*|\2 :\1|p')"
-    # generate links into sequential files
-    cache_dir="$(mktemp -d)"
-    providers="1 2 3 4"
-    for provider in $providers; do
-        generate_link "$provider" >"$cache_dir"/"$provider" &
-    done
-    wait
-    # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sort -g -r -s)
-    rm -r "$cache_dir"
+    if [ -n "$resp" ]; then
+        cache_dir="$(mktemp -d)"
+        providers="1 2 3 4"
+        for provider in $providers; do
+            generate_link "$provider" >"$cache_dir"/"$provider" &
+        done
+        wait
+        links=$(cat "$cache_dir"/* | sort -g -r -s)
+        rm -r "$cache_dir"
+    fi
+
+    # fallback to anidb.app
+    if [ -z "$links" ] && [ -n "$id" ]; then
+        _anidb_id="$id"
+        _ep_json="$(anidb_curl "https://anidb.app/api/frontend/anime/${_anidb_id}/episodes" -A "$agent" -H "Accept: application/json" --max-time 10)"
+        _m3u8="$(get_anidb_m3u8 "$_anidb_id" "$ep_no" "$_ep_json")"
+        if [ -n "$_m3u8" ]; then
+            _m3u8_content="$(anidb_curl "$_m3u8" -A "$agent" --max-time 10)"
+            if printf '%s' "$_m3u8_content" | grep -q "EXTM3U"; then
+                links="$(printf '%s' "$_m3u8_content" | sed 's|^#EXT-X-STREAM.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|; /EXT-X-I-FRAME/d' | sort -nr)"
+                [ -n "$links" ] && refr_flag="--referrer=https://anidb.app" && printf "\033[1;32m%s\033[0m Links Fetched\n" "anidb.app" 1>&2
+            fi
+        fi
+    fi
+
     select_quality "$quality"
     if printf "%s" "$ep_list" | grep -q "^$ep_no$"; then
         [ -z "$episode" ] && die "Episode is released, but no valid sources!"
@@ -338,6 +356,49 @@ search_anime() {
     search_gql='query( $search: SearchInput $limit: Int $page: Int $translationType: VaildTranslationTypeEnumType $countryOrigin: VaildCountryOriginEnumType ) { shows( search: $search limit: $limit page: $page translationType: $translationType countryOrigin: $countryOrigin ) { edges { _id name availableEpisodes airedStart __typename } }}'
     curl -e "$allanime_refr" -s -H "Content-Type: application/json" -X POST "${allanime_api}/api" --data "{\"variables\":{\"search\":{\"allowAdult\":false,\"allowUnknown\":false,\"query\":\"$1\"},\"limit\":40,\"page\":1,\"translationType\":\"$mode\",\"countryOrigin\":\"ALL\"},\"query\":\"$search_gql\"}" -A "$agent" | sed 's|Show|\
 | g' | sed -e 's#\"airedStart\":{}#\"airedStart\":{"year":0,}#' | sed -nrE "s|.*_id\":\"([^\"]*)\",\"name\":\"([^\"]*)\",.*${mode}\":([1-9][^,]*).*(year\":([0-9][^,]*)).*|\1	\2 (\3 episodes) (\5)|p" | sed -e 's#(0)##' | sed 's/\\"//g'
+}
+
+# anidb.app provider
+anidb_curl() {
+    _retries=3
+    _result=""
+    while [ $_retries -gt 0 ]; do
+        _result="$(curl -sL "$@" 2>/dev/null | tr -d '\r')"
+        [ -n "$_result" ] && printf '%s' "$_result" && return 0
+        _retries=$((_retries - 1))
+        [ $_retries -gt 0 ] && sleep 1
+    done
+    return 1
+}
+
+search_anidb() {
+    _query="$(printf '%s' "$1" | sed 's/ /+/g')"
+    _page="$(anidb_curl "https://anidb.app/search/suggestions?q=${_query}" -A "$agent" --max-time 10 | tr '\n' ' ' | sed 's/<a href/\n<a href/g')"
+    printf '%s' "$_page" | sed -nE 's|.*anime/[a-z0-9-]+-([0-9]+)".*alt="([^"]+)".*|\1\t\2|p'
+}
+
+episodes_list_anidb() {
+    _anime_id="$1"
+    _ep_json="$(anidb_curl "https://anidb.app/api/frontend/anime/${_anime_id}/episodes" -A "$agent" -H "Accept: application/json" --max-time 10)"
+    printf '%s' "$_ep_json" | sed 's/},{/}\n{/g' | sed -nE 's|.*"number":([0-9]+).*|\1|p' | sort -n -u
+}
+
+get_anidb_m3u8() {
+    _anime_id="$1"
+    _ep_no="$2"
+    _ep_json="${3:-}"
+    [ -z "$_ep_json" ] && _ep_json="$(anidb_curl "https://anidb.app/api/frontend/anime/${_anime_id}/episodes" -A "$agent" -H "Accept: application/json" --max-time 10)"
+    _ep_id="$(printf '%s' "$_ep_json" | sed -nE "s|.*\"id\":([0-9]+),\"number\":${_ep_no}[,}].*|\1|p" | head -1)"
+    [ -z "$_ep_id" ] && return 1
+    _lang_pref="jpn"
+    [ "$mode" = "dub" ] && _lang_pref="eng"
+    _lang_json="$(anidb_curl "https://anidb.app/api/frontend/episode/${_ep_id}/languages" -A "$agent" -H "Accept: application/json" --max-time 10)"
+    _embed_url="$(printf '%s' "$_lang_json" | sed -nE "s|.*\"code\":\"${_lang_pref}\".*\"embed_url\":\"([^\"]*)\".*|\1|p;s|.*\"embed_url\":\"([^\"]*)\".*\"code\":\"${_lang_pref}\".*|\1|p" | head -1)"
+    [ -z "$_embed_url" ] && _embed_url="$(printf '%s' "$_lang_json" | sed -nE 's|.*"embed_url":"([^"]*)".*|\1|p' | head -1)"
+    _embed_url="$(printf '%s' "$_embed_url" | sed 's|\\/|/|g')"
+    [ -z "$_embed_url" ] && return 1
+    _page="$(anidb_curl "$_embed_url" -A "$agent" --max-time 10)"
+    printf '%s' "$_page" | sed -nE "s|.*file: '([^']*)'.*|\1|p" | head -1
 }
 
 time_until_next_ep() {


### PR DESCRIPTION
## Summary

Adds anidb.app as a fallback scraping provider. When allanime returns no sources, the script now falls back to anidb.app's public API for stream extraction.

### Changes
- Added `anidb_curl` with retry logic and `\r` stripping for Windows compatibility
- Added `search_anidb`, `episodes_list_anidb`, `get_anidb_m3u8` for anidb.app API
- Modified `get_episode_url` to try allanime first, then fall back to anidb.app if no links are found

### How it works
1. Allanime is tried first (existing behavior)
2. If allanime returns empty results, anidb.app is used as fallback
3. anidb.app uses its public API for search, episodes, and m3u8 stream extraction
4. Supports both sub and dub via language preference