### PR TITLE
feat: support first available episode in ranges

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -351,6 +351,7 @@ play() {
     _end=$(printf "%s" "$ep_no" | grep -Eo '(-1|[0-9]+(\.[0-9]+)?)$')
     [ "$_start" = "-1" ] && ep_no=$(printf "%s" "$ep_list" | tail -n 1) && unset _start
     [ -z "$_end" ] || [ "$_end" = "$_start" ] && unset _start _end
+    [ "$_start" = "0" ] && _start=$(printf "%s" "$ep_list" | head -n 1)
     [ "$_end" = "-1" ] && _end=$(printf "%s" "$ep_list" | tail -n 1)
     _line_count=$(printf "%s\n" "$ep_no" | wc -l | tr -d "[:space:]")
     if [ "$_line_count" != 1 ] || [ -n "$_start" ]; then

--- a/ani-cli
+++ b/ani-cli
@@ -161,7 +161,7 @@ anidb_search() {
         [ "$curl_exe" = "curl" ] && die "Blocked by cloudflare. Try installing curl-impersonate"
         die "Blocked by cloudflare."
     fi
-    printf "%s" "$_page" | sed -nE 's|.*anime/([a-z0-9-]+-[0-9]+)".*alt="([^"]+)".*|\1\t\2|p' | sed -e "s|&#039;|'|g" -e 's|&quot;|"|g'
+    printf "%s" "$_page" | sed -nE 's|.*anime/([a-z0-9-]+-[0-9]+)".*alt="([^"]+)".*|\1\t\2|p' | sed -e "s|&#039;|'|g" -e 's|&quot;|"|g' -e "s|&amp;|\&|g"
 }
 
 # extract mal_id and seasons metadata

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="5.0.2"
+version_number="5.0.3"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="5.0.0"
+version_number="5.0.2"
 
 # UI
 

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -17,7 +17,7 @@ This tool scrapes the site anidb.
 .SH OPTIONS
 .TP
 \fB\-e | --episode | -r | --range\fR \fI\,<episode>\/\fR
-Specify the episode numbers to watch. If range is specified it should be quoted or separated by a non-numeric character (eg. -).
+Specify the episode numbers to watch. If a range is specified, it should be quoted or separated by a non-numeric character (e.g. -). Use 0 for the first available episode and -1 for the last.
 .TP
 \fB\-c | --continue\fR
 Continue watching anime from history.


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

Arguably both a bug fix at the provider level and a new feature.
This fixes #1853 

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev, replay and select work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `-q` quality works
- [ ] `-s` syncplay works
- [ ] `-v` vlc works
- [ ] `--dub` and regular (sub) mode both work
- [ ] `--nextep-countdown` countdown to next ep works
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

*(these don't block a merge)*

- [ ] `--skip` ani-skip works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
