### PR TITLE
chore: Update ani-cli-rs entry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 ## Homies
 
 * [animdl](https://github.com/justfoolingaround/animdl): Ridiculously efficient, fast and light-weight (supports most sources: allmanga, zoro ... (Python)
-* [ani-cli-rs](https://github.com/vorlie/ani-cli-rs): A cross-platform Rust port of ani-cli focused on the current AllAnime workflow. (Rust)
+* [ani-cli-rs](https://github.com/vorlie/ani-cli-rs): A cross-platform Rust port of ani-cli with two independent Anikoto catalogs and native MegaPlay/KotoCDN playback. (Rust)
 * [jerry](https://github.com/justchokingaround/jerry): stream anime with anilist tracking and syncing, with discord presence (Shell)
 * [anipy-cli](https://github.com/sdaqo/anipy-cli): ani-cli rewritten in python (Python)
 * [mangal](https://github.com/metafates/mangal): Download & read manga from any source with anilist sync (Go)


### PR DESCRIPTION
Updated ani-cli-rs description to include features.

# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev, replay and select work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `-q` quality works
- [ ] `-s` syncplay works
- [ ] `-v` vlc works
- [ ] `--dub` and regular (sub) mode both work
- [ ] `--nextep-countdown` countdown to next ep works
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

*(these don't block a merge)*

- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)

### Particular anime
- [ ] The safe bet: One Piece
- [ ] Episode 0: Saenai Heroine no Sodatekata ♭
- [ ] Unicode: Saenai Heroine no Sodatekata ♭
- [ ] Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- [ ] The examples of the help text
