### PR TITLE
docs: Enhance doccli entry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ Ani-skip uses the external lua script function of mpv and as such â€“ for now â€
 * [jerry](https://github.com/justchokingaround/jerry): stream anime with anilist tracking and syncing, with discord presence (Shell)
 * [anipy-cli](https://github.com/sdaqo/anipy-cli): ani-cli rewritten in python (Python)
 * [mov-cli](https://github.com/mov-cli/mov-cli): Watch everything from your terminal. (Python)
-* [doccli](https://github.com/TowarzyszFatCat/doccli):  A cli to watch anime with POLISH subtitles (Python)
+* [doccli](https://github.com/TowarzyszFatCat/doccli): [LINUX / WINDOWS] A CLI to watch anime with ENGLISH sub/dub or POLISH subtitles options, AniList integration, Discord RPC, and native Windows installer (Python)
 * [GoAnime](https://github.com/alvarorichard/GoAnime): A TUI tool to browse, play, and download anime in Portuguese and English, with Discord RPC, AniList integration, and intro skipping. (Go)
 * [Curd](https://github.com/Wraient/curd): A CLI tool to watch anime with Anilist, Discord RPC, Skip Intro/Outro/Filler/Recap (Go)
 * [ani-skip](https://github.com/synacktraa/ani-skip): Automatically skip opening and ending sequences for IINA on MacOS (Typescript, official IINA plugin API)


### PR DESCRIPTION
Updated the description of doccli to include additional features and platform compatibility.

# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [X] Documentation update

## Description

Updated the `doccli` entry in the README's "Homies" section to accurately reflect its latest cross-platform support, dual-language capabilities (English sub/dub or Polish subtitles), AniList integration, Discord RPC, and native Windows installer features.

