### PR TITLE
fix: forward skip_flag to syncplay player invocation

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="5.0.2"
+version_number="5.0.3"
 
 # UI
 

--- a/ani-cli
+++ b/ani-cli
@@ -380,7 +380,7 @@ play_episode() {
             fi
             ;;
         *vlc*) nohup $player_function --http-referrer="$refr" $player_extra_flags --play-and-exit --meta-title="${anime_title} Episode ${ep_no}" "$video_link" ${sub_link:+:input-slave="$sub_link"} >/dev/null 2>&1 & ;;
-        *yncpla*) nohup $player_function $player_extra_flags "$video_link" -- --referrer="$refr" ${sub_link:+--sub-file="$sub_link"} --force-media-title="${anime_title} Episode ${ep_no}" >/dev/null 2>&1 & ;;
+        *yncpla*) nohup $player_function $player_extra_flags "$video_link" -- $skip_flag --referrer="$refr" ${sub_link:+--sub-file="$sub_link"} --force-media-title="${anime_title} Episode ${ep_no}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$video_link" "${anime_title} Episode ${ep_no}" $player_extra_flags ;;
         catt) nohup catt cast $player_extra_flags "$video_link" >/dev/null 2>&1 & ;;
         iSH)

--- a/ani-cli
+++ b/ani-cli
@@ -331,7 +331,7 @@ play_episode() {
             fi
             ;;
         *vlc*) nohup $player_function $player_extra_flags --play-and-exit --meta-title="${anime_title} Episode ${ep_no}" "$video_link" >/dev/null 2>&1 & ;;
-        *yncpla*) nohup $player_function $player_extra_flags "$video_link" -- --force-media-title="${anime_title} Episode ${ep_no}" >/dev/null 2>&1 & ;;
+        *yncpla*) nohup $player_function $player_extra_flags "$video_link" -- $skip_flag --force-media-title="${anime_title} Episode ${ep_no}" >/dev/null 2>&1 & ;;
         download) "$player_function" "$video_link" "${anime_title} Episode ${ep_no}" $player_extra_flags ;;
         catt) nohup catt cast $player_extra_flags "$video_link" >/dev/null 2>&1 & ;;
         iSH)

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="5.0.3"
+version_number="5.0.5"
 
 # UI
 


### PR DESCRIPTION
## Summary
- `--skip` computes `skip_flag` via `ani-skip` and forwards it to the `*mpv*` and `*flatpak*mpv*` player branches in `play_episode()`, but the `*yncpla*` (syncplay) branch never included it, so combining `-s`/`--syncplay` with `--skip` silently did nothing.
- Adds `$skip_flag` to the syncplay invocation's player-args passthrough (after `--`), matching the other mpv-based branches.

## Test plan
- [x] Ran `ani-cli -s --skip "<anime>"` with `ani-skip` installed and confirmed intro is skipped when launched via syncplay.
- [x] Confirmed plain `ani-cli --skip "<anime>"` (no syncplay) still skips intros as before.