### PR TITLE
refactor: deeper hianime_curl error reporting

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -151,14 +151,27 @@ cleanup() {
 
 #shellcheck disable=SC2086
 hianime_curl() {
-    _response="$($curl_exe -sL -A "$agent" --max-time 10 $cipher_flag -w ' %{http_code}' "$@")" ||
-        die "Connection error: could not fetch $1 (curl exit $?)"
+    _curl_status=0
+    _response="$($curl_exe -sL -A "$agent" --max-time 10 $cipher_flag \
+        -w ' %{http_code}' "$@")" || _curl_status=$?
+
     _http_code=${_response##* }
     _response=${_response% *}
+
+    if [ "$_curl_status" -ne 0 ]; then
+        case "$_http_code" in
+            [1-5][0-9][0-9]) _detail="HTTP $_http_code" ;;
+            *) _detail="no HTTP response" ;;
+        esac
+        die "Connection error: could not fetch $1 ($_detail; curl exit $_curl_status)"
+    fi
+
     case "$_http_code" in
         2??) ;;
-        *) printf "%s" "$_response" | grep -qi "Just a moment" || die "Request failed: HTTP $_http_code from $1" ;;
+        *) printf "%s" "$_response" | grep -qi "Just a moment" ||
+            die "Request failed: HTTP $_http_code from $1" ;;
     esac
+
     printf "%s" "$_response"
 }
 

--- a/ani-cli
+++ b/ani-cli
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="5.1.0"
+version_number="5.1.2"
 
 # UI
 


### PR DESCRIPTION
There was a mini outage where we didn't get those juicy HTTP codes for a second

<img width="1897" height="812" alt="Screenshot 2026-09-12 at 00 22 51" src="https://github.com/user-attachments/assets/b0e5f387-2ece-47eb-a6b5-b08913f39b3a" />
<img width="1190" height="800" alt="Screenshot 2026-09-12 at 00 23 53" src="https://github.com/user-attachments/assets/af98acd7-ff77-44e5-a60b-f91875b29819" />
