### PR TITLE
feat: add interactive home dashboard, fzf preview engine, and thumbnail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ apk del grep sed curl fzf git ffmpeg ncurses
 - yt-dlp - m3u8 Downloader
 - ffmpeg - m3u8 Downloader (fallback)
 - fzf - User interface
+- chafa / catimg (optional, for inline terminal thumbnail preview)
 - ani-skip (optional, for auto-skipping anime intros)
 - patch - Self updating
 

--- a/ani-cli
+++ b/ani-cli
@@ -80,8 +80,11 @@ preview_anime() {
             fi
             if [ -s "$_img_file" ]; then
                 case "$_img_viewer" in
-                    *chafa*) "$_img_viewer" --format=symbols --size=22x8 --colors=256 "$_img_file" 2>/dev/null || true ;;
-                    *catimg*) "$_img_viewer" -w 44 -H 8 "$_img_file" 2>/dev/null || true ;;
+                    *chafa*)
+                        # shellcheck disable=SC2086
+                        "$_img_viewer" ${ANI_CLI_CHAFA_ARGS:---format=symbols --symbols=vhalf --size=28x12 --colors=256 --color-space=din99d --dither=ordered} "$_img_file" 2>/dev/null || true
+                        ;;
+                    *catimg*) "$_img_viewer" -w 56 -H 12 "$_img_file" 2>/dev/null || true ;;
                     *) ;;
                 esac
             fi
@@ -155,8 +158,12 @@ _img_viewer="\$(command -v chafa || command -v chafa.exe || which chafa || which
     [ ! -s "\$_img_file" ] && \$curl_exe -sL -A "\$agent" --max-time 5 "\$_img" -o "\$_img_file" 2>/dev/null || true
     if [ -s "\$_img_file" ]; then
       case "\$_img_viewer" in
-        *chafa*)  "\$_img_viewer" --format=symbols --size=22x8 --colors=256 "\$_img_file" 2>/dev/null || true ;;
-        *catimg*) "\$_img_viewer" -w 44 -H 8 "\$_img_file" 2>/dev/null || true ;;
+        *chafa*)
+          _chafa_cmd="\$_img_viewer \${ANI_CLI_CHAFA_ARGS:---format=symbols --symbols=vhalf --size=28x12 --colors=256 --color-space=din99d --dither=ordered}"
+          # shellcheck disable=SC2086
+          \$_chafa_cmd "\$_img_file" 2>/dev/null || true
+          ;;
+        *catimg*) "\$_img_viewer" -w 56 -H 12 "\$_img_file" 2>/dev/null || true ;;
         *) ;;
       esac
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -50,38 +50,53 @@ preview_anime() {
 
     # shellcheck disable=SC2059
     _page="$(anidb_curl "$(printf "$desc_api" "$_id")")"
-    _title="$(printf "%s" "$_page" | sed -nE 's|.*<title>([^<]+)</title>.*|\1|p' | sed 's| - AniDB.*||; s|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
+    _title="$(printf "%s" "$_page" | sed -nE 's|.*<h1[^>]*>([^<]+)</h1>.*|\1|p' | head -n 1)"
+    [ -z "$_title" ] && _title="$(printf "%s" "$_page" | sed -nE 's|.*<title>([^<]+)</title>.*|\1|p' | sed 's| - AniDB.*||; s|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
     [ -z "$_title" ] && _title="$_id"
 
-    _img="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:image" content="([^"]+)".*|\1|p' | head -n 1)"
-    _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
+    _img="$(printf "%s" "$_page" | sed -nE 's|.*src="([^"]*/poster/[^"]+)".*|\1|p' | head -n 1)"
+    [ -z "$_img" ] && _img="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:image" content="([^"]+)".*|\1|p' | head -n 1)"
+
+    _mal_id="$(printf "%s" "$_page" | sed -nE 's|.*https://myanimelist.net/anime/([0-9]+)/.*|\1|p' | head -n 1)"
+    _score="$(printf "%s" "$_page" | sed -nE 's|.*<svg.*class=".*text-yellow-400".*<\/svg>([0-9.]+)<.*|\1|p' | head -n 1)"
+    _status="$(printf "%s" "$_page" | sed -nE 's|.*href="/browse\?status=[^"]*"[^>]*>([^<]+)<.*|\1|p' | head -n 1)"
+    _type="$(printf "%s" "$_page" | sed -nE 's|.*href="/browse\?type=[^"]*"[^>]*>([^<]+)<.*|\1|p' | head -n 1)"
+    _genres="$(printf "%s" "$_page" | sed -n '/<div class="flex flex-wrap gap-1.5 mb-4">/,/<\/div>/p' | sed -nE 's|.*>([^<]+)</a>.*|\1|p' | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+
+    _desc="$(printf "%s" "$_page" | sed -n '/>Synopsis</,/\/p>/p' | sed -nE 's|.*<p class="text-sm text-faint leading-relaxed">(.*)</p>.*|\1|p' | sed 's|<br><br>|\n\n|g; s|<br>|\n|g; s|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g')"
+    [ -z "$_desc" ] && _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
     [ -z "$_desc" ] && _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta name="description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
     [ -z "$_desc" ] && _desc="No description available."
 
-    _mal_id="$(printf "%s" "$_page" | sed -nE 's|.*https://myanimelist.net/anime/([0-9]+)/.*|\1|p' | head -n 1)"
+    _img_viewer=$(dep_ch_failover "chafa,chafa.exe,catimg,catimg.exe")
 
     {
-        if [ "$thumbnail_preview" = 1 ] && [ -n "$_img" ]; then
+        if [ "$thumbnail_preview" = 1 ] && [ -n "$_img" ] && [ -n "$_img_viewer" ]; then
             _img_file="$_cache_dir/${_id}.jpg"
             if [ ! -s "$_img_file" ]; then
                 $curl_exe -sL -A "$agent" --max-time 5 "$_img" -o "$_img_file" 2>/dev/null || true
             fi
             if [ -s "$_img_file" ]; then
-                if command -v chafa >/dev/null 2>&1; then
-                    chafa --size=38x18 "$_img_file" 2>/dev/null || true
-                elif command -v catimg >/dev/null 2>&1; then
-                    catimg -w 76 -H 18 "$_img_file" 2>/dev/null || true
-                fi
+                case "$_img_viewer" in
+                    *chafa*) "$_img_viewer" --size=36x18 "$_img_file" 2>/dev/null || true ;;
+                    *catimg*) "$_img_viewer" -w 72 -H 18 "$_img_file" 2>/dev/null || true ;;
+                    *) ;;
+                esac
             fi
         fi
 
         printf "\033[1;36m%s\033[0m\n" "$_title"
-        [ -n "$_mal_id" ] && printf "\033[1;33mMyAnimeList ID:\033[0m %s\n" "$_mal_id"
+        [ -n "$_score" ] && printf "\033[1;33mScore:\033[0m %s  " "$_score"
+        [ -n "$_status" ] && printf "\033[1;35mStatus:\033[0m %s  " "$_status"
+        [ -n "$_type" ] && printf "\033[1;34mType:\033[0m %s" "$_type"
+        [ -n "$_score" ] || [ -n "$_status" ] || [ -n "$_type" ] && printf "\n"
+        [ -n "$_genres" ] && printf "\033[1;37mGenres:\033[0m %s\n" "$_genres"
+        [ -n "$_mal_id" ] && printf "\033[1;30mMAL ID: %s\033[0m\n" "$_mal_id"
         printf "\n\033[1;32mSynopsis:\033[0m\n"
         if command -v fold >/dev/null 2>&1; then
-            printf "%s\n" "$_desc" | fold -s -w 50
+            printf "%s\n" "$_desc" | fold -s -w 55
         elif command -v fmt >/dev/null 2>&1; then
-            printf "%s\n" "$_desc" | fmt -w 50
+            printf "%s\n" "$_desc" | fmt -w 55
         else
             printf "%s\n" "$_desc"
         fi
@@ -103,7 +118,7 @@ fi
 # $1 = prompt, $2 = multi select flag (for fzf/rofi), $3 = extra flags by user
 menu() {
     case "$menu_program" in
-        fzf) fzf --reverse --cycle --prompt "$1" $2 $3 ;;
+        fzf) fzf --reverse --cycle --prompt "$1" --height=60% --layout=reverse --border $2 $3 ;;
         rofi) rofi -sort -dmenu -i -p "$1" $2 $3 ;;
         dmenu) dmenu -l 20 -p "$1" $3 ;;
         *) "$menu_program" $3 "$1" ;;
@@ -120,7 +135,7 @@ nth() {
     _prompt="$1"
     [ $# -ne 1 ] && _multi_flag="$2"
     if [ "$menu_program" = "fzf" ] && [ "$preview_enabled" = 1 ] && printf "%s\n" "$_stdin" | head -n 1 | grep -q '	'; then
-        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$0\" --preview-anime {2}" --preview-window "right:50%:wrap" | cut -f 1)
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$0\" --preview-anime {2}" --preview-window "right:55%:wrap" | cut -f 1)
     else
         _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
     fi
@@ -349,7 +364,9 @@ time_until_next_ep() {
         fi
         printf "\n"
     done
-    exit 0
+    # DON'T exit 0 here. We are not a god. We return like a normal function
+    # so the caller can decide whether to loop back or crawl into a corner and cry.
+    return 0
 }
 
 # HISTORY
@@ -474,7 +491,7 @@ trending_anime() {
     _list="$(printf "%s" "$_page" | sed 's|},{"id"|\n|g' | sed -nE 's|.*"title":"([^"]+)".*|\1|p' | head -n 30)"
     [ -z "$_list" ] && die "Failed to fetch trending anime!"
     _selected="$(printf "%s\n" "$_list" | menu "Select Trending Anime: " "" "$menu_extra_flags")"
-    [ -z "$_selected" ] && exit 0
+    [ -z "$_selected" ] && return 1
     query="$_selected"
 }
 
@@ -494,7 +511,8 @@ home_menu() {
     _choice=$(printf "%s\n" "$_options" | menu "ani-cli > " "" "$menu_extra_flags" | cut -d "." -f 1 | tr -d "[:space:]")
     case "$_choice" in
         1)
-            # Proceed to search prompt
+            source=search
+            unset query
             ;;
         2)
             source=history
@@ -658,71 +676,120 @@ esac
 # idk where to put this, so I put it here...
 trap 'cleanup; exit 1' INT HUP TERM
 
-# home dashboard on zero arguments
-if [ -z "$query" ] && [ "$source" = "search" ] && [ "$home_dashboard" = 1 ] && [ -t 0 ]; then
-    home_menu
-fi
+while true; do
+    # home dashboard on zero arguments
+    if [ -z "$query" ] && [ "$source" = "search" ] && [ "$home_dashboard" = 1 ] && [ -t 0 ]; then
+        home_menu
+    fi
 
-# searching
-case "$source" in
-    history)
-        backup_old_hist
-        anime_list=$(while read -r ep_no anime_id anime_title; do process_hist_entry & done <"$histfile")
-        wait
-        [ -z "$anime_list" ] && die "No unwatched series in history!"
-        [ -z "${index##*[!0-9]*}" ] && anime_id=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: " | cut -f 1)
-        [ -z "${index##*[!0-9]*}" ] || anime_id=$(printf "%s" "$anime_list" | sed -n "${index}p" | cut -f 1)
-        [ -z "$anime_id" ] && exit 1
-        anime_title=$(printf "%s" "$anime_list" | grep "^$anime_id	" | cut -f 2 | sed 's| - episode.*||')
-        anidb_desc "$anime_id" || true
-        episode_maps="$(anidb_episodes "$anime_id")"
-        ep_list="$(printf "%s" "$episode_maps" | cut -f 2)"
-        ep_no=$(printf "%s" "$anime_list" | grep "^$anime_id	" | sed -nE 's/.*- episode (.+)$/\1/p')
-        ;;
-    trending)
-        trending_anime
-        query=$(printf "%s" "$query" | sed 's| |+|g')
-        anime_list=$(anidb_search "$query")
-        [ -z "$anime_list" ] && die "No results found!"
-        [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
-        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
-        [ -z "$result" ] && die "Invalid anime selection"
-        anime_title="$(printf "%s" "$result" | cut -f 2)"
-        anime_id="$(printf "%s" "$result" | cut -f 1)"
-        anidb_desc "$anime_id" || true
-        episode_maps="$(anidb_episodes "$anime_id")"
-        ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
-        [ -z "$ep_no" ] && die "Invalid episode selection"
-        ;;
-    *)
-        if [ "$menu_program" = "fzf" ]; then
-            while [ -z "$query" ]; do
-                printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
-            done
-        else
-            [ -z "$query" ] && query=$(: | menu "Search anime: " "" "$menu_extra_flags")
-            [ -z "$query" ] && exit 1
-        fi
-        # for checking new releases by specifying anime name
-        [ "$source" = "nextep" ] && time_until_next_ep "$query"
+    # searching
+    case "$source" in
+        history)
+            backup_old_hist
+            anime_list=$(while read -r ep_no anime_id anime_title; do process_hist_entry & done <"$histfile")
+            wait
+            if [ -z "$anime_list" ]; then
+                info "No unwatched series in history!"
+                source="search"
+                continue
+            fi
+            [ -z "${index##*[!0-9]*}" ] && anime_id=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: " | cut -f 1)
+            [ -z "${index##*[!0-9]*}" ] || anime_id=$(printf "%s" "$anime_list" | sed -n "${index}p" | cut -f 1)
+            if [ -z "$anime_id" ]; then
+                source="search"
+                continue
+            fi
+            anime_title=$(printf "%s" "$anime_list" | grep "^$anime_id	" | cut -f 2 | sed 's| - episode.*||')
+            anidb_desc "$anime_id" || true
+            episode_maps="$(anidb_episodes "$anime_id")"
+            ep_list="$(printf "%s" "$episode_maps" | cut -f 2)"
+            ep_no=$(printf "%s" "$anime_list" | grep "^$anime_id	" | sed -nE 's/.*- episode (.+)$/\1/p')
+            ;;
+        trending)
+            trending_anime || {
+                source="search"
+                continue
+            }
+            query=$(printf "%s" "$query" | sed 's| |+|g')
+            anime_list=$(anidb_search "$query")
+            if [ -z "$anime_list" ]; then
+                info "No results found!"
+                unset query
+                source="search"
+                continue
+            fi
+            [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
+            [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
+            if [ -z "$result" ]; then
+                unset query index
+                source="search"
+                continue
+            fi
+            anime_title="$(printf "%s" "$result" | cut -f 2)"
+            anime_id="$(printf "%s" "$result" | cut -f 1)"
+            anidb_desc "$anime_id" || true
+            episode_maps="$(anidb_episodes "$anime_id")"
+            ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
+            [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
+            if [ -z "$ep_no" ]; then
+                unset query index
+                source="search"
+                continue
+            fi
+            ;;
+        *)
+            if [ -z "$query" ]; then
+                if [ "$menu_program" = "fzf" ]; then
+                    printf "\33[2K\r\033[1;36mSearch anime (ESC/Enter to back): \033[0m" && read -r query
+                else
+                    query=$(: | menu "Search anime: " "" "$menu_extra_flags")
+                fi
+                if [ -z "$query" ]; then
+                    source="search"
+                    continue
+                fi
+            fi
+            # for checking new releases by specifying anime name
+            # after showing the countdown, reset and go back. we don't select anime here.
+            if [ "$source" = "nextep" ]; then
+                time_until_next_ep "$query"
+                printf "\033[1;33mPress Enter to go back...\033[0m" && read -r _
+                unset query
+                source="search"
+                continue
+            fi
 
-        query=$(printf "%s" "$query" | sed 's| |+|g')
+            _clean_query=$(printf "%s" "$query" | sed 's| |+|g')
 
-        anime_list=$(anidb_search "$query")
-        [ -z "$anime_list" ] && die "No results found!"
-        [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
-        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
-        [ -z "$result" ] && die "Invalid anime selection"
-        anime_title="$(printf "%s" "$result" | cut -f 2)"
-        anime_id="$(printf "%s" "$result" | cut -f 1)"
-        anidb_desc "$anime_id" || true
-        episode_maps="$(anidb_episodes "$anime_id")"
-        ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
-        [ -z "$ep_no" ] && die "Invalid episode selection"
-        ;;
-esac
+            anime_list=$(anidb_search "$_clean_query")
+            if [ -z "$anime_list" ]; then
+                info "No results found for $query!"
+                unset query
+                source="search"
+                continue
+            fi
+            [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
+            [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
+            if [ -z "$result" ]; then
+                unset query index
+                source="search"
+                continue
+            fi
+            anime_title="$(printf "%s" "$result" | cut -f 2)"
+            anime_id="$(printf "%s" "$result" | cut -f 1)"
+            anidb_desc "$anime_id" || true
+            episode_maps="$(anidb_episodes "$anime_id")"
+            ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
+            [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
+            if [ -z "$ep_no" ]; then
+                unset query index
+                source="search"
+                continue
+            fi
+            ;;
+    esac
+    break
+done
 
 # moves the cursor up one line and clears that line
 tput cuu1 && tput el

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,101 @@
 #!/bin/sh
 
-version_number="5.0.2"
+version_number="5.1.0"
+
+# CONFIG & NETWORK DEFAULTS (Because the network is a chaotic nightmare of TLS handshakes)
+
+base_api="https://anidb.app"
+search_api="${base_api}/browse?q=%s"
+# search_api_alt="${base_api}/search/suggestions?q=%s"
+desc_api="${base_api}/anime/%s"
+episodes_api="${base_api}/api/frontend/anime/%s/episodes"
+m3u8_api="${base_api}/api/frontend/episode/%s/languages"
+
+ciphers='ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305'
+tls13_ciphers='TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
+agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
+# checks for deps in order and returns the first available. format is "prog_a,prog_b,prog_c"
+dep_ch_failover() {
+    [ -z "$1" ] && return 1
+    prog=$(printf "%s" "$1" | cut -d "," -f 1)
+    rest=$(printf "%s" "$1" | cut -s -d "," -f 2-)
+    command -v "$prog" >/dev/null 2>&1 && printf "%s" "$prog" && return 0
+    [ -e "$prog" ] && printf "%s" "$prog" && return 0
+    dep_ch_failover "$rest"
+}
+
+curl_exe=$(dep_ch_failover "curl_firefox135,curl_chrome136,curl_chrome116,curl_ff117,curl") || curl_exe="curl"
+
+# SCRAPING HELPERS (Bypassing Cloudflare because my job applications are getting rejected anyway)
+
+# shellcheck disable=SC2086
+anidb_curl() {
+    $curl_exe -sL -A "$agent" --max-time 10 $cipher_flag "$@"
+}
+
+# PREVIEW ENGINE (Microsecond caching so fzf doesn't choke on my ADHD scrolling)
+
+preview_anime() {
+    _id="$1"
+    [ -z "$_id" ] && exit 0
+    _cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli/preview"
+    [ ! -d "$_cache_dir" ] && mkdir -p "$_cache_dir"
+    _cache_txt="$_cache_dir/${_id}.txt"
+
+    if [ -s "$_cache_txt" ]; then
+        cat "$_cache_txt"
+        exit 0
+    fi
+
+    # shellcheck disable=SC2059
+    _page="$(anidb_curl "$(printf "$desc_api" "$_id")")"
+    _title="$(printf "%s" "$_page" | sed -nE 's|.*<title>([^<]+)</title>.*|\1|p' | sed 's| - AniDB.*||; s|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
+    [ -z "$_title" ] && _title="$_id"
+
+    _img="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:image" content="([^"]+)".*|\1|p' | head -n 1)"
+    _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
+    [ -z "$_desc" ] && _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta name="description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
+    [ -z "$_desc" ] && _desc="No description available."
+
+    _mal_id="$(printf "%s" "$_page" | sed -nE 's|.*https://myanimelist.net/anime/([0-9]+)/.*|\1|p' | head -n 1)"
+
+    {
+        if [ "$thumbnail_preview" = 1 ] && [ -n "$_img" ]; then
+            _img_file="$_cache_dir/${_id}.jpg"
+            if [ ! -s "$_img_file" ]; then
+                $curl_exe -sL -A "$agent" --max-time 5 "$_img" -o "$_img_file" 2>/dev/null || true
+            fi
+            if [ -s "$_img_file" ]; then
+                if command -v chafa >/dev/null 2>&1; then
+                    chafa --size=38x18 "$_img_file" 2>/dev/null || true
+                elif command -v catimg >/dev/null 2>&1; then
+                    catimg -w 76 -H 18 "$_img_file" 2>/dev/null || true
+                fi
+            fi
+        fi
+
+        printf "\033[1;36m%s\033[0m\n" "$_title"
+        [ -n "$_mal_id" ] && printf "\033[1;33mMyAnimeList ID:\033[0m %s\n" "$_mal_id"
+        printf "\n\033[1;32mSynopsis:\033[0m\n"
+        if command -v fold >/dev/null 2>&1; then
+            printf "%s\n" "$_desc" | fold -s -w 50
+        elif command -v fmt >/dev/null 2>&1; then
+            printf "%s\n" "$_desc" | fmt -w 50
+        else
+            printf "%s\n" "$_desc"
+        fi
+    } >"$_cache_txt"
+
+    cat "$_cache_txt"
+    exit 0
+}
+
+# FAST PATH FOR INTERNAL FZF PREVIEW HELPER
+if [ "$1" = "--preview-anime" ]; then
+    thumbnail_preview="${ANI_CLI_THUMBNAILS:-1}"
+    preview_anime "$2"
+fi
 
 # UI
 
@@ -15,6 +110,7 @@ menu() {
     esac
 }
 
+# shellcheck disable=SC2086
 # provide menu. input format is either (ep_list) or (number \t anime_id \t anime_name)
 nth() {
     _stdin=$(cat -)
@@ -23,7 +119,11 @@ nth() {
     [ "$_line_count" -eq 1 ] && printf "%s" "$_stdin" | cut -f 2,3 && return 0
     _prompt="$1"
     [ $# -ne 1 ] && _multi_flag="$2"
-    _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
+    if [ "$menu_program" = "fzf" ] && [ "$preview_enabled" = 1 ] && printf "%s\n" "$_stdin" | head -n 1 | grep -q '	'; then
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$0\" --preview-anime {2}" --preview-window "right:50%:wrap" | cut -f 1)
+    else
+        _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
+    fi
     _line_start=$(printf "%s" "$_line" | head -n 1)
     _line_end=$(printf "%s" "$_line" | tail -n 1)
     [ -n "$_line" ] || return 1
@@ -65,6 +165,8 @@ help_info() {
         Select nth entry
       -q, --quality
         Specify the video quality
+      -t, --trending
+        Browse seasonal and trending anime
       -v, --vlc
         Use VLC to play the video
       -V, --version
@@ -81,6 +183,10 @@ help_info() {
         Use dmenu instead of fzf for the interactive menu
       --skip
         Use ani-skip to skip the intro of the episode (mpv only)
+      --no-preview
+        Disable interactive preview pane in fzf
+      --no-thumb
+        Disable thumbnail image rendering in preview
       --no-detach
         Don't detach the player (useful for in-terminal playback, mpv only)
       --exit-after-play
@@ -131,27 +237,12 @@ dep_ch() {
     command -v "$1" >/dev/null || die "Program $1 not found. Please install it."
 }
 
-# checks for deps in order and returns the first available. format is "prog_a,prog_b,prog_c"
-dep_ch_failover() {
-    [ -z "$1" ] && return 1
-    prog=$(printf "%s" "$1" | cut -d "," -f 1)
-    rest=$(printf "%s" "$1" | cut -s -d "," -f 2-)
-    command -v "$prog" >/dev/null 2>&1 && printf "%s" "$prog" && return 0
-    [ -e "$prog" ] && printf "%s" "$prog" && return 0
-    dep_ch_failover "$rest"
-}
-
 cleanup() {
     tput sgr0               # clears colors
     rm -f "${histfile}.new" # remove temp logfile
 }
 
 # SCRAPING
-
-#shellcheck disable=SC2086
-anidb_curl() {
-    $curl_exe -sL -A "$agent" --max-time 10 $cipher_flag "$@"
-}
 
 # search the query and give results. format is (id \t name)
 anidb_search() {
@@ -375,26 +466,65 @@ play() {
     [ "$player_function" != "debug" ] && [ "$player_function" != "download" ] && tput rc && tput ed
 }
 
+# TRENDING & DASHBOARD
+
+trending_anime() {
+    info "Fetching trending / seasonal anime..."
+    _page="$($curl_exe -s "https://animeschedule.net/api/v3/anime")"
+    _list="$(printf "%s" "$_page" | sed 's|},{"id"|\n|g' | sed -nE 's|.*"title":"([^"]+)".*|\1|p' | head -n 30)"
+    [ -z "$_list" ] && die "Failed to fetch trending anime!"
+    _selected="$(printf "%s\n" "$_list" | menu "Select Trending Anime: " "" "$menu_extra_flags")"
+    [ -z "$_selected" ] && exit 0
+    query="$_selected"
+}
+
+home_menu() {
+    _has_hist=0
+    [ -s "$histfile" ] && _has_hist=1
+
+    _options="1. Search Anime"
+    [ "$_has_hist" = 1 ] && _options="${_options}
+2. Continue Watching"
+    _options="${_options}
+3. Seasonal & Trending Anime
+4. Release Countdown (-N)
+5. Clear History
+6. Exit"
+
+    _choice=$(printf "%s\n" "$_options" | menu "ani-cli > " "" "$menu_extra_flags" | cut -d "." -f 1 | tr -d "[:space:]")
+    case "$_choice" in
+        1)
+            # Proceed to search prompt
+            ;;
+        2)
+            source=history
+            ;;
+        3)
+            source=trending
+            ;;
+        4)
+            source=nextep
+            ;;
+        5)
+            : >"$histfile"
+            info "History deleted."
+            exit 0
+            ;;
+        6 | *)
+            exit 0
+            ;;
+    esac
+}
+
 # MAIN
-
-# setup
-base_api="https://anidb.app"
-search_api="${base_api}/browse?q=%s"
-# search_api_alt="${base_api}/search/suggestions?q=%s"
-desc_api="${base_api}/anime/%s"
-episodes_api="${base_api}/api/frontend/anime/%s/episodes"
-m3u8_api="${base_api}/api/frontend/episode/%s/languages"
-
-ciphers='ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305'
-tls13_ciphers='TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
 mode="${ANI_CLI_MODE:-sub}"
 download_dir="${ANI_CLI_DOWNLOAD_DIR:-.}"
 log_episode="${ANI_CLI_LOG:-1}"
 quality="${ANI_CLI_QUALITY:-best}"
-
-curl_exe=$(dep_ch_failover "curl_firefox135,curl_chrome136,curl_chrome116,curl_ff117,curl") || die "Program curl not found"
+preview_enabled="${ANI_CLI_PREVIEW:-1}"
+thumbnail_preview="${ANI_CLI_THUMBNAILS:-1}"
+home_dashboard="${ANI_CLI_HOME:-1}"
 
 case "$(uname -a | cut -d " " -f 1,3-)" in
     *Darwin*)
@@ -484,6 +614,12 @@ while [ $# -gt 0 ]; do
             ep_no="$2"
             shift
             ;;
+        -t | --trending) source=trending ;;
+        --no-preview) preview_enabled=0 ;;
+        --no-thumb) thumbnail_preview=0 ;;
+        --preview-anime)
+            preview_anime "$2"
+            ;;
         --dub) mode="dub" ;;
         --no-detach) no_detach=1 ;;
         --exit-after-play) exit_after_play=1 && no_detach=1 ;;
@@ -508,7 +644,7 @@ info "Checking dependencies..."
 dep_ch "sed"
 dep_ch "grep"
 [ "$skip_intro" = 1 ] && dep_ch "ani-skip"
-dep_ch "$menu_program" # TODO: use dep_ch_failover to iterate through options
+dep_ch "$menu_program"
 
 case "$player_function" in
     debug) ;;
@@ -521,6 +657,11 @@ esac
 
 # idk where to put this, so I put it here...
 trap 'cleanup; exit 1' INT HUP TERM
+
+# home dashboard on zero arguments
+if [ -z "$query" ] && [ "$source" = "search" ] && [ "$home_dashboard" = 1 ] && [ -t 0 ]; then
+    home_menu
+fi
 
 # searching
 case "$source" in
@@ -537,6 +678,22 @@ case "$source" in
         episode_maps="$(anidb_episodes "$anime_id")"
         ep_list="$(printf "%s" "$episode_maps" | cut -f 2)"
         ep_no=$(printf "%s" "$anime_list" | grep "^$anime_id	" | sed -nE 's/.*- episode (.+)$/\1/p')
+        ;;
+    trending)
+        trending_anime
+        query=$(printf "%s" "$query" | sed 's| |+|g')
+        anime_list=$(anidb_search "$query")
+        [ -z "$anime_list" ] && die "No results found!"
+        [ "$index" -eq "$index" ] 2>/dev/null && result=$(printf "%s" "$anime_list" | sed -n "${index}p")
+        [ -z "$index" ] && result=$(printf "%s" "$anime_list" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select anime: ")
+        [ -z "$result" ] && die "Invalid anime selection"
+        anime_title="$(printf "%s" "$result" | cut -f 2)"
+        anime_id="$(printf "%s" "$result" | cut -f 1)"
+        anidb_desc "$anime_id" || true
+        episode_maps="$(anidb_episodes "$anime_id")"
+        ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
+        [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
+        [ -z "$ep_no" ] && die "Invalid episode selection"
         ;;
     *)
         if [ "$menu_program" = "fzf" ]; then

--- a/ani-cli
+++ b/ani-cli
@@ -116,8 +116,8 @@ preview_anime() {
 _write_preview_helper() {
     _helper="$_preview_cache_dir/preview_helper.sh"
     [ ! -d "$_preview_cache_dir" ] && mkdir -p "$_preview_cache_dir"
-    # Regenerate only when the cached helper is missing or version has changed
-    if [ ! -x "$_helper" ]; then
+    # Regenerate whenever helper is missing, version changes, or ani-cli is updated
+    if [ ! -x "$_helper" ] || [ "$0" -nt "$_helper" ]; then
         cat >"$_helper" <<HELPER
 #!/bin/sh
 # Minimal ani-cli preview helper v${version_number} — do NOT edit, auto-generated
@@ -167,7 +167,7 @@ _img_viewer="\$(command -v chafa || command -v chafa.exe || command -v catimg ||
   [ -n "\$_genres" ] && printf '\033[1;37mGenres:\033[0m %s\n' "\$_genres"
   [ -n "\$_mal_id" ] && printf '\033[1;30mMAL ID: %s\033[0m\n' "\$_mal_id"
   printf '\n\033[1;32mSynopsis:\033[0m\n'
-  printf '%s\n' "\$_desc" | fold -s -w 55 2>/dev/null || printf '%s\n' "\$_desc"
+  printf '%s\n' "\$_desc"
 } >"\$_cache_txt"
 exec cat "\$_cache_txt"
 HELPER
@@ -208,7 +208,7 @@ nth() {
         # Use tiny standalone helper instead of forking full $0 — prevents Win32 error 299
         # (cygheap read copy failed) on MSYS2/Git Bash which can't reliably fork large processes
         _preview_helper="$(_write_preview_helper)"
-        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "right:55%:wrap" | cut -f 1)
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "right:25%:wrap:border-left" --bind 'focus:refresh-preview' | cut -f 1)
     else
         _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
     fi
@@ -352,11 +352,23 @@ anidb_desc() {
     [ -n "$seasons" ] && seasons_option="\nchange_season"
 }
 
-# get the episodes list of the selected anime. format is (id \t ep_no)
+# get the episodes list of the selected anime. format is (ep_id \t ep_no) for internal use.
+# also exported as ep_no \t ep_id \t ep_title for display — see anidb_episode_display()
 anidb_episodes() {
     #shellcheck disable=SC2059
     _page="$(anidb_curl "$(printf "$episodes_api" "${1##*-}")")"
     printf "%s" "$_page" | sed 's|},{|}\n{|g' | sed -nE 's|.*"id":([0-9]+).*"number":([0-9]+).*|\1\t\2|p'
+}
+
+# Get episodes formatted for fzf display: ep_no - ep_title (plain, no tabs so no preview fires)
+anidb_episode_display() {
+    #shellcheck disable=SC2059
+    _page="$(anidb_curl "$(printf "$episodes_api" "${1##*-}")")"
+    # Try to pull title from JSON. Falls back to just number if field absent.
+    printf "%s" "$_page" | sed 's|},{|}\n{|g' |
+        sed -nE 's|.*"number":([0-9]+).*"title":"([^"]+)".*|\1 - \2|p; \
+                 t; \
+                 s|.*"number":([0-9]+).*|\1|p'
 }
 
 # extract the individual m3u8 links from response of embed urls
@@ -399,46 +411,68 @@ get_video_link() {
     fi
 }
 
-# provide countdown for the next episode release both sub and dub
+# provide countdown for the next episode release both sub and dub.
+# shows fzf picker first so user can choose the right show, not dump all 20 matches.
 time_until_next_ep() {
     animeschedule="https://animeschedule.net"
     _query="$(printf "%s" "$*" | tr ' ' '+')"
-    $curl_exe -s -G "$animeschedule/api/v3/anime" --data "q=${_query}" | sed 's|},{"id"|\n|g' | while read -r _entry; do
-        _route=$(printf "%s" "$_entry" | sed -nE 's|.*"route":"([^"]*)",.*|\1|p')
-        _eng_title=$(printf '%s' "$_entry" | sed -nE 's|.*"english":"([^"]*)".*|\1|p')
-        [ -z "$_eng_title" ] && _eng_title=$(printf '%s' "$_entry" | sed -nE 's|.*,"title":"([^"]*)".*|\1|p')
-        [ -z "$_eng_title" ] && _eng_title="N/A"
-        _jpn_title=$(printf '%s' "$_entry" | sed -nE 's|.*"romaji":"([^"]*)".*|\1|p')
-        [ -z "$_jpn_title" ] && _jpn_title="N/A"
-        _status=$(printf '%s' "$_entry" | sed -nE 's|.*"status":"([^"]*)".*|\1|p')
-        [ -z "$_status" ] && _status="Unknown"
+    _raw="$($curl_exe -s -G "$animeschedule/api/v3/anime" --data "q=${_query}")"
+    [ -z "$_raw" ] && info "Could not reach animeschedule.net" && return 0
 
-        case "$_status" in
-            Ongoing) _color="33" ;;
-            Finished) _color="32" ;;
-            *) _color="36" ;;
-        esac
+    # Build a picker list: index\troute\tdisplay_name
+    _pick_list="$(printf "%s" "$_raw" | sed 's|},{"id"|\n|g' |
+        awk 'BEGIN{i=1} {
+            route=""; eng=""; jpn=""; status=""
+            match($0, /"route":"([^"]+)"/, a); route=a[1]
+            match($0, /"english":"([^"]+)"/, a); eng=a[1]
+            if (!eng) { match($0, /,"title":"([^"]+)"/, a); eng=a[1] }
+            match($0, /"romaji":"([^"]+)"/, a); jpn=a[1]
+            match($0, /"status":"([^"]+)"/, a); status=a[1]
+            if (route) { printf "%d\t%s\t%s (%s) [%s]\n", i, route, eng, jpn, status; i++ }
+        }')"
 
-        printf "Eng: %s\n" "$_eng_title"
-        printf "Jpn: %s\n" "$_jpn_title"
-        printf "Status: \033[1;%sm%s\033[0m\n" "$_color" "$_status"
+    [ -z "$_pick_list" ] && info "No results found for: $*" && return 0
 
-        if [ "$_status" != "Finished" ]; then
-            _page="$($curl_exe -s "$animeschedule/anime/$_route")"
-            _sub_ep=$(printf "%s" "$_page" | sed -nE 's|.*release-time-type-subs"[^>]*><span class="release-time-episode-number">Episode ([0-9]+)</span>.*|\1|p' | head -n 1)
-            _dub_ep=$(printf "%s" "$_page" | sed -nE 's|.*release-time-type-dub"[^>]*><span class="release-time-episode-number">Episode ([0-9]+)</span>.*|\1|p' | head -n 1)
-            _sub_countdown=$(printf "%s" "$_page" | sed -nE 's|.*class="countdown-time" datetime="([^"]*)".*|\1|p' | head -n 1)
-            _dub_countdown=$(printf "%s" "$_page" | sed -nE 's|.*class="countdown-time countdown-time-dub" datetime="([^"]*)".*|\1|p' | head -n 1)
+    # If only one result, skip picker
+    _pick_count="$(printf "%s\n" "$_pick_list" | wc -l | tr -d '[:space:]')"
+    if [ "$_pick_count" -eq 1 ]; then
+        _route="$(printf "%s" "$_pick_list" | cut -f 2)"
+        _label="$(printf "%s" "$_pick_list" | cut -f 3)"
+    else
+        _selected="$(printf "%s\n" "$_pick_list" |
+            fzf --reverse --cycle --prompt "Pick show for countdown: " --height=60% --layout=reverse --border \
+                --delimiter='\t' --with-nth=1,3)"
+        [ -z "$_selected" ] && return 0
+        _route="$(printf "%s" "$_selected" | cut -f 2)"
+        _label="$(printf "%s" "$_selected" | cut -f 3)"
+    fi
 
-            [ -n "$_sub_ep" ] && [ -n "$_sub_countdown" ] &&
-                printf "Next Sub: Episode %s in \033[1;%sm%s\033[0m\n" "$_sub_ep" "$_color" "$_sub_countdown" || printf "Next Sub: N/A\n"
-            [ -n "$_dub_ep" ] && [ -n "$_dub_countdown" ] &&
-                printf "Next Dub: Episode %s in \033[1;%sm%s\033[0m\n" "$_dub_ep" "$_color" "$_dub_countdown" || printf "Next Dub: N/A\n"
-        fi
-        printf "\n"
-    done
-    # DON'T exit 0 here. We are not a god. We return like a normal function
-    # so the caller can decide whether to loop back or crawl into a corner and cry.
+    printf "\033[1;36m%s\033[0m\n" "$_label"
+    _entry="$(printf "%s" "$_raw" | sed 's|},{"id"|\n|g' | grep "\"route\":\"${_route}\"")"
+    _status="$(printf "%s" "$_entry" | sed -nE 's|.*"status":"([^"]*)".*|\1|p')"
+
+    case "$_status" in
+        Ongoing) _color="33" ;;
+        Finished) _color="32" ;;
+        *) _color="36" ;;
+    esac
+    printf "Status: \033[1;%sm%s\033[0m\n" "$_color" "${_status:-Unknown}"
+
+    if [ "$_status" != "Finished" ]; then
+        _page="$($curl_exe -s "$animeschedule/anime/$_route")"
+        _sub_ep=$(printf "%s" "$_page" | sed -nE 's|.*release-time-type-subs"[^>]*><span class="release-time-episode-number">Episode ([0-9]+)</span>.*|\1|p' | head -n 1)
+        _dub_ep=$(printf "%s" "$_page" | sed -nE 's|.*release-time-type-dub"[^>]*><span class="release-time-episode-number">Episode ([0-9]+)</span>.*|\1|p' | head -n 1)
+        _sub_countdown=$(printf "%s" "$_page" | sed -nE 's|.*class="countdown-time" datetime="([^"]*)".*|\1|p' | head -n 1)
+        _dub_countdown=$(printf "%s" "$_page" | sed -nE 's|.*class="countdown-time countdown-time-dub" datetime="([^"]*)".*|\1|p' | head -n 1)
+        [ -n "$_sub_ep" ] && [ -n "$_sub_countdown" ] &&
+            printf "Next Sub: Episode %s in \033[1;%sm%s\033[0m\n" "$_sub_ep" "$_color" "$_sub_countdown" ||
+            printf "Next Sub: N/A\n"
+        [ -n "$_dub_ep" ] && [ -n "$_dub_countdown" ] &&
+            printf "Next Dub: Episode %s in \033[1;%sm%s\033[0m\n" "$_dub_ep" "$_color" "$_dub_countdown" ||
+            printf "Next Dub: N/A\n"
+    else
+        printf "This show is finished airing. No upcoming episodes.\n"
+    fi
     return 0
 }
 
@@ -803,7 +837,7 @@ while true; do
             anidb_desc "$anime_id" || true
             episode_maps="$(anidb_episodes "$anime_id")"
             ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-            [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
+            [ -z "$ep_no" ] && ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p')
             if [ -z "$ep_no" ]; then
                 unset query index
                 source="search"
@@ -853,7 +887,7 @@ while true; do
             anidb_desc "$anime_id" || true
             episode_maps="$(anidb_episodes "$anime_id")"
             ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-            [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
+            [ -z "$ep_no" ] && ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p')
             if [ -z "$ep_no" ]; then
                 unset query index
                 source="search"
@@ -879,7 +913,7 @@ while cmd=$(printf "next\nreplay\nprevious\nselect$seasons_option\nchange_qualit
         next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
         replay) video_link="$replay" ;;
         previous) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{g;1!p;};h") 2>/dev/null ;;
-        select) ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag") ;;
+        select) ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p') ;;
         change_season)
             new_anime="$(printf "%s" "$seasons" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select season: ")"
             [ -z "$new_anime" ] && die "Invalid season selection"
@@ -888,7 +922,7 @@ while cmd=$(printf "next\nreplay\nprevious\nselect$seasons_option\nchange_qualit
             anidb_desc "$anime_id" || true
             episode_maps="$(anidb_episodes "$anime_id")"
             ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-            ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
+            ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p')
             [ -z "$ep_no" ] && die "Invalid episode selection"
             ;;
         change_quality)

--- a/ani-cli
+++ b/ani-cli
@@ -80,8 +80,8 @@ preview_anime() {
             fi
             if [ -s "$_img_file" ]; then
                 case "$_img_viewer" in
-                    *chafa*) "$_img_viewer" --size=36x18 "$_img_file" 2>/dev/null || true ;;
-                    *catimg*) "$_img_viewer" -w 72 -H 18 "$_img_file" 2>/dev/null || true ;;
+                    *chafa*) "$_img_viewer" --format=symbols --size=22x8 --colors=256 "$_img_file" 2>/dev/null || true ;;
+                    *catimg*) "$_img_viewer" -w 44 -H 8 "$_img_file" 2>/dev/null || true ;;
                     *) ;;
                 esac
             fi
@@ -155,7 +155,7 @@ _img_viewer="\$(command -v chafa || command -v chafa.exe || which chafa || which
     [ ! -s "\$_img_file" ] && \$curl_exe -sL -A "\$agent" --max-time 5 "\$_img" -o "\$_img_file" 2>/dev/null || true
     if [ -s "\$_img_file" ]; then
       case "\$_img_viewer" in
-        *chafa*)  "\$_img_viewer" --size=22x8 --colors=256 "\$_img_file" 2>/dev/null || true ;;
+        *chafa*)  "\$_img_viewer" --format=symbols --size=22x8 --colors=256 "\$_img_file" 2>/dev/null || true ;;
         *catimg*) "\$_img_viewer" -w 44 -H 8 "\$_img_file" 2>/dev/null || true ;;
         *) ;;
       esac

--- a/ani-cli
+++ b/ani-cli
@@ -34,14 +34,16 @@ anidb_curl() {
     $curl_exe -sL -A "$agent" --max-time 10 $cipher_flag "$@"
 }
 
-# PREVIEW ENGINE (Microsecond caching so fzf doesn't choke on my ADHD scrolling)
+## PREVIEW ENGINE (Microsecond caching so fzf doesn't choke on my ADHD scrolling)
+# Cache is version-stamped so stale pre-fix data gets purged automatically
+
+_preview_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli/preview/${version_number}"
 
 preview_anime() {
     _id="$1"
     [ -z "$_id" ] && exit 0
-    _cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/ani-cli/preview"
-    [ ! -d "$_cache_dir" ] && mkdir -p "$_cache_dir"
-    _cache_txt="$_cache_dir/${_id}.txt"
+    [ ! -d "$_preview_cache_dir" ] && mkdir -p "$_preview_cache_dir"
+    _cache_txt="$_preview_cache_dir/${_id}.txt"
 
     if [ -s "$_cache_txt" ]; then
         cat "$_cache_txt"
@@ -61,9 +63,9 @@ preview_anime() {
     _score="$(printf "%s" "$_page" | sed -nE 's|.*<svg.*class=".*text-yellow-400".*<\/svg>([0-9.]+)<.*|\1|p' | head -n 1)"
     _status="$(printf "%s" "$_page" | sed -nE 's|.*href="/browse\?status=[^"]*"[^>]*>([^<]+)<.*|\1|p' | head -n 1)"
     _type="$(printf "%s" "$_page" | sed -nE 's|.*href="/browse\?type=[^"]*"[^>]*>([^<]+)<.*|\1|p' | head -n 1)"
-    _genres="$(printf "%s" "$_page" | sed -n '/<div class="flex flex-wrap gap-1.5 mb-4">/,/<\/div>/p' | sed -nE 's|.*>([^<]+)</a>.*|\1|p' | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
+    _genres="$(printf "%s" "$_page" | sed -n '/<div class="flex flex-wrap gap-1.5 mb-4">/,/<\/div>/p' | sed -nE 's|.*>([^<]+)<\/a>.*|\1|p' | tr '\n' ',' | sed 's/,$//; s/,/, /g')"
 
-    _desc="$(printf "%s" "$_page" | sed -n '/>Synopsis</,/\/p>/p' | sed -nE 's|.*<p class="text-sm text-faint leading-relaxed">(.*)</p>.*|\1|p' | sed 's|<br><br>|\n\n|g; s|<br>|\n|g; s|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g')"
+    _desc="$(printf "%s" "$_page" | sed -n '/>Synopsis</,/\/p>/p' | sed -nE 's|.*<p class="text-sm text-faint leading-relaxed">(.*)<\/p>.*|\1|p' | sed 's|<br><br>|\n\n|g; s|<br>|\n|g; s|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g')"
     [ -z "$_desc" ] && _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta property="og:description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
     [ -z "$_desc" ] && _desc="$(printf "%s" "$_page" | sed -nE 's|.*<meta name="description" content="([^"]+)".*|\1|p' | sed 's|&#039;|'\''|g; s|&quot;|"|g; s|&amp;|\&|g' | head -n 1)"
     [ -z "$_desc" ] && _desc="No description available."
@@ -72,7 +74,7 @@ preview_anime() {
 
     {
         if [ "$thumbnail_preview" = 1 ] && [ -n "$_img" ] && [ -n "$_img_viewer" ]; then
-            _img_file="$_cache_dir/${_id}.jpg"
+            _img_file="$_preview_cache_dir/${_id}.jpg"
             if [ ! -s "$_img_file" ]; then
                 $curl_exe -sL -A "$agent" --max-time 5 "$_img" -o "$_img_file" 2>/dev/null || true
             fi
@@ -106,7 +108,75 @@ preview_anime() {
     exit 0
 }
 
-# FAST PATH FOR INTERNAL FZF PREVIEW HELPER
+# FAST PATH — ani-cli --preview-anime <id>
+# Keep this block TINY. Forking $0 (the full script) on MSYS2/Windows causes
+# Win32 error 299 (cygheap read copy failed) because MSYS2 has to clone the
+# entire address space. Instead we write a minimal helper to disk and call that.
+# This function bakes the helper; nth() points fzf at it.
+_write_preview_helper() {
+    _helper="$_preview_cache_dir/preview_helper.sh"
+    [ ! -d "$_preview_cache_dir" ] && mkdir -p "$_preview_cache_dir"
+    # Regenerate only when the cached helper is missing or version has changed
+    if [ ! -x "$_helper" ]; then
+        cat >"$_helper" <<HELPER
+#!/bin/sh
+# Minimal ani-cli preview helper v${version_number} — do NOT edit, auto-generated
+base_api="${base_api}"
+desc_api="${desc_api}"
+agent="${agent}"
+curl_exe="${curl_exe}"
+cipher_flag="${cipher_flag:-}"
+thumbnail_preview="\${ANI_CLI_THUMBNAILS:-1}"
+_id="\$1"
+[ -z "\$_id" ] && exit 0
+_cache_dir="${_preview_cache_dir}"
+_cache_txt="\$_cache_dir/\${_id}.txt"
+[ -s "\$_cache_txt" ] && exec cat "\$_cache_txt"
+# shellcheck disable=SC2059
+_page="\$(\$curl_exe -sL -A "\$agent" --max-time 10 \$cipher_flag "\$(printf "\$desc_api" "\$_id")")"
+_title="\$(printf '%s' "\$_page" | sed -nE 's|.*<h1[^>]*>([^<]+)</h1>.*|\\1|p' | head -n 1)"
+[ -z "\$_title" ] && _title="\$(printf '%s' "\$_page" | sed -nE 's|.*<title>([^<]+)</title>.*|\\1|p' | sed 's| - AniDB.*||' | head -n 1)"
+[ -z "\$_title" ] && _title="\$_id"
+_img="\$(printf '%s' "\$_page" | sed -nE 's|.*src="([^"]*/poster/[^"]+)".*|\\1|p' | head -n 1)"
+_mal_id="\$(printf '%s' "\$_page" | sed -nE 's|.*myanimelist.net/anime/([0-9]+)/.*|\\1|p' | head -n 1)"
+_score="\$(printf '%s' "\$_page" | sed -nE 's|.*text-yellow-400".*<\/svg>([0-9.]+)<.*|\\1|p' | head -n 1)"
+_status="\$(printf '%s' "\$_page" | sed -nE 's|.*browse\?status=[^"]*"[^>]*>([^<]+)<.*|\\1|p' | head -n 1)"
+_type="\$(printf '%s' "\$_page" | sed -nE 's|.*browse\?type=[^"]*"[^>]*>([^<]+)<.*|\\1|p' | head -n 1)"
+_genres="\$(printf '%s' "\$_page" | sed -n '/<div class="flex flex-wrap gap-1.5 mb-4">/,/<\/div>/p' | sed -nE 's|.*>([^<]+)<\/a>.*|\\1|p' | tr '\n' ',' | sed 's/,\$//')"
+_desc="\$(printf '%s' "\$_page" | sed -n '/>Synopsis</,/\/p>/p' | sed -nE 's|.*<p class="text-sm text-faint leading-relaxed">(.*)<\/p>.*|\\1|p' | sed 's|<br><br>|\n\n|g; s|<br>|\n|g; s|&#039;|'"'"'|g; s|&amp;|\&|g')"
+[ -z "\$_desc" ] && _desc="\$(printf '%s' "\$_page" | sed -nE 's|.*og:description" content="([^"]+)".*|\\1|p' | head -n 1)"
+[ -z "\$_desc" ] && _desc="No description available."
+_img_viewer="\$(command -v chafa || command -v chafa.exe || command -v catimg || command -v catimg.exe || true)"
+{
+  if [ "\$thumbnail_preview" = 1 ] && [ -n "\$_img" ] && [ -n "\$_img_viewer" ]; then
+    _img_file="\$_cache_dir/\${_id}.jpg"
+    [ ! -s "\$_img_file" ] && \$curl_exe -sL -A "\$agent" --max-time 5 "\$_img" -o "\$_img_file" 2>/dev/null || true
+    if [ -s "\$_img_file" ]; then
+      case "\$_img_viewer" in
+        *chafa*)  "\$_img_viewer" --size=36x18 "\$_img_file" 2>/dev/null || true ;;
+        *catimg*) "\$_img_viewer" -w 72 -H 18 "\$_img_file" 2>/dev/null || true ;;
+        *) ;;
+      esac
+    fi
+  fi
+  printf '\033[1;36m%s\033[0m\n' "\$_title"
+  [ -n "\$_score" ]  && printf '\033[1;33mScore:\033[0m %s  ' "\$_score"
+  [ -n "\$_status" ] && printf '\033[1;35mStatus:\033[0m %s  ' "\$_status"
+  [ -n "\$_type" ]   && printf '\033[1;34mType:\033[0m %s' "\$_type"
+  { [ -n "\$_score" ] || [ -n "\$_status" ] || [ -n "\$_type" ]; } && printf '\n'
+  [ -n "\$_genres" ] && printf '\033[1;37mGenres:\033[0m %s\n' "\$_genres"
+  [ -n "\$_mal_id" ] && printf '\033[1;30mMAL ID: %s\033[0m\n' "\$_mal_id"
+  printf '\n\033[1;32mSynopsis:\033[0m\n'
+  printf '%s\n' "\$_desc" | fold -s -w 55 2>/dev/null || printf '%s\n' "\$_desc"
+} >"\$_cache_txt"
+exec cat "\$_cache_txt"
+HELPER
+        chmod +x "$_helper"
+    fi
+    printf "%s" "$_helper"
+}
+
+# Fast path: still support direct --preview-anime for backward compat / manual calls
 if [ "$1" = "--preview-anime" ]; then
     thumbnail_preview="${ANI_CLI_THUMBNAILS:-1}"
     preview_anime "$2"
@@ -135,7 +205,10 @@ nth() {
     _prompt="$1"
     [ $# -ne 1 ] && _multi_flag="$2"
     if [ "$menu_program" = "fzf" ] && [ "$preview_enabled" = 1 ] && printf "%s\n" "$_stdin" | head -n 1 | grep -q '	'; then
-        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$0\" --preview-anime {2}" --preview-window "right:55%:wrap" | cut -f 1)
+        # Use tiny standalone helper instead of forking full $0 — prevents Win32 error 299
+        # (cygheap read copy failed) on MSYS2/Git Bash which can't reliably fork large processes
+        _preview_helper="$(_write_preview_helper)"
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "right:55%:wrap" | cut -f 1)
     else
         _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -153,19 +153,20 @@ _img_viewer="\$(command -v chafa || command -v chafa.exe || command -v catimg ||
     [ ! -s "\$_img_file" ] && \$curl_exe -sL -A "\$agent" --max-time 5 "\$_img" -o "\$_img_file" 2>/dev/null || true
     if [ -s "\$_img_file" ]; then
       case "\$_img_viewer" in
-        *chafa*)  "\$_img_viewer" --size=28x12 --colors=256 "\$_img_file" 2>/dev/null || true ;;
-        *catimg*) "\$_img_viewer" -w 56 -H 12 "\$_img_file" 2>/dev/null || true ;;
+        *chafa*)  "\$_img_viewer" --size=22x8 --colors=256 "\$_img_file" 2>/dev/null || true ;;
+        *catimg*) "\$_img_viewer" -w 44 -H 8 "\$_img_file" 2>/dev/null || true ;;
         *) ;;
       esac
     fi
   fi
   printf '\033[1;36m%s\033[0m\n' "\$_title"
-  [ -n "\$_score" ]  && printf '\033[1;33mScore:\033[0m %s  ' "\$_score"
-  [ -n "\$_status" ] && printf '\033[1;35mStatus:\033[0m %s  ' "\$_status"
-  [ -n "\$_type" ]   && printf '\033[1;34mType:\033[0m %s' "\$_type"
-  { [ -n "\$_score" ] || [ -n "\$_status" ] || [ -n "\$_type" ]; } && printf '\n'
+  _meta=""
+  [ -n "\$_score" ] && _meta="\033[1;33m★ \$_score\033[0m"
+  [ -n "\$_type" ] && _meta="\${_meta:+\$_meta | }\033[1;34m\$_type\033[0m"
+  [ -n "\$_status" ] && _meta="\${_meta:+\$_meta | }\033[1;35m\$_status\033[0m"
+  [ -n "\$_mal_id" ] && _meta="\${_meta:+\$_meta | }\033[1;30mMAL:\$_mal_id\033[0m"
+  [ -n "\$_meta" ] && printf '%b\n' "\$_meta"
   [ -n "\$_genres" ] && printf '\033[1;37mGenres:\033[0m %s\n' "\$_genres"
-  [ -n "\$_mal_id" ] && printf '\033[1;30mMAL ID: %s\033[0m\n' "\$_mal_id"
   printf '\n\033[1;32mSynopsis:\033[0m\n'
   printf '%s\n' "\$_desc"
 } >"\$_cache_txt"
@@ -208,7 +209,8 @@ nth() {
         # Use tiny standalone helper instead of forking full $0 — prevents Win32 error 299
         # (cygheap read copy failed) on MSYS2/Git Bash which can't reliably fork large processes
         _preview_helper="$(_write_preview_helper)"
-        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "right:40%:wrap:border-left" --bind 'focus:refresh-preview' | cut -f 1)
+        _preview_win="${ANI_CLI_PREVIEW_WINDOW:-right:40%:wrap:border-left}"
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=85% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "$_preview_win" --bind 'focus:refresh-preview,ctrl-d:preview-page-down,ctrl-u:preview-page-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up' | cut -f 1)
     else
         _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -153,8 +153,8 @@ _img_viewer="\$(command -v chafa || command -v chafa.exe || command -v catimg ||
     [ ! -s "\$_img_file" ] && \$curl_exe -sL -A "\$agent" --max-time 5 "\$_img" -o "\$_img_file" 2>/dev/null || true
     if [ -s "\$_img_file" ]; then
       case "\$_img_viewer" in
-        *chafa*)  "\$_img_viewer" --size=36x18 "\$_img_file" 2>/dev/null || true ;;
-        *catimg*) "\$_img_viewer" -w 72 -H 18 "\$_img_file" 2>/dev/null || true ;;
+        *chafa*)  "\$_img_viewer" --size=28x12 --colors=256 "\$_img_file" 2>/dev/null || true ;;
+        *catimg*) "\$_img_viewer" -w 56 -H 12 "\$_img_file" 2>/dev/null || true ;;
         *) ;;
       esac
     fi
@@ -208,7 +208,7 @@ nth() {
         # Use tiny standalone helper instead of forking full $0 — prevents Win32 error 299
         # (cygheap read copy failed) on MSYS2/Git Bash which can't reliably fork large processes
         _preview_helper="$(_write_preview_helper)"
-        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "right:25%:wrap:border-left" --bind 'focus:refresh-preview' | cut -f 1)
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=80% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "right:40%:wrap:border-left" --bind 'focus:refresh-preview' | cut -f 1)
     else
         _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
     fi
@@ -352,23 +352,11 @@ anidb_desc() {
     [ -n "$seasons" ] && seasons_option="\nchange_season"
 }
 
-# get the episodes list of the selected anime. format is (ep_id \t ep_no) for internal use.
-# also exported as ep_no \t ep_id \t ep_title for display — see anidb_episode_display()
+# get the episodes list of the selected anime. format is (id \t ep_no)
 anidb_episodes() {
     #shellcheck disable=SC2059
     _page="$(anidb_curl "$(printf "$episodes_api" "${1##*-}")")"
     printf "%s" "$_page" | sed 's|},{|}\n{|g' | sed -nE 's|.*"id":([0-9]+).*"number":([0-9]+).*|\1\t\2|p'
-}
-
-# Get episodes formatted for fzf display: ep_no - ep_title (plain, no tabs so no preview fires)
-anidb_episode_display() {
-    #shellcheck disable=SC2059
-    _page="$(anidb_curl "$(printf "$episodes_api" "${1##*-}")")"
-    # Try to pull title from JSON. Falls back to just number if field absent.
-    printf "%s" "$_page" | sed 's|},{|}\n{|g' |
-        sed -nE 's|.*"number":([0-9]+).*"title":"([^"]+)".*|\1 - \2|p; \
-                 t; \
-                 s|.*"number":([0-9]+).*|\1|p'
 }
 
 # extract the individual m3u8 links from response of embed urls
@@ -837,7 +825,7 @@ while true; do
             anidb_desc "$anime_id" || true
             episode_maps="$(anidb_episodes "$anime_id")"
             ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-            [ -z "$ep_no" ] && ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p')
+            [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
             if [ -z "$ep_no" ]; then
                 unset query index
                 source="search"
@@ -887,7 +875,7 @@ while true; do
             anidb_desc "$anime_id" || true
             episode_maps="$(anidb_episodes "$anime_id")"
             ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-            [ -z "$ep_no" ] && ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p')
+            [ -z "$ep_no" ] && ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
             if [ -z "$ep_no" ]; then
                 unset query index
                 source="search"
@@ -913,7 +901,7 @@ while cmd=$(printf "next\nreplay\nprevious\nselect$seasons_option\nchange_qualit
         next) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{n;p;}") 2>/dev/null ;;
         replay) video_link="$replay" ;;
         previous) ep_no=$(printf "%s" "$ep_list" | sed -n "/^${ep_no}$/{g;1!p;};h") 2>/dev/null ;;
-        select) ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p') ;;
+        select) ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag") ;;
         change_season)
             new_anime="$(printf "%s" "$seasons" | nl -w 2 | sed 's/^[[:space:]]//' | nth "Select season: ")"
             [ -z "$new_anime" ] && die "Invalid season selection"
@@ -922,7 +910,7 @@ while cmd=$(printf "next\nreplay\nprevious\nselect$seasons_option\nchange_qualit
             anidb_desc "$anime_id" || true
             episode_maps="$(anidb_episodes "$anime_id")"
             ep_list="$(printf '%s' "$episode_maps" | cut -f 2)"
-            ep_no=$(anidb_episode_display "$anime_id" | menu "Select episode: " "$menu_multi_flag" "$menu_extra_flags" | sed -nE 's|^([0-9.]+).*|\1|p')
+            ep_no=$(printf "%s" "$ep_list" | nth "Select episode: " "$menu_multi_flag")
             [ -z "$ep_no" ] && die "Invalid episode selection"
             ;;
         change_quality)

--- a/ani-cli
+++ b/ani-cli
@@ -134,19 +134,21 @@ _cache_txt="\$_cache_dir/\${_id}.txt"
 [ -s "\$_cache_txt" ] && exec cat "\$_cache_txt"
 # shellcheck disable=SC2059
 _page="\$(\$curl_exe -sL -A "\$agent" --max-time 10 \$cipher_flag "\$(printf "\$desc_api" "\$_id")")"
-_title="\$(printf '%s' "\$_page" | sed -nE 's|.*<h1[^>]*>([^<]+)</h1>.*|\\1|p' | head -n 1)"
-[ -z "\$_title" ] && _title="\$(printf '%s' "\$_page" | sed -nE 's|.*<title>([^<]+)</title>.*|\\1|p' | sed 's| - AniDB.*||' | head -n 1)"
+_title="\$(printf '%s' "\$_page" | sed -nE 's|.*<meta property="og:title" content="([^"]+)".*|\\1|p' | sed 's| [—-] AniDB.*||' | head -n 1)"
+[ -z "\$_title" ] && _title="\$(printf '%s' "\$_page" | sed -nE 's|.*<h1[^>]*>([^<]+)</h1>.*|\\1|p' | head -n 1)"
+[ -z "\$_title" ] && _title="\$(printf '%s' "\$_page" | sed -nE 's|.*<title>([^<]+)</title>.*|\\1|p' | sed 's| [—-] AniDB.*||; s| - AniDB.*||' | head -n 1)"
 [ -z "\$_title" ] && _title="\$_id"
-_img="\$(printf '%s' "\$_page" | sed -nE 's|.*src="([^"]*/poster/[^"]+)".*|\\1|p' | head -n 1)"
+_img="\$(printf '%s' "\$_page" | sed -nE 's|.*<meta property="og:image" content="([^"]+)".*|\\1|p' | head -n 1)"
+[ -z "\$_img" ] && _img="\$(printf '%s' "\$_page" | sed -nE 's|.*src="([^"]*/poster/[^"]+)".*|\\1|p' | head -n 1)"
 _mal_id="\$(printf '%s' "\$_page" | sed -nE 's|.*myanimelist.net/anime/([0-9]+)/.*|\\1|p' | head -n 1)"
 _score="\$(printf '%s' "\$_page" | sed -nE 's|.*text-yellow-400".*<\/svg>([0-9.]+)<.*|\\1|p' | head -n 1)"
 _status="\$(printf '%s' "\$_page" | sed -nE 's|.*browse\?status=[^"]*"[^>]*>([^<]+)<.*|\\1|p' | head -n 1)"
 _type="\$(printf '%s' "\$_page" | sed -nE 's|.*browse\?type=[^"]*"[^>]*>([^<]+)<.*|\\1|p' | head -n 1)"
 _genres="\$(printf '%s' "\$_page" | sed -n '/<div class="flex flex-wrap gap-1.5 mb-4">/,/<\/div>/p' | sed -nE 's|.*>([^<]+)<\/a>.*|\\1|p' | tr '\n' ',' | sed 's/,\$//')"
 _desc="\$(printf '%s' "\$_page" | sed -n '/>Synopsis</,/\/p>/p' | sed -nE 's|.*<p class="text-sm text-faint leading-relaxed">(.*)<\/p>.*|\\1|p' | sed 's|<br><br>|\n\n|g; s|<br>|\n|g; s|&#039;|'"'"'|g; s|&amp;|\&|g')"
-[ -z "\$_desc" ] && _desc="\$(printf '%s' "\$_page" | sed -nE 's|.*og:description" content="([^"]+)".*|\\1|p' | head -n 1)"
+[ -z "\$_desc" ] && _desc="\$(printf '%s' "\$_page" | sed -nE 's|.*og:description" content="([^"]+)".*|\\1|p' | sed 's|&#039;|'"'"'|g; s|&amp;|\&|g' | head -n 1)"
 [ -z "\$_desc" ] && _desc="No description available."
-_img_viewer="\$(command -v chafa || command -v chafa.exe || command -v catimg || command -v catimg.exe || true)"
+_img_viewer="\$(command -v chafa || command -v chafa.exe || which chafa || which chafa.exe || true)"
 {
   if [ "\$thumbnail_preview" = 1 ] && [ -n "\$_img" ] && [ -n "\$_img_viewer" ]; then
     _img_file="\$_cache_dir/\${_id}.jpg"
@@ -210,7 +212,7 @@ nth() {
         # (cygheap read copy failed) on MSYS2/Git Bash which can't reliably fork large processes
         _preview_helper="$(_write_preview_helper)"
         _preview_win="${ANI_CLI_PREVIEW_WINDOW:-right:40%:wrap:border-left}"
-        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=85% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "$_preview_win" --bind 'focus:refresh-preview,ctrl-d:preview-page-down,ctrl-u:preview-page-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up' | cut -f 1)
+        _line=$(printf "%s\n" "$_stdin" | fzf --reverse --cycle --prompt "$_prompt" --height=85% --layout=reverse --border --delimiter='\t' --with-nth=1,3 $_multi_flag $menu_extra_flags --preview "\"$_preview_helper\" {2}" --preview-window "$_preview_win" --bind 'load:refresh-preview,focus:refresh-preview,ctrl-d:preview-page-down,ctrl-u:preview-page-up,ctrl-f:preview-page-down,ctrl-b:preview-page-up' | cut -f 1)
     else
         _line=$(printf "%s" "$_stdin" | cut -f 1,3 | tr '\t' ' ' | menu "$_prompt" "$_multi_flag" "$menu_extra_flags" | cut -d " " -f 1)
     fi

--- a/ani-cli
+++ b/ani-cli
@@ -609,7 +609,12 @@ home_menu() {
     case "$_choice" in
         1)
             source=search
-            unset query
+            if [ "$menu_program" = "fzf" ]; then
+                printf "\33[2K\r\033[1;36mSearch anime: \033[0m" && read -r query
+            else
+                query=$(: | menu "Search anime: " "" "$menu_extra_flags")
+            fi
+            [ -z "$query" ] && return 0
             ;;
         2)
             source=history
@@ -619,13 +624,20 @@ home_menu() {
             ;;
         4)
             source=nextep
+            if [ "$menu_program" = "fzf" ]; then
+                printf "\33[2K\r\033[1;36mCountdown anime: \033[0m" && read -r query
+            else
+                query=$(: | menu "Countdown anime: " "" "$menu_extra_flags")
+            fi
+            [ -z "$query" ] && return 0
             ;;
         5)
             : >"$histfile"
             info "History deleted."
-            exit 0
+            return 0
             ;;
         6 | *)
+            cleanup
             exit 0
             ;;
     esac

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -37,6 +37,9 @@ Show summary of options.
 \fB\-q | --quality\fR \fI\,<best|worst|360|480|720|1080>\/\fR
 Set the video quality. Default quality is best.
 .TP
+\fB\-t | --trending\fR
+Browse seasonal and trending anime.
+.TP
 \fB\-s | --syncplay\fR
 Watch anime together with friends, using Syncplay (works with mpv only).
 .TP
@@ -63,6 +66,12 @@ Use dmenu instead of fzf for the interactive menu
 .TP
 \fB\--skip\fR
 Use ani-skip to skip the intro of the episode (mpv only)
+.TP
+\fB\--no-preview\fR
+Disable interactive preview pane in fzf
+.TP
+\fB\--no-thumb\fR
+Disable thumbnail image rendering in preview
 .TP
 \fB\--no-detach\fR
 Don't detach the player (useful for in-terminal playback, mpv only)
@@ -99,6 +108,15 @@ Controls the frontend of ani-cli. Can be fzf, rofi, dmenu or any other program. 
 \fBANI_CLI_MENU_FLAGS\fR
 Controls the flags for the frontend. Last flag must take prompt as argument. Default is none
 .TP
+\fBANI_CLI_PREVIEW\fR
+Controls the interactive fzf preview pane. Can be 1 (enabled) or 0 (disabled). Default is 1.
+.TP
+\fBANI_CLI_THUMBNAILS\fR
+Controls image thumbnail rendering in preview via chafa/catimg. Can be 1 (enabled) or 0 (disabled). Default is 1.
+.TP
+\fBANI_CLI_HOME\fR
+Controls the zero-argument interactive home dashboard. Can be 1 (enabled) or 0 (disabled). Default is 1.
+.TP
 \fBANI_CLI_LOG\fR
 Controls the logging feature for playback. Can be 1(logs) or 0(doesn't log). Default is 1.
 .TP
@@ -106,7 +124,7 @@ Controls the logging feature for playback. Can be 1(logs) or 0(doesn't log). Def
 Controls the directory ani-cli uses for storing history. A /ani-cli subfolder is created there for the histfile if doesn't exists. Default is $XDG_STATE_HOME if set, $HOME/.local/state if not.
 .TP
 \fBANI_CLI_DEFAULT_SOURCE\fR
-Controls the default source. Valid is history (equivalent to -c), everything else means search. Default is search.
+Controls the default source. Valid is history (equivalent to -c), trending (equivalent to -t), everything else means search. Default is search.
 .TP
 \fBANI_CLI_SKIP_INTRO\fR
 Controls if ani-skip is used to skip intros (works with mpv only). Can be 0 (disabled) or 1 (enabled). Default is 0.


### PR DESCRIPTION
### Summary
- Adds an interactive zero-argument home dashboard (`Search`, `Continue Watching`, `Seasonal & Trending`, `Release Countdown`, `Clear History`).
- Adds a real-time `fzf` preview engine displaying anime synopsis, score, and MyAnimeList ID with local file caching for instant scrolling.
- Adds optional inline thumbnail rendering via `chafa`/`catimg` with pure fallback if tools are absent (zero mandatory dependencies).
- Adds `-t` / `--trending` flag for direct seasonal anime exploration.

### Contribution Guidelines Checklist
- [x] Ran `shfmt -i 4 -ci -d -w ani-cli` (0 diffs).
- [x] Ran `shellcheck -s sh -o all -e 2250 ani-cli` (0 errors, 0 warnings).
- [x] Bumped version to `5.1.0` in `ani-cli` and `ani-cli.1`.
- [x] Updated `README.md` and manpage `ani-cli.1`.
- [x] Zero extra mandatory dependencies.
- [x] Fixes #1873
