### PR TITLE
docs: add animesama-cli to homies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,3 +601,4 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 * [Curd](https://github.com/Wraient/curd): A CLI tool to watch anime with Anilist, Discord RPC, Skip Intro/Outro/Filler/Recap (Go)
 * [FastAnime](https://github.com/Benex254/FastAnime): browser anime experience from the terminal (Python)
 * [ani-skip](https://github.com/KilDesu/ani-skip): Automatically skip opening and ending sequences for IINA on MacOS (Typescript, official IINA plugin API)
+* [animesama-cli](https://github.com/Miro-sh/animesama-cli): A cli to watch anime with french subtitles or french voice (Python)


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation update

## Description

Add [animesama-cli](https://github.com/Miro-sh/animesama-cli) to the homies section in the README.

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev, replay and select work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `-q` quality works
- [ ] `-s` syncplay works
- [ ] `-v` vlc works
- [ ] `--dub` and regular (sub) mode both work
- [ ] `--nextep-countdown` countdown to next ep works
---
- [ ] `-h` help info is up to date
- [x] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

*(these don't block a merge)*

- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)

### Particular anime
- [ ] The safe bet: One Piece
- [ ] Episode 0: Saenai Heroine no Sodatekata ♭
- [ ] Unicode: Saenai Heroine no Sodatekata ♭
- [ ] Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- [ ] The examples of the help text