### PR TITLE
fix: correct user-level flatpak mpv path (io.mpv.Mpv, not io.mpv/Mpv)

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -515,7 +515,6 @@ case "$player_function" in
     download) dep_ch_failover "yt-dlp,ffmpeg" >/dev/null || die 'Neither yt-dlp nor ffmpeg found' ;;
     android*) printf "\33[2K\rChecking of players on Android is disabled.\n" ;;
     *iSH*) printf "\33[2K\rChecking of players on iOS is disabled\n" ;;
-    *flatpak*mpv*) dep_ch "flatpak" ;;
     *) dep_ch "$player_function" ;;
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -515,6 +515,7 @@ case "$player_function" in
     download) dep_ch_failover "yt-dlp,ffmpeg" >/dev/null || die 'Neither yt-dlp nor ffmpeg found' ;;
     android*) printf "\33[2K\rChecking of players on Android is disabled.\n" ;;
     *iSH*) printf "\33[2K\rChecking of players on iOS is disabled\n" ;;
+    *flatpak*mpv*) dep_ch "flatpak" ;;
     *) dep_ch "$player_function" ;;
 esac
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="5.0.1"
+version_number="5.0.2"
 
 # UI
 
@@ -407,7 +407,7 @@ case "$(uname -a | cut -d " " -f 1,3-)" in
         player_function="${ANI_CLI_PLAYER:-iSH}"
         curl_exe=$(dep_ch_failover "curl_safari260_ios,$curl_exe")
         ;;                                                                                                                                                                                               # iOS (iSH)
-    *) player_function="${ANI_CLI_PLAYER:-$(dep_ch_failover "mpv,$HOME/.local/share/flatpak/app/io.mpv/Mpv/,/var/lib/flatpak/app/io.mpv.Mpv/,vlc")}" || die 'No player found. Looked for mpv and vlc' ;; # Linux OS
+    *) player_function="${ANI_CLI_PLAYER:-$(dep_ch_failover "mpv,$HOME/.local/share/flatpak/app/io.mpv.Mpv/,/var/lib/flatpak/app/io.mpv.Mpv/,vlc")}" || die 'No player found. Looked for mpv and vlc' ;; # Linux OS
 esac
 
 player_extra_flags="${ANI_CLI_PLAYER_FLAGS:-""}"


### PR DESCRIPTION
## Summary
Fixes ani-cli failing to find/launch mpv on Fedora 44 Workstation (and any distro where mpv is installed via Flatpak rather than a native package). Fedora ships no `mpv` package by default — it needs RPM Fusion, which isn't enabled out of the box — so most Fedora users install mpv via Flatpak/GNOME Software instead. Two separate bugs in the Linux player-detection path stack on top of each other to break that case entirely:

**1. Wrong user-level flatpak path (`ani-cli` line ~410)**
The Linux fallback in b0993d4 added a correct system-wide flatpak path check (`/var/lib/flatpak/app/io.mpv.Mpv/`) but the existing user-level path (`$HOME/.local/share/flatpak/app/io.mpv/Mpv/`) has a typo: a slash where the real flatpak app-id uses a dot. Flatpak's real app-id directory is always `io.mpv.Mpv` (confirmed via `flatpak remote-info flathub io.mpv.Mpv` → `Ref: app/io.mpv.Mpv/x86_64/stable`, and the layout of other installed flatpaks on a real system, e.g. `app/com.brave.Browser/`). As written, `io.mpv/Mpv` can never exist, so a genuine user-level flatpak install of mpv is never detected.

**2. Missing case arm in the post-detection dependency check (`ani-cli` line ~513-519)**
Even once `player_function` correctly resolves to the flatpak path, a second, separate check (`dep_ch "$player_function"`) re-validates it with `command -v`, which fails on a literal directory path like `/var/lib/flatpak/app/io.mpv.Mpv/` — even though `play_episode()` already knows how to launch it via `flatpak run io.mpv.Mpv`. This check had no `*flatpak*mpv*` arm to skip past it, unlike `play_episode()`, so it always dies with `Program /var/lib/flatpak/app/io.mpv.Mpv/ not found. Please install it.`

Both bugs had to be fixed for flatpak-installed mpv to work at all on Linux, system-wide or per-user.

## Test plan
- [x] `sh -n ani-cli` passes
- [x] Reproduced and fixed live on Fedora 44 Workstation: installed mpv via `flatpak install flathub io.mpv.Mpv` (system-wide, matching GNOME Software's default), confirmed each error in sequence (`No player found...` → `Program /var/lib/flatpak/app/io.mpv.Mpv/ not found...`), fixed both, then ran `ani-cli` end-to-end and confirmed playback actually works
- [x] Simulated `dep_ch_failover` against both the correct (`io.mpv.Mpv`) and buggy (`io.mpv/Mpv`) user-level paths to confirm the exact failure mode before the fix
- [x] Verified the real flatpak app-id via `flatpak remote-info --user flathub io.mpv.Mpv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)