### PR TITLE
ci: claude pr review with fix suggestions and opt out

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 # Pull Request Template
 
+- [ ] No Claude Review Please
+
 ## Type of change
 
 - [ ] Bug fix

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -74,6 +74,20 @@ jobs:
             diff needed to satisfy the tool — don't rewrite unrelated lines,
             and don't invent style changes the tools didn't flag.
 
+            Also check the version bump. The base branch's ani-cli is at
+            ./ani-cli (workspace root); the PR's is at pr-head/ani-cli. Compare
+            the `version_number="X.Y.Z"` line between the two:
+              - If ani-cli wasn't changed by the PR, skip this check.
+              - If it was changed but version_number is identical to base (or
+                lower), the bump is missing. Suggest fixing it by always
+                incrementing the patch number (the third, z component) by 1
+                from the base value — regardless of how large the rest of the
+                diff is, do not judge whether it should be a minor or major
+                bump instead. Post this as an inline ```suggestion``` on the
+                version_number line so it's committable in one click.
+              - If version_number already increased in any way, leave it
+                alone.
+
             For anything beyond those two tools (logic bugs, portability,
             security), use gh pr diff for context and comment normally.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,85 @@
+name: Claude PR Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    # pull_request_target always evaluates *this* file from the base branch,
+    # never the PR's copy, so a fork PR cannot alter review logic or exfiltrate
+    # secrets by editing the workflow. Ignoring the workflows path too is
+    # belt-and-suspenders: PRs that touch workflow files skip auto-review
+    # entirely rather than relying solely on that guarantee.
+    paths-ignore:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # Opt-out: author checks "[ ] No Claude Review Please" in the PR body
+    # (present by default in PULL_REQUEST_TEMPLATE.md).
+    if: >-
+      !contains(github.event.pull_request.body, '[x] No Claude Review Please') &&
+      !contains(github.event.pull_request.body, '[X] No Claude Review Please')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6          # base branch at workspace root (trusted)
+
+      - uses: actions/checkout@v6          # PR head, isolated in a subdir
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+
+      - name: Install shfmt
+        run: |
+          go install mvdan.cc/sh/v3/cmd/shfmt@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          # shellcheck ships preinstalled on the ubuntu-latest runner image.
+
+      - uses: anthropics/claude-code-action@6d63f3a36cec5179d0cf49088ae8cef8ad18cf17  # v1.0.189
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # The action's default actor-permission check is skipped: this repo
+          # relies on pull_request_target's base-branch pinning + the
+          # paths-ignore filter above instead. That combo stops secret
+          # exfiltration and workflow tampering; it does NOT stop a stranger's
+          # PR from spending review quota or feeding Claude prompt-injected
+          # diff content. Blast radius of the latter is bounded by
+          # allowedTools below (read + comment only, plus two linters that
+          # only parse text and never execute it).
+          allowed_non_write_users: "*"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this shell script change. ani-cli is POSIX-sh, no bashisms,
+            no awk, no wget.
+
+            The PR's version of the script is checked out read-only at
+            pr-head/ani-cli. If it changed, run these two commands verbatim
+            (they are exactly what CI enforces) and use their output to drive
+            part of your review:
+
+              shellcheck -s sh -o all -e 2250 pr-head/ani-cli
+              shfmt -i 4 -ci -d pr-head/ani-cli
+
+            For every issue either tool reports, post an inline review
+            comment on the exact line via the inline-comment tool, with the
+            corrected code inside a ```suggestion fence so the author can
+            commit it with one click. Keep each suggestion to the minimal
+            diff needed to satisfy the tool — don't rewrite unrelated lines,
+            and don't invent style changes the tools didn't flag.
+
+            For anything beyond those two tools (logic bugs, portability,
+            security), use gh pr diff for context and comment normally.
+
+            Use `gh pr comment` for top-level feedback. Only post GitHub
+            comments — never edit files directly.
+
+          claude_args: |
+            --add-dir pr-head
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(shellcheck:*),Bash(shfmt:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -81,5 +81,7 @@ jobs:
             comments — never edit files directly.
 
           claude_args: |
+            --model claude-opus-5
+            --effort high
             --add-dir pr-head
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(shellcheck:*),Bash(shfmt:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -83,8 +83,10 @@ jobs:
                 incrementing the patch number (the third, z component) by 1
                 from the base value — regardless of how large the rest of the
                 diff is, do not judge whether it should be a minor or major
-                bump instead. Post this as an inline ```suggestion``` on the
-                version_number line so it's committable in one click.
+                bump instead. The version_number line itself is unchanged, so
+                it isn't part of the diff and can't be anchored with an
+                inline/suggestion comment — raise it in the top-level
+                `gh pr comment` instead, stating the exact line to change.
               - If version_number already increased in any way, leave it
                 alone.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,49 +55,48 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+  
+            Review this shell script change. ani-cli is POSIX-sh: no bashisms,
+            no awk, no wget. Base version at ./ani-cli, PR version at
+            pr-head/ani-cli. Only post comments, never edit files.
+  
+            Gather first: `gh pr diff`, plus, if ani-cli changed, verbatim
+  
+                shellcheck -s sh -o all -e 2250 pr-head/ani-cli
+                shfmt -i 4 -ci -d pr-head/ani-cli
+  
+            Then produce exactly two things, in this order.
+  
+            1. One top-level `gh pr comment`, always, even when both linters
+            are clean. The only place prose belongs. What the change does,
+            whether the approach holds up, any logic, portability or security
+            concern the linters cannot see, plus the version verdict below.
+            Under 150 words, no headings, no recap of the inline comments.
+            Never mention your own tooling, environment or limitations in any
+            comment. If the linter output is missing, review the diff and say
+            nothing about it.
+  
+            2. One inline comment per linter finding, prose-free. The body is
+            one line plus a ```suggestion fence holding the minimal fix,
+            nothing else. For shellcheck that line is a markdown link to
+            https://www.shellcheck.net/wiki/SC0000 titled with the code; for
+            shfmt it is the literal `shfmt -i 4 -ci`, including the backticks.
+            The fence replaces exactly the lines you anchor to, closing braces
+            included, so count both before posting. Never post a comment
+            correcting an earlier one; drop the fence if unsure.
+  
+            Version verdict: if ani-cli changed and `version_number="X.Y.Z"` is
+            unchanged or lower than base, say so and give the base patch number
+            incremented by one. Never judge minor or major. If it already
+            increased, say nothing.
 
-            Review this shell script change. ani-cli is POSIX-sh, no bashisms,
-            no awk, no wget.
-
-            The PR's version of the script is checked out read-only at
-            pr-head/ani-cli. If it changed, run these two commands verbatim
-            (they are exactly what CI enforces) and use their output to drive
-            part of your review:
-
-              shellcheck -s sh -o all -e 2250 pr-head/ani-cli
-              shfmt -i 4 -ci -d pr-head/ani-cli
-
-            For every issue either tool reports, post an inline review
-            comment on the exact line via the inline-comment tool, with the
-            corrected code inside a ```suggestion fence so the author can
-            commit it with one click. Keep each suggestion to the minimal
-            diff needed to satisfy the tool — don't rewrite unrelated lines,
-            and don't invent style changes the tools didn't flag.
-
-            Also check the version bump. The base branch's ani-cli is at
-            ./ani-cli (workspace root); the PR's is at pr-head/ani-cli. Compare
-            the `version_number="X.Y.Z"` line between the two:
-              - If ani-cli wasn't changed by the PR, skip this check.
-              - If it was changed but version_number is identical to base (or
-                lower), the bump is missing. Suggest fixing it by always
-                incrementing the patch number (the third, z component) by 1
-                from the base value — regardless of how large the rest of the
-                diff is, do not judge whether it should be a minor or major
-                bump instead. The version_number line itself is unchanged, so
-                it isn't part of the diff and can't be anchored with an
-                inline/suggestion comment — raise it in the top-level
-                `gh pr comment` instead, stating the exact line to change.
-              - If version_number already increased in any way, leave it
-                alone.
-
-            For anything beyond those two tools (logic bugs, portability,
-            security), use gh pr diff for context and comment normally.
-
-            Use `gh pr comment` for top-level feedback. Only post GitHub
-            comments — never edit files directly.
-
+          # Re: effort.
+          # Low seems to produce low quality top level comments, but is sufficient for the linter suggestions
+          # High had a tendency to overthink in earlier prompt iterations, but could be tried again later
+          # At the current brevity of the toplevel review, Medium seems to yield the best results at an acceptable latency.
+          # Model should stay Opus. Opus 5 Low is preferable to Sonnet 5 Max for code review.
           claude_args: |
             --model claude-opus-5
-            --effort high
+            --effort medium
             --add-dir pr-head
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(shellcheck:*),Bash(shfmt:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github__add_issue_comment,mcp__github_comment__update_claude_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(shellcheck:*),Bash(shfmt:*)"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Documentation update

## Description

Apparently this is possible.
I made sure to have it include instructions for committable suggestions in review comments, as that's the highest value automation we can get on top of our `shellcheck` and `shfmt` runs.
Contributors who aren't fond of AI are able to opt out of the review by ticking the box at the top of the PR template.