### PR TITLE
Added notification support for Linux

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -194,6 +194,12 @@ anidb_m3u8() {
     anidb_curl "${_m3u8_master}" | sed 's|^#EXT-X-STREAM.*x||g; s|,.*|p|g; /^#/d; $!N; s|\n| >|;/EXT-X-I-FRAME/d'
 }
 
+# get the poster URL to display for the notification
+anidb_poster_url() {
+	_page="$(anidb_curl "$(printf "$desc_api" "$1")")"
+	printf "%s" "$_page" | sed -nE 's|.*<meta property="og:image" content="([^"]+)".*|\1|p' | head -n 1
+}
+
 # select the quality according to the setting
 select_quality() {
     case "$1" in
@@ -292,6 +298,22 @@ update_history() {
     mv "${histfile}.new" "$histfile"
 }
 
+# NOTIFICATIONS
+
+# $1 = anime name, $2 = anime id
+notify_playing() {
+	command -v "notify-send" >/dev/null 2>&1 || return 0
+
+	_poster="/tmp/ani-cli-$2.jpg"
+
+	if [ ! -f "$_poster" ]; then
+		_poster_url="$(anidb_poster_url "$2")"
+		[ -n "$_poster_url" ] && anidb_curl "$_poster_url" > "$_poster"
+	fi
+
+	notify-send -u low --icon "$_poster" "Now playing" "$1"
+}
+
 # PLAYING
 
 # shellcheck disable=SC2086
@@ -314,6 +336,7 @@ play_episode() {
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$video_link" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${anime_title} Episode ${ep_no}" $player_extra_flags >/dev/null 2>&1 & ;;
         *flatpak*mpv*) flatpak run io.mpv.Mpv $skip_flag $player_extra_flags --force-media-title="${anime_title} Episode ${ep_no}" "$video_link" >/dev/null 2>&1 & ;;
         *mpv*)
+			notify_playing "${anime_title} Episode ${ep_no}" "$anime_id"
             if [ "$no_detach" = 0 ]; then
                 nohup $player_function $skip_flag $player_extra_flags --force-media-title="${anime_title} Episode ${ep_no}" "$video_link" >/dev/null 2>&1 &
             else


### PR DESCRIPTION
* Added two functions `notify_playing` and `anidb_poster_url`
* `notify_playing` checks for the existence of the `notify-send` command using `command` shell built in and displays a notification using the freedesktop notification implementation. Returns early if the command does not exist.
* `anidb_poster_url` uses `sed` for extracting the image url from the description page.

Flow of notification (only added for the mpv route):
1. Check if notify-send exists, if not then return early.
2. Check if the poster image has been scraped or not, if not then first find the url using `anidb_poster_url` and get it using `anidb_curl`.
3. Display the notification containing the name and the poster image.

# Pull Request Template

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation update

## Description

This pull request aims to add notification features to ani-cli. It would be cool to have a notification feature showing, Now Playing: <Anime Name> Episode <Episode Number> along with the poster image. I use the anidb website itself to find the image link from a meta tag in the header and then download it to /tmp/ani-cli-<anime_id>.jpg. Then show it on screen. I could not discern if notify-send is a dependency or not because most people who will want to watch anime using this will have some graphical environment with notifications already installed. Maybe it can be a toggleable setting?

## Checklist

- [x] any anime playing
- [ ] bumped version
---
- [x] next, prev, replay and select work
- [x] `-c` history and continue work
- [x] `-d` downloads work
- [x] `-e` (select episode) aka `-r` (range selection) works
- [x] `-S` select index works
- [x] `-q` quality works
- [x] `-s` syncplay works
- [x] `-v` vlc works
- [x] `--dub` and regular (sub) mode both work
- [x] `--nextep-countdown` countdown to next ep works
---
- [x] `-h` help info is up to date
- [ ] Readme is up to date
- [x] Man page is up to date

## Additional Testcases

*(these don't block a merge)*

- [ ] `--skip` ani-skip works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
